### PR TITLE
New `Universal.UseStatements.DisallowUseClass` sniff

### DIFF
--- a/Universal/Docs/UseStatements/DisallowUseClassStandard.xml
+++ b/Universal/Docs/UseStatements/DisallowUseClassStandard.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<documentation title="Disallow Use Class/Trait/Interface">
+    <standard>
+    <![CDATA[
+    Disallow the use of `use` import statements for classes, traits and interfaces, with or without alias.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Other type of use import statements.">
+        <![CDATA[
+use function Vendor\Sub\functionName;
+use const Vendor\Sub\CONST;
+        ]]>
+        </code>
+        <code title="Invalid: Class/trait/interface use import statement.">
+        <![CDATA[
+use Vendor\Sub\ClassName;
+use Vendor\Sub\InterfaceName as Other;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/UseStatements/DisallowUseClassSniff.php
+++ b/Universal/Sniffs/UseStatements/DisallowUseClassSniff.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\UseStatements;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\UseStatements;
+
+/**
+ * Disallow class/trait/interface import `use` statements.
+ *
+ * Related sniffs:
+ * - `Universal.UseStatements.DisallowUseFunction`
+ * - `Universal.UseStatements.DisallowUseConst`
+ *
+ * @since 1.0.0
+ */
+class DisallowUseClassSniff implements Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [\T_USE];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        try {
+            $statements = UseStatements::splitImportUseStatement($phpcsFile, $stackPtr);
+        } catch (RuntimeException $e) {
+            // Not an import use statement. Bow out.
+            return;
+        }
+
+        if (empty($statements['name'])) {
+            // No class/trait/interface import statements found.
+            return;
+        }
+
+        $tokens         = $phpcsFile->getTokens();
+        $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($stackPtr + 1));
+
+        foreach ($statements['name'] as $alias => $fullName) {
+            $reportPtr = $stackPtr;
+            do {
+                $reportPtr = $phpcsFile->findNext(\T_STRING, ($reportPtr + 1), $endOfStatement, false, $alias);
+                if ($reportPtr === false) {
+                    // Shouldn't be possible.
+                    continue 2;
+                }
+
+                $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($reportPtr + 1), $endOfStatement, true);
+                if ($next !== false && $tokens[$next]['code'] === \T_NS_SEPARATOR) {
+                    // Namespace level with same name. Continue searching
+                    continue;
+                }
+
+                break;
+            } while (true);
+
+            $error  = 'Use import statements for classes/traits/interfaces are not allowed.';
+            $error .= ' Found import statement for: "%s"';
+            $data   = [$fullName, $alias];
+
+            $offsetFromEnd = (\strlen($alias) + 1);
+            if (\substr($fullName, -$offsetFromEnd) === '\\' . $alias) {
+                $phpcsFile->recordMetric($reportPtr, 'Use import statement for class/interface/trait', 'without alias');
+
+                $phpcsFile->addError($error, $reportPtr, 'FoundWithoutAlias', $data);
+                continue;
+            }
+
+            $phpcsFile->recordMetric($reportPtr, 'Use import statement for class/interface/trait', 'with alias');
+
+            $error .= ' with alias: "%s"';
+            $phpcsFile->addError($error, $reportPtr, 'FoundWithAlias', $data);
+        }
+    }
+}

--- a/Universal/Tests/UseStatements/DisallowUseClassUnitTest.inc
+++ b/Universal/Tests/UseStatements/DisallowUseClassUnitTest.inc
@@ -1,0 +1,38 @@
+<?php
+
+// Ignore, not class import.
+use function MyNamespace\myFunction;
+use const MyNamespace\YOUR_CONST as CONST_ALIAS;
+
+// These should be flagged.
+use My\NS\SomeClass;
+use My\NS\SomeClass as OtherClass;
+
+use Vendor\Foo\ClassA as ClassABC,
+    Vendor\Bar\InterfaceB,
+	Vendor\Bar\Bar, // Testing finding the correct line to report on.
+    Vendor\Baz\ClassC;
+
+use some\namespacing\{
+    SomeClassA,
+    deeper\level\SomeClassB,
+    another\level\SomeClassC as C
+};
+
+// Mixed group use statement. Yes, this is allowed.
+use Some\NS\{
+    ClassName, // Error.
+    function SubLevel\functionName,
+    const Constants\CONSTANT_NAME as SOME_CONSTANT,
+    function SubLevel\AnotherName,
+    AnotherLevel, // Error.
+};
+
+// Ignore as not import use.
+$closure = function() use($bar) {
+    return $bar;
+};
+
+class Foo {
+    use MyNamespace\Bar;
+}

--- a/Universal/Tests/UseStatements/DisallowUseClassUnitTest.php
+++ b/Universal/Tests/UseStatements/DisallowUseClassUnitTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\UseStatements;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the DisallowUseClass sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\UseStatements\DisallowUseClassSniff
+ *
+ * @since 1.0.0
+ */
+class DisallowUseClassUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getErrorList()
+    {
+        return [
+            8  => 1,
+            9  => 1,
+            11 => 1,
+            12 => 1,
+            13 => 1,
+            14 => 1,
+            17 => 1,
+            18 => 1,
+            19 => 1,
+            24 => 1,
+            28 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array <int line number> => <int number of warnings>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Sniff to forbid using import use statements for classes/traits/interfaces.

The sniff contains two error codes `FoundWithoutAlias` and `FoundWithAlias` to allow for only forbidding class `use` import statements with or without alias.

Includes unit tests.
Includes documentation.
Includes metrics.

Related to #1