### PR TITLE
New `Universal.Namespaces.OneDeclarationPerFile` sniff

### DIFF
--- a/Universal/Docs/Namespaces/OneDeclarationPerFileStandard.xml
+++ b/Universal/Docs/Namespaces/OneDeclarationPerFileStandard.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<documentation title="One Namespace Declaration Per File">
+    <standard>
+    <![CDATA[
+    There should be only one namespace declaration per file.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: One namespace declaration in a file.">
+        <![CDATA[
+namespace Vendor\Project\Sub;
+        ]]>
+        </code>
+        <code title="Invalid: Multiple namespace declarations in a file.">
+        <![CDATA[
+namespace Vendor\Project\Sub\A {
+}
+
+<em>namespace Vendor\Project\Sub\B {
+}</em>
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/Namespaces/OneDeclarationPerFileSniff.php
+++ b/Universal/Sniffs/Namespaces/OneDeclarationPerFileSniff.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\Namespaces;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\Namespaces;
+
+/**
+ * Disallow having more than one namespace declaration in a file.
+ *
+ * @since 1.0.0
+ */
+class OneDeclarationPerFileSniff implements Sniff
+{
+
+    /**
+     * Current file being scanned.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    private $currentFile;
+
+    /**
+     * Stack pointer to the first namespace declaration seen in the file.
+     *
+     * @since 1.0.0
+     *
+     * @var int|false
+     */
+    private $declarationSeen = false;
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [\T_NAMESPACE];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $fileName = $phpcsFile->getFilename();
+        if ($this->currentFile !== $fileName) {
+            // Reset the properties for each new file.
+            $this->currentFile     = $fileName;
+            $this->declarationSeen = false;
+        }
+
+        if (Namespaces::isDeclaration($phpcsFile, $stackPtr) === false) {
+            // Namespace operator, not a declaration; or live coding/parse error.
+            return;
+        }
+
+        if ($this->declarationSeen === false) {
+            // This is the first namespace declaration in the file.
+            $this->declarationSeen = $stackPtr;
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        // OK, so this is a file with multiple namespace declarations.
+        $phpcsFile->addError(
+            'There should be only one namespace declaration per file. The first declaration was found on line %d',
+            $stackPtr,
+            'MultipleFound',
+            [$tokens[$this->declarationSeen]['line']]
+        );
+    }
+}

--- a/Universal/Tests/Namespaces/OneDeclarationPerFileUnitTest.1.inc
+++ b/Universal/Tests/Namespaces/OneDeclarationPerFileUnitTest.1.inc
@@ -1,0 +1,22 @@
+<?php
+
+// Multiple namespaces in one file without curly braces.
+
+namespace Vendor\Project\FirstNamespace;
+
+// Code ...
+
+namespace Vendor\Project\SecondNamespace; // Error.
+
+echo namespace\CONSTANT_NAME; // OK, namespace operator.
+
+namespace Vendor\Project\ThirdNamespace; // Error.
+
+$foo = namespace\function_call(); // OK, namespace operator.
+
+namespace Vendor\Project\FourthNamespace; // Error.
+
+// More code...
+
+// Intentional parse error. Will be ignored.
+namespace /* some comment */;

--- a/Universal/Tests/Namespaces/OneDeclarationPerFileUnitTest.2.inc
+++ b/Universal/Tests/Namespaces/OneDeclarationPerFileUnitTest.2.inc
@@ -1,0 +1,26 @@
+<?php
+
+// Multiple namespaces in one file using curly braces.
+
+namespace Vendor\Project\FirstNamespace {
+
+    // Code ...
+}
+
+namespace Vendor\Project\SecondNamespace { // Error.
+
+    echo namespace\CONSTANT_NAME; // OK, namespace operator.
+}
+
+namespace /* some comment */ { // Error.
+
+    // More code...
+}
+
+namespace Vendor\Project\FourthNamespace { // Error.
+
+    $foo = namespace\function_call(); // OK, namespace operator.
+}
+
+// Intentional parse error.
+namespace {

--- a/Universal/Tests/Namespaces/OneDeclarationPerFileUnitTest.3.inc
+++ b/Universal/Tests/Namespaces/OneDeclarationPerFileUnitTest.3.inc
@@ -1,0 +1,11 @@
+<?php
+
+// One declaration in the file.
+// Also tests that there is no cross-file bleed-through.
+
+namespace Vendor\Project\ValidDeclaration;
+
+echo namespace\ClassName::$property; // Ok, not namespace declaration.
+
+// Intentional parse error. This has to be the last test in the file.
+namespace

--- a/Universal/Tests/Namespaces/OneDeclarationPerFileUnitTest.php
+++ b/Universal/Tests/Namespaces/OneDeclarationPerFileUnitTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\Namespaces;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the OneDeclarationPerFile sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\Namespaces\OneDeclarationPerFileSniff
+ *
+ * @since 1.0.0
+ */
+class OneDeclarationPerFileUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @param string $testFile The name of the file being tested.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getErrorList($testFile = '')
+    {
+        switch ($testFile) {
+            case 'OneDeclarationPerFileUnitTest.1.inc':
+                return [
+                    9  => 1,
+                    13 => 1,
+                    17 => 1,
+                ];
+
+            case 'OneDeclarationPerFileUnitTest.2.inc':
+                return [
+                    10 => 1,
+                    15 => 1,
+                    20 => 1,
+                    26 => 1,
+                ];
+
+            default:
+                return [];
+        }
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array <int line number> => <int number of warnings>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
New sniff to disallow the use of multiple namespaces within a file.

Includes unit tests.
Includes documentation.