### PR TITLE
New `Universal.Namespaces.EnforceCurlyBraceSyntax` sniff

### DIFF
--- a/Universal/Docs/Namespaces/EnforceCurlyBraceSyntaxStandard.xml
+++ b/Universal/Docs/Namespaces/EnforceCurlyBraceSyntaxStandard.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<documentation title="Enforce Curly Brace Namespace Syntax">
+    <standard>
+    <![CDATA[
+    Namespace declarations without curly braces are not allowed.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Namespace declaration with braces.">
+        <![CDATA[
+namespace Vendor\Project\Scoped <em>{</em>
+    // Code.
+<em>}</em>
+        ]]>
+        </code>
+        <code title="Invalid: Namespace declaration without braces.">
+        <![CDATA[
+namespace Vendor\Project\Sub<em>;</em>
+
+// Code
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/Namespaces/EnforceCurlyBraceSyntaxSniff.php
+++ b/Universal/Sniffs/Namespaces/EnforceCurlyBraceSyntaxSniff.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\Namespaces;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\Namespaces;
+
+/**
+ * Enforce the use of namespace declarations using the curly brace syntax.
+ *
+ * @since 1.0.0
+ */
+class EnforceCurlyBraceSyntaxSniff implements Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [\T_NAMESPACE];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (Namespaces::isDeclaration($phpcsFile, $stackPtr) === false) {
+            // Namespace operator, not a declaration; or live coding/parse error.
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['scope_condition']) === true
+            && $tokens[$stackPtr]['scope_condition'] === $stackPtr
+        ) {
+            $phpcsFile->recordMetric($stackPtr, 'Namespace declaration using curly brace syntax', 'yes');
+            return;
+        }
+
+        $phpcsFile->recordMetric($stackPtr, 'Namespace declaration using curly brace syntax', 'no');
+
+        $phpcsFile->addError(
+            'Namespace declarations without curly braces are not allowed.',
+            $stackPtr,
+            'Forbidden'
+        );
+    }
+}

--- a/Universal/Tests/Namespaces/EnforceCurlyBraceSyntaxUnitTest.inc
+++ b/Universal/Tests/Namespaces/EnforceCurlyBraceSyntaxUnitTest.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Vendor\Project\NamedScopedNamespace { // OK.
+    // Code
+    $foo = namespace\function_call(); // OK. Namespace operator, not namespace declaration.
+}
+
+echo namespace\ClassName::$property; // OK. Namespace operator, not namespace declaration.
+
+namespace Vendor\Project\ /* comment*/ ValidDeclaration; // Error.
+
+namespace Vendor; // Error.
+
+// Intentional parse error. This has to be the last test in the file.
+namespace

--- a/Universal/Tests/Namespaces/EnforceCurlyBraceSyntaxUnitTest.php
+++ b/Universal/Tests/Namespaces/EnforceCurlyBraceSyntaxUnitTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\Namespaces;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the EnforceCurlyBraceSyntax sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\Namespaces\EnforceCurlyBraceSyntaxSniff
+ *
+ * @since 1.0.0
+ */
+class EnforceCurlyBraceSyntaxUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getErrorList()
+    {
+        return [
+            10 => 1,
+            12 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array <int line number> => <int number of warnings>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
New sniff to enforce using the alternative namespace syntax using curly braces:
```php
namespace Vendor\Project {
    // Code...
}
```

Includes unit tests.
Includes documentation.
Includes metrics.