### PR TITLE
New `Universal.UseStatements.DisallowUseFunction` sniff

### DIFF
--- a/Universal/Docs/UseStatements/DisallowUseFunctionStandard.xml
+++ b/Universal/Docs/UseStatements/DisallowUseFunctionStandard.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<documentation title="Disallow Use Function">
+    <standard>
+    <![CDATA[
+    Disallow the use of `use function` import statements, with or without alias.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Other type of use import statements.">
+        <![CDATA[
+use Vendor\Sub\ClassName;
+use const Vendor\Sub\CONST;
+        ]]>
+        </code>
+        <code title="Invalid: use function import statements.">
+        <![CDATA[
+use function Vendor\Sub\functionName;
+use function Vendor\Sub\functionName as otherFunction;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/UseStatements/DisallowUseFunctionSniff.php
+++ b/Universal/Sniffs/UseStatements/DisallowUseFunctionSniff.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\UseStatements;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\UseStatements;
+
+/**
+ * Disallow function import `use` statements.
+ *
+ * Related sniffs:
+ * - `Universal.UseStatements.DisallowUseClass`
+ * - `Universal.UseStatements.DisallowUseConst`
+ *
+ * @since 1.0.0
+ */
+class DisallowUseFunctionSniff implements Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [\T_USE];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        try {
+            $statements = UseStatements::splitImportUseStatement($phpcsFile, $stackPtr);
+        } catch (RuntimeException $e) {
+            // Not an import use statement. Bow out.
+            return;
+        }
+
+        if (empty($statements['function'])) {
+            // No import statements for functions found.
+            return;
+        }
+
+        $tokens         = $phpcsFile->getTokens();
+        $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($stackPtr + 1));
+
+        foreach ($statements['function'] as $alias => $fullName) {
+            $reportPtr = $stackPtr;
+            do {
+                $reportPtr = $phpcsFile->findNext(\T_STRING, ($reportPtr + 1), $endOfStatement, false, $alias);
+                if ($reportPtr === false) {
+                    // Shouldn't be possible.
+                    continue 2;
+                }
+
+                $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($reportPtr + 1), $endOfStatement, true);
+                if ($next !== false && $tokens[$next]['code'] === \T_NS_SEPARATOR) {
+                    // Namespace level with same name. Continue searching
+                    continue;
+                }
+
+                break;
+            } while (true);
+
+            $error  = 'Use import statements for functions are not allowed.';
+            $error .= ' Found import statement for: "%s"';
+            $data   = [$fullName, $alias];
+
+            $offsetFromEnd = (\strlen($alias) + 1);
+            if (\substr($fullName, -$offsetFromEnd) === '\\' . $alias) {
+                $phpcsFile->recordMetric($reportPtr, 'Use import statement for functions', 'without alias');
+
+                $phpcsFile->addError($error, $reportPtr, 'FoundWithoutAlias', $data);
+                continue;
+            }
+
+            $phpcsFile->recordMetric($reportPtr, 'Use import statement for functions', 'with alias');
+
+            $error .= ' with alias: "%s"';
+            $phpcsFile->addError($error, $reportPtr, 'FoundWithAlias', $data);
+        }
+    }
+}

--- a/Universal/Tests/UseStatements/DisallowUseFunctionUnitTest.inc
+++ b/Universal/Tests/UseStatements/DisallowUseFunctionUnitTest.inc
@@ -1,0 +1,37 @@
+<?php
+
+// Ignore, not function import.
+use My\NS\SomeClass;
+use const MyNamespace\YOUR_CONST as CONST_ALIAS;
+
+// These should be flagged.
+use function MyNamespace\myFunction;
+use function Vendor\YourNamespace\yourFunction as FunctionAlias;
+
+use function foo\math\sin,
+    foo\math\cos as FooCos,
+    foo\math\cosh;
+
+use function bar\math\{
+    Msin,
+    level\Mcos as BarCos,
+    Mcosh,
+};
+
+// Mixed group use statement. Yes, this is allowed.
+use Some\NS\{
+    ClassName,
+    function SubLevel\functionName, // Error.
+    const Constants\CONSTANT_NAME as SOME_CONSTANT,
+    function SubLevel\AnotherName, // Error.
+    AnotherLevel,
+};
+
+// Ignore as not import use.
+$closure = function() use($bar) {
+    return $bar;
+};
+
+class Foo {
+    use MyNamespace\Bar;
+}

--- a/Universal/Tests/UseStatements/DisallowUseFunctionUnitTest.php
+++ b/Universal/Tests/UseStatements/DisallowUseFunctionUnitTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\UseStatements;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the DisallowUseFunction sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\UseStatements\DisallowUseFunctionSniff
+ *
+ * @since 1.0.0
+ */
+class DisallowUseFunctionUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getErrorList()
+    {
+        return [
+            8  => 1,
+            9  => 1,
+            11 => 1,
+            12 => 1,
+            13 => 1,
+            16 => 1,
+            17 => 1,
+            18 => 1,
+            24 => 1,
+            26 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array <int line number> => <int number of warnings>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Sniff to forbid using import use statements for functions.

The sniff contains two error codes `FoundWithoutAlias` and `FoundWithAlias` to allow for only forbidding function `use` import statements with or without alias.

Includes unit tests.
Includes documentation.
Includes metrics.

Related to #1