### PR TITLE
New DisallowShortListSyntax and DisallowLongListSyntax sniffs (includes QA setup)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.travis.yml export-ignore
+/phpcs.xml.dist export-ignore
 
 #
 # Auto detect text files and perform LF normalization

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,10 @@
 /.gitignore export-ignore
 /.travis.yml export-ignore
 /phpcs.xml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/phpunit-bootstrap.php export-ignore
+/NormalizedArrays/Tests/ export-ignore
+/Universal/Tests/ export-ignore
 
 #
 # Auto detect text files and perform LF normalization

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
+build/
 vendor/
-composer.lock
+/composer.lock
 /.phpcs.xml
 /phpcs.xml
+/phpunit.xml
+/.phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 vendor/
 composer.lock
+/.phpcs.xml
+/phpcs.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,31 @@ cache:
 
 php:
   - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
   - 7.3
-  - "nightly"
+
+env:
+  jobs:
+    # `master`
+    - PHPCS_VERSION="dev-master" LINT=1
+    # Lowest supported PHPCS version.
+    - PHPCS_VERSION="3.3.1"
 
 # Define the stages used.
+# For non-PRs, only the sniff and quicktest stages are run.
+# For pull requests and merges, the full script is run (skipping quicktest).
+# Note: for pull requests, "develop" is the base branch name.
+# See: https://docs.travis-ci.com/user/conditions-v1
 stages:
   - name: sniff
+  - name: quicktest
+    if: type = push AND branch NOT IN (master, develop)
   - name: test
+    if: branch IN (master, develop)
 
 jobs:
   fast_finish: true
@@ -28,6 +46,7 @@ jobs:
     #### SNIFF STAGE ####
     - stage: sniff
       php: 7.4
+      env: PHPCS_VERSION="dev-master"
       addons:
         apt:
           packages:
@@ -52,15 +71,63 @@ jobs:
         # Check that the sniffs available are feature complete.
         - composer check-complete
 
+    #### QUICK TEST STAGE ####
+    # This is a much quicker test which only runs the unit tests and linting against the low/high
+    # supported PHP/PHPCS combinations.
+    - stage: quicktest
+      php: 7.4
+      env: PHPCS_VERSION="dev-master" LINT=1
+    - php: 7.3
+      env: PHPCS_VERSION="3.3.1"
+
+    - php: 5.4
+      env: PHPCS_VERSION="dev-master" LINT=1
+    - php: 5.4
+      env: PHPCS_VERSION="3.3.1"
+
+    #### TEST STAGE ####
+    # Additional builds to prevent issues with PHPCS versions incompatible with certain PHP versions.
+    - stage: test
+      php: 7.4
+      env: PHPCS_VERSION="dev-master" LINT=1
+    # PHPCS is only compatible with PHP 7.4 as of version 3.5.0.
+    - php: 7.4
+      env: PHPCS_VERSION="3.5.0"
+
+    - php: "nightly"
+      env: PHPCS_VERSION="n/a" LINT=1
+
   allow_failures:
     # Allow failures for unstable builds.
     - php: "nightly"
+
 
 before_install:
   # Speed up build time by disabling Xdebug when its not needed.
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
 
   - export XMLLINT_INDENT="    "
+
+  # On stable PHPCS versions, allow for PHP deprecation notices.
+  # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
+  - |
+    if [[ "$TRAVIS_BUILD_STAGE_NAME" != "Sniff" && $PHPCS_BRANCH != "dev-master" && "$PHPCS_VERSION" != "n/a" ]]; then
+      echo 'error_reporting = E_ALL & ~E_DEPRECATED' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+    fi
+
+
+install:
+  # Set up test environment using Composer.
+  - |
+    if [[ $PHPCS_VERSION != "n/a" ]]; then
+      composer require --no-update --no-scripts squizlabs/php_codesniffer:${PHPCS_VERSION}
+    fi
+  - |
+    if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Sniff" || $PHPCS_VERSION == "n/a" ]]; then
+      # The sniff stage doesn't run the unit tests, so no need for PHPUnit.
+      # The build on nightly also doesn't run the tests (yet).
+      composer remove --dev phpunit/phpunit --no-update --no-scripts
+    fi
 
   # --prefer-dist will allow for optimal use of the travis caching ability.
   # The Composer PHPCS plugin takes care of setting the installed_paths for PHPCS.
@@ -69,4 +136,7 @@ before_install:
 
 script:
   # Lint PHP files against parse errors.
-  - composer lint
+  - if [[ "$LINT" == "1" ]]; then composer lint; fi
+
+  # Run the tests.
+  - if [[ $PHPCS_VERSION != "n/a" ]]; then composer test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,13 @@ jobs:
           packages:
             - libxml2-utils
       script:
+        # Validate the composer.json file.
+        # @link https://getcomposer.org/doc/03-cli.md#validate
+        - composer validate --no-check-all --strict
+
+        # Check the code style of the code base.
+        - composer checkcs
+
         # Validate the xml files.
         # @link http://xmlsoft.org/xmllint.html
         - xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd ./NormalizedArrays/ruleset.xml
@@ -53,13 +60,10 @@ before_install:
   - export XMLLINT_INDENT="    "
 
   # --prefer-dist will allow for optimal use of the travis caching ability.
+  # The Composer PHPCS plugin takes care of setting the installed_paths for PHPCS.
   - composer install --prefer-dist --no-suggest
 
 
 script:
   # Lint PHP files against parse errors.
   - composer lint
-
-  # Validate the composer.json file on low/high PHP versions.
-  # @link https://getcomposer.org/doc/03-cli.md#validate
-  - composer validate --no-check-all --strict

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ cache:
 php:
   - 5.4
   - 7.3
+  - "nightly"
 
 # Define the stages used.
 stages:
@@ -41,6 +42,10 @@ jobs:
         - diff -B ./NormalizedArrays/ruleset.xml <(xmllint --format "./NormalizedArrays/ruleset.xml")
         - diff -B ./Universal/ruleset.xml <(xmllint --format "./Universal/ruleset.xml")
 
+  allow_failures:
+    # Allow failures for unstable builds.
+    - php: "nightly"
+
 before_install:
   # Speed up build time by disabling Xdebug when its not needed.
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
@@ -52,6 +57,9 @@ before_install:
 
 
 script:
+  # Lint PHP files against parse errors.
+  - composer lint
+
   # Validate the composer.json file on low/high PHP versions.
   # @link https://getcomposer.org/doc/03-cli.md#validate
   - composer validate --no-check-all --strict

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,9 @@ jobs:
         - diff -B ./NormalizedArrays/ruleset.xml <(xmllint --format "./NormalizedArrays/ruleset.xml")
         - diff -B ./Universal/ruleset.xml <(xmllint --format "./Universal/ruleset.xml")
 
+        # Check that the sniffs available are feature complete.
+        - composer check-complete
+
   allow_failures:
     # Allow failures for unstable builds.
     - php: "nightly"

--- a/Universal/Docs/Lists/DisallowLongListSyntaxStandard.xml
+++ b/Universal/Docs/Lists/DisallowLongListSyntaxStandard.xml
@@ -1,0 +1,19 @@
+<documentation title="Disallow Long List Syntax">
+    <standard>
+    <![CDATA[
+    Short list syntax must be used.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Short form of list.">
+        <![CDATA[
+<em>[</em>$a, $b<em>]</em> = $array;
+        ]]>
+        </code>
+        <code title="Invalid: Long form of list.">
+        <![CDATA[
+<em>list(</em>$a, $b<em>)</em> = $array;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Docs/Lists/DisallowShortListSyntaxStandard.xml
+++ b/Universal/Docs/Lists/DisallowShortListSyntaxStandard.xml
@@ -1,0 +1,19 @@
+<documentation title="Disallow Short List Syntax">
+    <standard>
+    <![CDATA[
+    Long list syntax must be used.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Long form of list.">
+        <![CDATA[
+<em>list(</em>$a, $b<em>)</em> = $array;
+        ]]>
+        </code>
+        <code title="Invalid: Short form of list.">
+        <![CDATA[
+<em>[</em>$a, $b<em>]</em> = $array;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/Lists/DisallowLongListSyntaxSniff.php
+++ b/Universal/Sniffs/Lists/DisallowLongListSyntaxSniff.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\Lists;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHPCSUtils\Utils\Lists;
+
+/**
+ * Bans the use of the PHP long list syntax.
+ *
+ * @since 1.0.0
+ */
+class DisallowLongListSyntaxSniff implements Sniff
+{
+
+    /**
+     * Registers the tokens that this sniff wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return int[]
+     */
+    public function register()
+    {
+        return [\T_LIST];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $openClose = Lists::getOpenClose($phpcsFile, $stackPtr);
+        if ($openClose === false) {
+            // Live coding or parse error.
+            return;
+        }
+
+        $phpcsFile->recordMetric($stackPtr, 'Short list syntax used', 'no');
+
+        $fix = $phpcsFile->addFixableError('Long list syntax is not allowed', $stackPtr, 'Found');
+
+        if ($fix === true) {
+            $opener = $openClose['opener'];
+            $closer = $openClose['closer'];
+
+            $phpcsFile->fixer->beginChangeset();
+
+            $phpcsFile->fixer->replaceToken($stackPtr, '');
+            $phpcsFile->fixer->replaceToken($opener, '[');
+            $phpcsFile->fixer->replaceToken($closer, ']');
+
+            $phpcsFile->fixer->endChangeset();
+        }
+    }
+}

--- a/Universal/Sniffs/Lists/DisallowShortListSyntaxSniff.php
+++ b/Universal/Sniffs/Lists/DisallowShortListSyntaxSniff.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\Lists;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHPCSUtils\Utils\Lists;
+
+/**
+ * Bans the use of the PHP short list syntax.
+ *
+ * @since 1.0.0
+ */
+class DisallowShortListSyntaxSniff implements Sniff
+{
+
+    /**
+     * Registers the tokens that this sniff wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return int[]
+     */
+    public function register()
+    {
+        return [
+            \T_OPEN_SHORT_ARRAY,
+            \T_OPEN_SQUARE_BRACKET, // BC for PHPCS < 3.3.0.
+        ];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens    = $phpcsFile->getTokens();
+        $openClose = Lists::getOpenClose($phpcsFile, $stackPtr);
+
+        if ($openClose === false) {
+            // Not a short list, live coding or parse error.
+            if (isset($tokens[$stackPtr]['bracket_closer']) === true) {
+                // No need to examine nested subs of this short array/array access.
+                return $tokens[$stackPtr]['bracket_closer'];
+            }
+
+            return;
+        }
+
+        $phpcsFile->recordMetric($stackPtr, 'Short list syntax used', 'yes');
+
+        $fix = $phpcsFile->addFixableError('Short list syntax is not allowed', $stackPtr, 'Found');
+
+        if ($fix === true) {
+            $opener = $openClose['opener'];
+            $closer = $openClose['closer'];
+
+            $phpcsFile->fixer->beginChangeset();
+            $phpcsFile->fixer->replaceToken($opener, 'list(');
+            $phpcsFile->fixer->replaceToken($closer, ')');
+            $phpcsFile->fixer->endChangeset();
+        }
+    }
+}

--- a/Universal/Tests/Lists/DisallowLongListSyntaxUnitTest.inc
+++ b/Universal/Tests/Lists/DisallowLongListSyntaxUnitTest.inc
@@ -1,0 +1,21 @@
+<?php
+list($a) = $array;
+[$a] = $array;
+list($a, list($b, $c, $d)) = $array;
+[$a, [$b, $c, $d]] = $array;
+list($a[], list($a[], $a[], $a[],),) = $array;
+list(
+    $a,
+    list(
+        $b,
+        $c,
+        $d,
+    ),
+) = $array;
+
+list/*comment*/($a, $b, $c);
+
+list = $array; // Intentional parse error.
+
+// Intentional parse error. This has to be the last test in the file.
+list(

--- a/Universal/Tests/Lists/DisallowLongListSyntaxUnitTest.inc.fixed
+++ b/Universal/Tests/Lists/DisallowLongListSyntaxUnitTest.inc.fixed
@@ -1,0 +1,21 @@
+<?php
+[$a] = $array;
+[$a] = $array;
+[$a, [$b, $c, $d]] = $array;
+[$a, [$b, $c, $d]] = $array;
+[$a[], [$a[], $a[], $a[],],] = $array;
+[
+    $a,
+    [
+        $b,
+        $c,
+        $d,
+    ],
+] = $array;
+
+/*comment*/[$a, $b, $c];
+
+list = $array; // Intentional parse error.
+
+// Intentional parse error. This has to be the last test in the file.
+list(

--- a/Universal/Tests/Lists/DisallowLongListSyntaxUnitTest.php
+++ b/Universal/Tests/Lists/DisallowLongListSyntaxUnitTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\Lists;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the DisallowLongListSyntax sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\Lists\DisallowLongListSyntaxSniff
+ *
+ * @since 1.0.0
+ */
+class DisallowLongListSyntaxUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [
+            2  => 1,
+            4  => 2,
+            6  => 2,
+            7  => 1,
+            9  => 1,
+            16 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}

--- a/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.inc
+++ b/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.inc
@@ -1,0 +1,20 @@
+<?php
+// Short array, not short list.
+$var = [1,2,3];
+
+// Array access, not short list.
+$var[1];
+
+list($a) = $array;
+[$a] = $array;
+list($a, list($b, $c, $d)) = $array;
+[$a, [$b, $c, $d]] = $array;
+[$a[], [$a[], $a[], $a[],],] = $array;
+[
+    $a,
+    [
+        $b,
+        $c,
+        $d,
+    ],
+] = $array;

--- a/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.inc.fixed
+++ b/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.inc.fixed
@@ -1,0 +1,20 @@
+<?php
+// Short array, not short list.
+$var = [1,2,3];
+
+// Array access, not short list.
+$var[1];
+
+list($a) = $array;
+list($a) = $array;
+list($a, list($b, $c, $d)) = $array;
+list($a, list($b, $c, $d)) = $array;
+list($a[], list($a[], $a[], $a[],),) = $array;
+list(
+    $a,
+    list(
+        $b,
+        $c,
+        $d,
+    ),
+) = $array;

--- a/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.php
+++ b/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\Lists;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the DisallowShortListSyntax sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\Lists\DisallowShortListSyntaxSniff
+ *
+ * @since 1.0.0
+ */
+class DisallowShortListSyntaxUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [
+            9  => 1,
+            11 => 2,
+            12 => 2,
+            13 => 1,
+            15 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -27,14 +27,23 @@
     },
     "require-dev" : {
         "jakub-onderka/php-parallel-lint": "^1.0",
-        "jakub-onderka/php-console-highlighter": "^0.4"
+        "jakub-onderka/php-console-highlighter": "^0.4",
+        "phpcsstandards/phpcsdevtools": "^1.0 || dev-develop"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "scripts" : {
         "install-standards": [
             "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
         ],
         "lint": [
             "@php ./vendor/jakub-onderka/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
+        ],
+        "checkcs": [
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
+        ],
+        "fixcs": [
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "require-dev" : {
         "jakub-onderka/php-parallel-lint": "^1.0",
         "jakub-onderka/php-console-highlighter": "^0.4",
-        "phpcsstandards/phpcsdevtools": "^1.0 || dev-develop"
+        "phpcsstandards/phpcsdevtools": "^1.0 || dev-develop",
+        "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
@@ -47,6 +48,10 @@
         ],
         "check-complete": [
             "@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./NormalizedArrays ./Universal"
+        ],
+        "test": [
+            "@php ./vendor/phpunit/phpunit/phpunit --filter NormalizedArrays ./vendor/squizlabs/php_codesniffer/tests/AllTests.php",
+            "@php ./vendor/phpunit/phpunit/phpunit --filter Universal ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,16 @@
         "dealerdirect/phpcodesniffer-composer-installer" : "^0.3 || ^0.4.1 || ^0.5 || ^0.6",
         "phpcsstandards/phpcsutils" : "^1.0 || dev-develop"
     },
+    "require-dev" : {
+        "jakub-onderka/php-parallel-lint": "^1.0",
+        "jakub-onderka/php-console-highlighter": "^0.4"
+    },
     "scripts" : {
         "install-standards": [
             "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
+        ],
+        "lint": [
+            "@php ./vendor/jakub-onderka/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,9 @@
         ],
         "fixcs": [
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
+        ],
+        "check-complete": [
+            "@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./NormalizedArrays ./Universal"
         ]
     }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCSExtra" xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd">
+    <description>Check the code of the PHPCSExtra package itself.</description>
+
+    <!--
+    #############################################################################
+    COMMAND LINE ARGUMENTS
+    https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+    #############################################################################
+    -->
+
+    <file>.</file>
+
+    <!-- Exclude Composer vendor directory. -->
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+
+    <!-- Only check PHP files. -->
+    <arg name="extensions" value="php"/>
+
+    <!-- Show progress, show the error codes for each message (source). -->
+    <arg value="ps"/>
+
+    <!-- Strip the filepaths down to the relevant bit. -->
+    <arg name="basepath" value="./"/>
+
+    <!-- Check up to 8 files simultaneously. -->
+    <arg name="parallel" value="8"/>
+
+    <!--
+    #############################################################################
+    USE THE PHPCSDev RULESET
+    #############################################################################
+    -->
+
+    <rule ref="PHPCSDev">
+        <!-- Allow for the file docblock on the line directly following the PHP open tag.
+             As the sniff in PHPCS does not use modular error codes (yet - see PR #2729),
+             the complete error code needs to be disabled, not just the bit involving
+             the file docblocks.
+        -->
+        <exclude name="PSR12.Files.FileHeader.SpacingAfterBlock"/>
+    </rule>
+
+    <!-- Set minimum PHP version supported to PHP 5.4. -->
+    <config name="testVersion" value="5.4-"/>
+
+    <!-- Enforce short arrays. -->
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+
+</ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -47,4 +47,16 @@
     <!-- Enforce short arrays. -->
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 
+
+    <!--
+    #############################################################################
+    SELECTIVE EXCLUSIONS
+    Exclude specific files for specific sniffs and/or exclude sub-groups in sniffs.
+    #############################################################################
+    -->
+
+    <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
+        <exclude-pattern>/phpunit-bootstrap\.php$</exclude-pattern>
+    </rule>
+
 </ruleset>

--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * Bootstrap file for running the tests.
+ *
+ * - Load the PHPCS PHPUnit bootstrap file providing cross-version PHPUnit support.
+ *   {@link https://github.com/squizlabs/PHP_CodeSniffer/pull/1384}
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+if (\defined('PHP_CODESNIFFER_IN_TESTS') === false) {
+    \define('PHP_CODESNIFFER_IN_TESTS', true);
+}
+
+$ds = \DIRECTORY_SEPARATOR;
+
+/*
+ * Load the necessary PHPCS files.
+ */
+// Get the PHPCS dir from an environment variable.
+$phpcsDir          = \getenv('PHPCS_DIR');
+$composerPHPCSPath = __DIR__ . $ds . 'vendor' . $ds . 'squizlabs' . $ds . 'php_codesniffer';
+
+if ($phpcsDir === false && \is_dir($composerPHPCSPath)) {
+    // PHPCS installed via Composer.
+    $phpcsDir = $composerPHPCSPath;
+} elseif ($phpcsDir !== false) {
+    /*
+     * PHPCS in a custom directory.
+     * For this to work, the `PHPCS_DIR` needs to be set in a custom `phpunit.xml` file.
+     */
+    $phpcsDir = \realpath($phpcsDir);
+}
+
+// Try and load the PHPCS autoloader.
+if ($phpcsDir !== false
+    && \file_exists($phpcsDir . $ds . 'autoload.php')
+    && \file_exists($phpcsDir . $ds . 'tests' . $ds . 'bootstrap.php')
+) {
+    require_once $phpcsDir . $ds . 'autoload.php';
+    require_once $phpcsDir . $ds . 'tests' . $ds . 'bootstrap.php'; // PHPUnit 6.x+ support.
+} else {
+    echo 'Uh oh... can\'t find PHPCS.
+
+If you use Composer, please run `composer install`.
+Otherwise, make sure you set a `PHPCS_DIR` environment variable in your phpunit.xml file
+pointing to the PHPCS directory.
+';
+
+    die(1);
+}
+
+/*
+ * Set the PHPCS_IGNORE_TEST environmen variable to ignore tests from other standards.
+ */
+$phpcsExtraStandards = [
+    'NormalizedArrays' => true,
+    'Universal'        => true,
+];
+
+$allStandards   = PHP_CodeSniffer\Util\Standards::getInstalledStandards();
+$allStandards[] = 'Generic';
+
+$standardsToIgnore = [];
+foreach ($allStandards as $standard) {
+    if (isset($phpcsExtraStandards[$standard]) === true) {
+        continue;
+    }
+
+    $standardsToIgnore[] = $standard;
+}
+
+$standardsToIgnoreString = \implode(',', $standardsToIgnore);
+\putenv("PHPCS_IGNORE_TESTS={$standardsToIgnoreString}");
+
+// Clean up.
+unset($ds, $phpcsDir, $composerPHPCSPath, $allStandards, $standardsToIgnore, $standard, $standardsToIgnoreString);

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
+    backupGlobals="true"
+    bootstrap="./phpunit-bootstrap.php"
+    beStrictAboutTestsThatDoNotTestAnything="false"
+    colors="true"
+    forceCoversAnnotation="true">
+
+    <testsuites>
+        <testsuite name="PHPCSExtra">
+            <directory suffix="UnitTest.php">./NormalizedArrays/Tests/</directory>
+            <directory suffix="UnitTest.php">./Universal/Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+</phpunit>


### PR DESCRIPTION
This introduces the first two sniffs into the repo and with that the first PHP code.
So, aside from the two sniffs, this PR also includes setting up all the QA/build checks related to the PHP files (linting, sniffing, testing and feature completeness check).

## New `Universal.Lists.DisallowShortListSyntax` sniff

Sister-sniff to the PHPCS native `Generic.Arrays.DisallowShortArraySyntax` sniffs to disallow the use of short lists.

Includes fixer.
Includes unit tests.
Includes documentation.

Includes partial metrics. Combine this sniff with the `Universal.Lists.DisallowLongListSyntax` sniff to get the full picture.

## New `Universal.Lists.DisallowLongListSyntax` sniff

Sister-sniff to the PHPCS native `Generic.Arrays.DisallowLongArraySyntax` and the `Universal.Lists.DisallowShortListSyntax` sniffs to disallow the use of long lists.

Includes fixer.
Includes unit tests.
Includes documentation.

Includes partial metrics. Combine this sniff with the `Universal.Lists.DisallowShortListSyntax` sniff to get the full picture.

### QA: lint PHP files in this repo

### QA: add code style check for the code in this repo

This:
* Adds a custom PHPCS ruleset which uses the `PHPCSDev` ruleset to check the code style of code in this repo, with a few, very select, exclusions.
* Adds convenience scripts to the `composer.json` file to check the code of the repo.
* And allows for individual developers to overload the `phpcs.xml.dist` file by ignoring the typical overload files.

**Important notes**:
For the time being - until v 1.0.0 has been tagged for the `PHPCSDevTools` package -, the `require` will use the `dev-develop` branch of `PHPCSDevTools`.

Also, the `composer validate` check doesn't need to be run on every build. Running it on just one build is sufficient, so moving it to the `sniff` stage.

### QA: check all sniffs contributed are feature complete

The `PHPCSDevTools` repo offers a script to check that all sniffs are "feature complete", i.e. are accompanied by documentation in `..Standard.xml` format, as well as unit tests.

This check is now enabled.

### QA: enable unit testing for the code in this repo

This:
* Adds a PHPUnit `phpunit.xml.dist` configuration file.
* Adds a `phpunit-bootstrap.php` file to load the necessary prerequisites for the unit testing.
* Adds convenience script to the `composer.json` file to run the unit tests for the repo.
* Adds the necessary changes to the Travis script to test against the relevant PHP / PHPCS combinations.
    Includes moving the build against `nightly` to the `test` stage to allow it to lint files. The `PHPCS_VERSION` has been set to `n/a` to skip unit testing (for now).
* And allow for individual developers to overload the `phpunit.xml.dist` file by ignoring the typical overload files.

Other tweaks included:
* Moving the `composer install` to the Travis `install` step and skipping that step for the `sniff` stage as we don't need a full composer install for that stage.