### PR TITLE
New `Universal.Namespaces.DisallowCurlyBraceSyntax` sniff

### DIFF
--- a/Universal/Docs/Namespaces/DisallowCurlyBraceSyntaxStandard.xml
+++ b/Universal/Docs/Namespaces/DisallowCurlyBraceSyntaxStandard.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<documentation title="Disallow Curly Brace Namespace Syntax">
+    <standard>
+    <![CDATA[
+    Namespace declarations using the curly brace syntax are not allowed.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Namespace declaration without braces.">
+        <![CDATA[
+namespace Vendor\Project\Sub<em>;</em>
+
+// Code
+        ]]>
+        </code>
+        <code title="Invalid: Namespace declaration with braces.">
+        <![CDATA[
+namespace Vendor\Project\Scoped <em>{</em>
+    // Code.
+<em>}</em>
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/Namespaces/DisallowCurlyBraceSyntaxSniff.php
+++ b/Universal/Sniffs/Namespaces/DisallowCurlyBraceSyntaxSniff.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\Namespaces;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\Namespaces;
+
+/**
+ * Disallow the use of namespace declarations using the curly brace syntax.
+ *
+ * @since 1.0.0
+ */
+class DisallowCurlyBraceSyntaxSniff implements Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [\T_NAMESPACE];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (Namespaces::isDeclaration($phpcsFile, $stackPtr) === false) {
+            // Namespace operator, not a declaration; or live coding/parse error.
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['scope_condition']) === false
+            || $tokens[$stackPtr]['scope_condition'] !== $stackPtr
+        ) {
+            $phpcsFile->recordMetric($stackPtr, 'Namespace declaration using curly brace syntax', 'no');
+            return;
+        }
+
+        $phpcsFile->recordMetric($stackPtr, 'Namespace declaration using curly brace syntax', 'yes');
+
+        $phpcsFile->addError(
+            'Namespace declarations using the curly brace syntax are not allowed.',
+            $stackPtr,
+            'Forbidden'
+        );
+    }
+}

--- a/Universal/Tests/Namespaces/DisallowCurlyBraceSyntaxUnitTest.inc
+++ b/Universal/Tests/Namespaces/DisallowCurlyBraceSyntaxUnitTest.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Vendor\Project\ValidDeclaration;
+
+echo namespace\ClassName::$property; // OK. Namespace operator, not namespace declaration.
+
+namespace {} // Error.
+
+namespace Vendor\Project\NamedScopedNamespace { // Error.
+    // Code
+    $foo = namespace\function_call(); // OK. Namespace operator, not namespace declaration.
+}
+
+namespace /* some comment */ {} // Error.
+
+// Intentional parse error. This has to be the last test in the file.
+namespace

--- a/Universal/Tests/Namespaces/DisallowCurlyBraceSyntaxUnitTest.php
+++ b/Universal/Tests/Namespaces/DisallowCurlyBraceSyntaxUnitTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\Namespaces;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the DisallowCurlyBraceSyntax sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\Namespaces\DisallowCurlyBraceSyntaxSniff
+ *
+ * @since 1.0.0
+ */
+class DisallowCurlyBraceSyntaxUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getErrorList()
+    {
+        return [
+            7  => 1,
+            9  => 1,
+            14 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array <int line number> => <int number of warnings>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
New sniff to disallow the alternative namespace syntax using curly braces:
```php
namespace Vendor\Project {
    // Code...
}
```

Includes unit tests.
Includes documentation.
Includes metrics.