### PR TITLE
New `Universal.UseStatements.DisallowUseConst` sniff

### DIFF
--- a/Universal/Docs/UseStatements/DisallowUseConstStandard.xml
+++ b/Universal/Docs/UseStatements/DisallowUseConstStandard.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<documentation title="Disallow Use Const">
+    <standard>
+    <![CDATA[
+    Disallow the use of `use const` import statements, with or without alias.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Other type of use import statements.">
+        <![CDATA[
+use Vendor\Sub\ClassName;
+use function Vendor\Sub\functionName;
+        ]]>
+        </code>
+        <code title="Invalid: use const import statements.">
+        <![CDATA[
+use const Vendor\Sub\CONST;
+use const Vendor\Sub\BAR as otherConst;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/UseStatements/DisallowUseConstSniff.php
+++ b/Universal/Sniffs/UseStatements/DisallowUseConstSniff.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\UseStatements;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\UseStatements;
+
+/**
+ * Disallow constant import `use` statements.
+ *
+ * Related sniffs:
+ * - `Universal.UseStatements.DisallowUseClass`
+ * - `Universal.UseStatements.DisallowUseFunction`
+ *
+ * @since 1.0.0
+ */
+class DisallowUseConstSniff implements Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [\T_USE];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        try {
+            $statements = UseStatements::splitImportUseStatement($phpcsFile, $stackPtr);
+        } catch (RuntimeException $e) {
+            // Not an import use statement. Bow out.
+            return;
+        }
+
+        if (empty($statements['const'])) {
+            // No import statements for constants found.
+            return;
+        }
+
+        $tokens         = $phpcsFile->getTokens();
+        $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($stackPtr + 1));
+
+        foreach ($statements['const'] as $alias => $fullName) {
+            $reportPtr = $stackPtr;
+            do {
+                $reportPtr = $phpcsFile->findNext(\T_STRING, ($reportPtr + 1), $endOfStatement, false, $alias);
+                if ($reportPtr === false) {
+                    // Shouldn't be possible.
+                    continue 2;
+                }
+
+                $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($reportPtr + 1), $endOfStatement, true);
+                if ($next !== false && $tokens[$next]['code'] === \T_NS_SEPARATOR) {
+                    // Namespace level with same name. Continue searching
+                    continue;
+                }
+
+                break;
+            } while (true);
+
+            $error  = 'Use import statements for constants are not allowed.';
+            $error .= ' Found import statement for: "%s"';
+            $data   = [$fullName, $alias];
+
+            $offsetFromEnd = (\strlen($alias) + 1);
+            if (\substr($fullName, -$offsetFromEnd) === '\\' . $alias) {
+                $phpcsFile->recordMetric($reportPtr, 'Use import statement for constant', 'without alias');
+
+                $phpcsFile->addError($error, $reportPtr, 'FoundWithoutAlias', $data);
+                continue;
+            }
+
+            $phpcsFile->recordMetric($reportPtr, 'Use import statement for constant', 'with alias');
+
+            $error .= ' with alias: "%s"';
+            $phpcsFile->addError($error, $reportPtr, 'FoundWithAlias', $data);
+        }
+    }
+}

--- a/Universal/Tests/UseStatements/DisallowUseConstUnitTest.inc
+++ b/Universal/Tests/UseStatements/DisallowUseConstUnitTest.inc
@@ -1,0 +1,35 @@
+<?php
+
+// Ignore, not const import.
+use My\NS\SomeClass;
+use function Vendor\YourNamespace\yourFunction as FunctionAlias;
+
+// These should be flagged.
+use CONST MyNamespace\MY_CONST;
+use const MyNamespace\YOUR_CONST as CONST_ALIAS;
+
+use const foo\math\PI,
+    foo\math\GOLDEN_RATIO as MATH_GOLDEN;
+
+use const bar\math\{
+    BGAMMA as BAR_GAMMA,
+    BGOLDEN_RATIO
+};
+
+// Mixed group use statement. Yes, this is allowed.
+use Some\NS\{
+    ClassName,
+    function SubLevel\functionName,
+    const Constants\CONSTANT_NAME as SOME_CONSTANT, // Error.
+    function SubLevel\AnotherName,
+    AnotherLevel,
+};
+
+// Ignore as not import use.
+$closure = function() use($bar) {
+    return $bar;
+};
+
+class Foo {
+    use MyNamespace\Bar;
+}

--- a/Universal/Tests/UseStatements/DisallowUseConstUnitTest.php
+++ b/Universal/Tests/UseStatements/DisallowUseConstUnitTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\UseStatements;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the DisallowUseConst sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\UseStatements\DisallowUseConstSniff
+ *
+ * @since 1.0.0
+ */
+class DisallowUseConstUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getErrorList()
+    {
+        return [
+            8  => 1,
+            9  => 1,
+            11 => 1,
+            12 => 1,
+            15 => 1,
+            16 => 1,
+            23 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array <int line number> => <int number of warnings>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Sniff to forbid using import use statements for constants.

The sniff contains two error codes `FoundWithoutAlias` and `FoundWithAlias` to allow for only forbidding constant `use` import statements with or without alias.

Includes unit tests.
Includes documentation.
Includes metrics.

Related to #1