### PR TITLE
New `Universal.ControlStructures.IfElseDeclaration` sniff

### DIFF
--- a/Universal/Docs/ControlStructures/IfElseDeclarationStandard.xml
+++ b/Universal/Docs/ControlStructures/IfElseDeclarationStandard.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<documentation title="If-else Declarations">
+    <standard>
+    <![CDATA[
+    The `else` and `elseif` keywords should be on a new line.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: `elseif` and `else` each on a new line.">
+        <![CDATA[
+if ($foo) {
+    $var = 1;
+}<em>
+elseif</em> ($bar) {
+    $var = 2;
+}
+else {
+    $var = 3;
+}
+        ]]>
+        </code>
+        <code title="Invalid: `elseif` and `else` on the same line as the closing curly of the preceding (else)if.">
+        <![CDATA[
+if ($foo) {
+    $var = 1;
+} <em>elseif</em> ($bar) {
+    $var = 2;
+} <em>else</em> {
+    $var = 3;
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/ControlStructures/IfElseDeclarationSniff.php
+++ b/Universal/Sniffs/ControlStructures/IfElseDeclarationSniff.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\ControlStructures;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Verifies that `else(if)` statements with braces are on a new line.
+ *
+ * Sister-sniff to the following two PHPCS native sniffs which each demand that `else[]if` is on the
+ * same line as the closing curly of the preceding `(else)if`:
+ * - `PEAR.ControlStructures.ControlSignature[.Found]`
+ * - `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace`
+ *
+ * Other related sniffs:
+ * - `Squiz.ControlStructures.ElseIfDeclaration` Forbids the use of "elseif", demands "else if".
+ * - `PSR2.ControlStructures.ElseIfDeclaration`  Forbids the use of "else if", demands "elseif".
+ *
+ * @since 1.0.0
+ */
+class IfElseDeclarationSniff implements Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [
+            \T_ELSE,
+            \T_ELSEIF,
+        ];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        /*
+         * Check for control structures without braces and alternative syntax.
+         */
+        $scopePtr = $stackPtr;
+        if (isset($tokens[$stackPtr]['scope_opener']) === false) {
+            // Deal with "else if".
+            $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            if ($tokens[$next]['code'] === \T_IF) {
+                $scopePtr = $next;
+            }
+        }
+
+        if (isset($tokens[$scopePtr]['scope_opener']) === false
+            || $tokens[$tokens[$scopePtr]['scope_opener']]['code'] === \T_COLON
+        ) {
+            // No scope opener found or alternative syntax (not our concern).
+            return;
+        }
+
+        /*
+         * Check whether the else(if) is on a new line.
+         */
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        if ($prevNonEmpty === false || $tokens[$prevNonEmpty]['code'] !== \T_CLOSE_CURLY_BRACKET) {
+            // Parse error. Not our concern.
+            return;
+        }
+
+        if ($tokens[$prevNonEmpty]['line'] !== $tokens[$stackPtr]['line']) {
+            $phpcsFile->recordMetric($stackPtr, 'Else(if) on a new line', 'yes');
+            return;
+        }
+
+        $phpcsFile->recordMetric($stackPtr, 'Else(if) on a new line', 'no');
+
+        $errorBase = \strtoupper($tokens[$stackPtr]['content']);
+        $error     = $errorBase . ' statement must be on a new line.';
+
+        $prevNonWhitespace = $phpcsFile->findPrevious(\T_WHITESPACE, ($stackPtr - 1), null, true);
+
+        if ($prevNonWhitespace !== $prevNonEmpty) {
+            // Comment found between previous scope closer and the keyword.
+            $fix = $phpcsFile->addError($error, $stackPtr, 'NoNewLine');
+            return;
+        }
+
+        $fix = $phpcsFile->addFixableError($error, $stackPtr, 'NoNewLine');
+        if ($fix === false) {
+            return;
+        }
+
+        /*
+         * Fix it.
+         */
+
+        // Figure out the indentation for the else(if).
+        $indentBase = $prevNonEmpty;
+        if (isset($tokens[$prevNonEmpty]['scope_condition']) === true
+            && ($tokens[$tokens[$prevNonEmpty]['scope_condition']]['column'] === 1
+            || ($tokens[($tokens[$prevNonEmpty]['scope_condition'] - 1)]['code'] === \T_WHITESPACE
+                && $tokens[($tokens[$prevNonEmpty]['scope_condition'] - 1)]['column'] === 1))
+        ) {
+            // Base the indentation off the previous if/elseif if on a line by itself.
+            $indentBase = $tokens[$prevNonEmpty]['scope_condition'];
+        }
+
+        $indent            = '';
+        $firstOnIndentLine = $indentBase;
+        if ($tokens[$firstOnIndentLine]['column'] !== 1) {
+            while (isset($tokens[($firstOnIndentLine - 1)]) && $tokens[--$firstOnIndentLine]['column'] !== 1);
+
+            if ($tokens[$firstOnIndentLine]['code'] === \T_WHITESPACE) {
+                $indent = $tokens[$firstOnIndentLine]['content'];
+            }
+        }
+
+        $phpcsFile->fixer->beginChangeset();
+
+        // Remove any whitespace between the previous scope closer and the else(if).
+        for ($i = ($prevNonEmpty + 1); $i < $stackPtr; $i++) {
+            $phpcsFile->fixer->replaceToken($i, '');
+        }
+
+        $phpcsFile->fixer->addContent($prevNonEmpty, $phpcsFile->eolChar . $indent);
+        $phpcsFile->fixer->endChangeset();
+    }
+}

--- a/Universal/Tests/ControlStructures/IfElseDeclarationUnitTest.inc
+++ b/Universal/Tests/ControlStructures/IfElseDeclarationUnitTest.inc
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * Alternative control structure syntax. Ignore.
+ */
+if (true):
+    // Code.
+elseif (false):
+    // Code.
+else:
+    // Code.
+endif;
+
+/*
+ * Control structure without braces. Ignore.
+ */
+if (true)
+    function_call($a); elseif (false)
+    function_call($a); else
+    function_call($a);
+
+/*
+ * OK: else/elseif on the next line.
+ */
+if ( true ) {
+    // Code.
+}
+elseif {
+    // Code.
+}
+else if {
+    // Code.
+}
+else {
+    // Code.
+}
+
+/*
+ * OK: Comments and additional blank lines between the structures allowed.
+ */
+
+if ( true ) {
+    // Code.
+}
+// Some comment - this comment should be ignored.
+else {
+    // Code.
+}
+
+if ( true ) {
+    // Code.
+} // Trailing comment.
+
+/* phpcs:ignore Standard.Category.Sniffname -- for reasons. */
+else {
+    // Code.
+}
+
+// OK - multiple blank lines between if/else are ignored, not the concern of this sniff.
+if ( true ) {
+    // Code.
+}
+
+
+else {
+    // Code.
+}
+
+
+/*
+ * Error: else/elseif should be on the next line.
+ *
+ * We're not concerned with `else if` vs  elseif` or whether the keywords are on the same line
+ * if `else if` is used. That's the concern of a sniff checking the keyword.
+ */
+
+if ( true ) {
+    // Code.
+} else { // Error.
+    // Code.
+}
+
+if ( true ) {
+    // Code.
+} elseif( 1 ) { // Error.
+    // Code.
+} else if       (2 // Error.
+    || 6
+) {
+    // Code.
+} else // Error.
+    if (2) {
+    // Code.
+} /* comment */ elseif (3) { // Error, non-autofixable as it's unclear where the comment should go.
+    // Code.
+} else { // Error.
+    // Code.
+}
+
+/*
+ * Test fixer for combined errors
+ */
+
+    // Test fixer with indentation.
+    if ( true ) {
+        // Code.
+    } else { // Error.
+        // Code.
+    }
+
+        if ( true ) {
+            // Code.
+        } elseif( 1 ) { // Error.
+            // Code.
+        } else if (2 // Error.
+            && 5
+        ) {
+            // Code.
+        } else( 3 ) { // Error.
+            // Code.
+        }
+
+            // Test fixer with tokens other than whitespace indentation on the line with the previous if.
+/*test*/    if ( true ) {
+                // Code.
+            } else { // Error.
+                // Code.
+            }
+
+    // Test fixer with single-line control structure.
+    if ( $a === 1 ) { echo $a; } elseif ( $a === 2 ) { echo $b; } else { echo $c; } // Error x 2.
+
+// Live coding.
+// Intentional parse error. This test has to be the last in the file.
+    if ($a) {
+        // Code.
+    } else {
+        // Code.

--- a/Universal/Tests/ControlStructures/IfElseDeclarationUnitTest.inc.fixed
+++ b/Universal/Tests/ControlStructures/IfElseDeclarationUnitTest.inc.fixed
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * Alternative control structure syntax. Ignore.
+ */
+if (true):
+    // Code.
+elseif (false):
+    // Code.
+else:
+    // Code.
+endif;
+
+/*
+ * Control structure without braces. Ignore.
+ */
+if (true)
+    function_call($a); elseif (false)
+    function_call($a); else
+    function_call($a);
+
+/*
+ * OK: else/elseif on the next line.
+ */
+if ( true ) {
+    // Code.
+}
+elseif {
+    // Code.
+}
+else if {
+    // Code.
+}
+else {
+    // Code.
+}
+
+/*
+ * OK: Comments and additional blank lines between the structures allowed.
+ */
+
+if ( true ) {
+    // Code.
+}
+// Some comment - this comment should be ignored.
+else {
+    // Code.
+}
+
+if ( true ) {
+    // Code.
+} // Trailing comment.
+
+/* phpcs:ignore Standard.Category.Sniffname -- for reasons. */
+else {
+    // Code.
+}
+
+// OK - multiple blank lines between if/else are ignored, not the concern of this sniff.
+if ( true ) {
+    // Code.
+}
+
+
+else {
+    // Code.
+}
+
+
+/*
+ * Error: else/elseif should be on the next line.
+ *
+ * We're not concerned with `else if` vs  elseif` or whether the keywords are on the same line
+ * if `else if` is used. That's the concern of a sniff checking the keyword.
+ */
+
+if ( true ) {
+    // Code.
+}
+else { // Error.
+    // Code.
+}
+
+if ( true ) {
+    // Code.
+}
+elseif( 1 ) { // Error.
+    // Code.
+}
+else if       (2 // Error.
+    || 6
+) {
+    // Code.
+}
+else // Error.
+    if (2) {
+    // Code.
+} /* comment */ elseif (3) { // Error, non-autofixable as it's unclear where the comment should go.
+    // Code.
+}
+else { // Error.
+    // Code.
+}
+
+/*
+ * Test fixer for combined errors
+ */
+
+    // Test fixer with indentation.
+    if ( true ) {
+        // Code.
+    }
+    else { // Error.
+        // Code.
+    }
+
+        if ( true ) {
+            // Code.
+        }
+        elseif( 1 ) { // Error.
+            // Code.
+        }
+        else if (2 // Error.
+            && 5
+        ) {
+            // Code.
+        }
+        else( 3 ) { // Error.
+            // Code.
+        }
+
+            // Test fixer with tokens other than whitespace indentation on the line with the previous if.
+/*test*/    if ( true ) {
+                // Code.
+            }
+            else { // Error.
+                // Code.
+            }
+
+    // Test fixer with single-line control structure.
+    if ( $a === 1 ) { echo $a; }
+    elseif ( $a === 2 ) { echo $b; }
+    else { echo $c; } // Error x 2.
+
+// Live coding.
+// Intentional parse error. This test has to be the last in the file.
+    if ($a) {
+        // Code.
+    } else {
+        // Code.

--- a/Universal/Tests/ControlStructures/IfElseDeclarationUnitTest.php
+++ b/Universal/Tests/ControlStructures/IfElseDeclarationUnitTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\ControlStructures;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the IfElseDeclaration sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\ControlStructures\IfElseDeclarationSniff
+ *
+ * @since 1.0.0
+ */
+class IfElseDeclarationUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getErrorList()
+    {
+        return [
+            79  => 1,
+            85  => 1,
+            87  => 1,
+            91  => 1,
+            94  => 1,
+            96  => 1,
+            107 => 1,
+            113 => 1,
+            115 => 1,
+            119 => 1,
+            126 => 1,
+            131 => 2,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array <int line number> => <int number of warnings>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -59,4 +59,20 @@
         <exclude-pattern>/phpunit-bootstrap\.php$</exclude-pattern>
     </rule>
 
+
+    <!--
+    #############################################################################
+    TEMPORARY ADJUSTMENTS
+    Adjustments which should be removed once the associated issue has been resolved.
+    #############################################################################
+    -->
+
+    <!-- Bug in PHPCS. This exclusion can be removed once the fix has been merged.
+         Ref: https://github.com/squizlabs/PHP_CodeSniffer/issues/2822
+         Ref: https://github.com/squizlabs/PHP_CodeSniffer/pull/2827
+    -->
+    <rule ref="Generic.ControlStructures.InlineControlStructure">
+        <exclude-pattern>/Universal/Sniffs/ControlStructures/IfElseDeclarationSniff\.php$</exclude-pattern>
+    </rule>
+
 </ruleset>


### PR DESCRIPTION
New sniff to verify that `else(if)` statements with braces are on a new line.

Sister-sniff to the following two PHPCS native sniffs which each demand that `else[]if` is on the same line as the closing curly of the preceding `(else)if`:
- `PEAR.ControlStructures.ControlSignature[.Found]`
- `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace`

Other related sniffs:
- `Squiz.ControlStructures.ElseIfDeclaration` Forbids the use of "elseif", demands "else if".
- `PSR2.ControlStructures.ElseIfDeclaration`  Forbids the use of "else if", demands "elseif".

Includes fixer.
Includes unit tests.
Includes documentation.
Includes metrics.


Includes minor PHPCS ruleset adjustment - a temporary exclusion for a bug in PHPCS upstream