### PR TITLE
New `NormalizedArrays.Arrays.CommaAfterLast` sniff

### DIFF
--- a/NormalizedArrays/Docs/Arrays/CommaAfterLastStandard.xml
+++ b/NormalizedArrays/Docs/Arrays/CommaAfterLastStandard.xml
@@ -1,0 +1,39 @@
+<documentation title="Comma After Last Array Item">
+    <standard>
+    <![CDATA[
+      For single-line arrays, there should be <em>no</em> comma after the last array item.
+
+      However, for multi-line arrays, there <em>should</em> be a comma after the last array item.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Single-line array without a comma after the last item">
+        <![CDATA[
+$args = array(1, 2, 3);
+        ]]>
+        </code>
+        <code title="Invalid: Single-line array with a comma after the last item">
+        <![CDATA[
+$args = array(1, 2, 3<em>,</em> );
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: Multi-line array with a comma after the last item">
+        <![CDATA[
+$args = [
+    1 => 'foo',
+    2 => 'bar'<em>,</em>
+];
+        ]]>
+        </code>
+        <code title="Invalid: Multi-line array without a comma after the last item">
+        <![CDATA[
+$args = [
+    1 => 'foo',
+    2 => 'bar'
+];
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/NormalizedArrays/Sniffs/Arrays/CommaAfterLastSniff.php
+++ b/NormalizedArrays/Sniffs/Arrays/CommaAfterLastSniff.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\NormalizedArrays\Sniffs\Arrays;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\Arrays;
+
+/**
+ * Enforce/forbid a comma after the last item in an array declaration.
+ *
+ * Allows for different settings for single-line and multi-line arrays.
+ *
+ * @since 1.0.0
+ */
+class CommaAfterLastSniff implements Sniff
+{
+
+    /**
+     * Whether or not to enforce a comma after the last array item in a single-line array.
+     *
+     * Valid values:
+     * - 'enforce' to always demand a comma after the last item in single-line arrays;
+     * - 'forbid'  to disallow a comma after the last item in single-line arrays;
+     * - 'skip'    to ignore single-line arrays.
+     *
+     * Defaults to: 'forbid'.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    public $singleLine = 'forbid';
+
+    /**
+     * Whether or not to enforce a comma after the last array item in a multi-line array.
+     *
+     * Valid values:
+     * - 'enforce' to always demand a comma after the last item in single-line arrays;
+     * - 'forbid'  to disallow a comma after the last item in single-line arrays;
+     * - 'skip'    to ignore multi-line arrays.
+     *
+     * Defaults to: 'enforce'.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    public $multiLine = 'enforce';
+
+    /**
+     * The input values to consider as valid for the public properties.
+     *
+     * Used for input validation.
+     *
+     * @since 1.0.0
+     *
+     * @var array
+     */
+    private $validValues = [
+        'enforce' => true,
+        'forbid'  => true,
+        'skip'    => true,
+    ];
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [
+            \T_ARRAY,
+            \T_OPEN_SHORT_ARRAY,
+            \T_OPEN_SQUARE_BRACKET,
+        ];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Validate the property input. Invalid values will result in the check being skipped.
+        if (isset($this->validValues[$this->singleLine]) === false) {
+            $this->singleLine = 'skip';
+        }
+        if (isset($this->validValues[$this->multiLine]) === false) {
+            $this->multiLine = 'skip';
+        }
+
+        $openClose = Arrays::getOpenClose($phpcsFile, $stackPtr);
+        if ($openClose === false) {
+            // Short list, real square bracket, live coding or parse error.
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        $opener = $openClose['opener'];
+        $closer = $openClose['closer'];
+
+        $action    = $this->singleLine;
+        $phrase    = 'single-line';
+        $errorCode = 'SingleLine';
+        if ($tokens[$opener]['line'] !== $tokens[$closer]['line']) {
+            $action    = $this->multiLine;
+            $phrase    = 'multi-line';
+            $errorCode = 'MultiLine';
+        }
+
+        if ($action === 'skip') {
+            // Nothing to do.
+            return;
+        }
+
+        $lastNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($closer - 1), $opener, true);
+        if ($lastNonEmpty === false || $lastNonEmpty === $opener) {
+            // Bow out: empty array.
+            return;
+        }
+
+        $isComma = ($tokens[$lastNonEmpty]['code'] === \T_COMMA);
+
+        $phpcsFile->recordMetric(
+            $stackPtr,
+            \ucfirst($phrase) . ' array - comma after last item',
+            ($isComma === true ? 'yes' : 'no')
+        );
+
+        switch ($action) {
+            case 'enforce':
+                if ($isComma === true) {
+                    return;
+                }
+
+                $error     = 'There should be a comma after the last array item in a %s array.';
+                $errorCode = 'Missing' . $errorCode;
+                $data      = [$phrase];
+                $fix       = $phpcsFile->addFixableError($error, $lastNonEmpty, $errorCode, $data);
+                if ($fix === true) {
+                    $extraContent = ',';
+
+                    if ($tokens[$lastNonEmpty]['code'] === \T_END_HEREDOC
+                        || $tokens[$lastNonEmpty]['code'] === \T_END_NOWDOC
+                    ) {
+                        // Prevent parse errors in PHP < 7.3 which doesn't support flexible heredoc/nowdoc.
+                        $extraContent = $phpcsFile->eolChar . $extraContent;
+                    }
+
+                    $phpcsFile->fixer->addContent($lastNonEmpty, $extraContent);
+                }
+
+                return;
+
+            case 'forbid':
+                if ($isComma === false) {
+                    return;
+                }
+
+                $error     = 'A comma after the last array item in a %s array is not allowed.';
+                $errorCode = 'Found' . $errorCode;
+                $data      = [$phrase];
+                $fix       = $phpcsFile->addFixableError($error, $lastNonEmpty, $errorCode, $data);
+                if ($fix === true) {
+                    $start = $lastNonEmpty;
+                    $end   = $lastNonEmpty;
+
+                    // Make sure we're not leaving a superfluous blank line behind.
+                    $prevNonWhitespace = $phpcsFile->findPrevious(\T_WHITESPACE, ($lastNonEmpty - 1), $opener, true);
+                    $nextNonWhitespace = $phpcsFile->findNext(\T_WHITESPACE, ($lastNonEmpty + 1), ($closer + 1), true);
+                    if ($prevNonWhitespace !== false
+                        && $tokens[$prevNonWhitespace]['line'] < $tokens[$lastNonEmpty]['line']
+                        && $nextNonWhitespace !== false
+                        && $tokens[$nextNonWhitespace]['line'] > $tokens[$lastNonEmpty]['line']
+                    ) {
+                        $start = ($prevNonWhitespace + 1);
+                    }
+
+                    $phpcsFile->fixer->beginChangeset();
+                    for ($i = $start; $i <= $end; $i++) {
+                        $phpcsFile->fixer->replaceToken($i, '');
+                    }
+
+                    $phpcsFile->fixer->endChangeset();
+                }
+
+                return;
+        }
+    }
+}

--- a/NormalizedArrays/Tests/Arrays/CommaAfterLastUnitTest.inc
+++ b/NormalizedArrays/Tests/Arrays/CommaAfterLastUnitTest.inc
@@ -1,0 +1,177 @@
+<?php
+
+/*
+ * Verify that non-arrays are not touched by the sniff.
+ * - square brackets, not short array.
+ * - short lists.
+ */
+$a['array_access'] = 123;
+
+// Short list, not short array.
+[,,] = $array;
+[$var1, , [$var2, $var3,], $var4,] = $array;
+
+/*
+ * Empty arrays should be ignored.
+ */
+$empty = array();
+$empty = [ /* comment */ ];
+
+/*
+ * Test skipping the checks when 'skip' has been passed.
+ */
+// phpcs:set NormalizedArrays.Arrays.CommaAfterLast singleLine skip
+// phpcs:set NormalizedArrays.Arrays.CommaAfterLast multiLine skip
+
+$ignore = array(1, 2, 3,);
+$ignore = [
+    1,
+    3
+];
+
+/*
+ * Test skipping the checks when invalid property settings have been passed.
+ */
+// phpcs:set NormalizedArrays.Arrays.CommaAfterLast singleLine disallow
+// phpcs:set NormalizedArrays.Arrays.CommaAfterLast multiLine demand
+
+$ignore = array(1, 2, 3,);
+$ignore = [
+    1,
+    3
+];
+
+/*
+ * Test enforcing a comma after the last array item.
+ */
+// phpcs:set NormalizedArrays.Arrays.CommaAfterLast singleLine enforce
+
+$good = array( 1, 2, 3, );
+$good = [ 'a', 'b', 'c', ];
+
+$missing = array( 1, 2, 3 );
+$missing = [ 'a', 'b', 'c' ];
+
+// phpcs:set NormalizedArrays.Arrays.CommaAfterLast multiLine enforce
+
+$good = array(
+    1,
+    3,
+);
+$good = [
+    'a',
+    'c',
+];
+
+$goodHeredoc = function_call()->method_name( array(
+        'phrase'        => <<<EOD
+Here comes some text.
+EOD
+,
+) );
+
+$missing = array(
+    1,
+    3
+);
+$missing = [
+    'a',
+    'c'/* Comment. */
+];
+
+$missingInNested = array(
+    1 => 'value' ,
+    2 => [
+        'a' => 'value'     ,// phpcs:disable Standard.Category.Sniff - the extra spacing is fine, might be for alignment with other comments.
+        'b' => array(
+            1
+        ),
+        'c' => apply_filters( 'filter', $input, $var )
+    ],
+    3 => apply_filters( 'filter', $input, $var )/* phpcs:ignore Standard.Category.Sniff */
+);
+
+$missing = array(
+         'first',
+         'second'
+         //'third',
+        );
+
+$missingNowdoc = function_call()->method_name( array(
+        'phrase'        => <<<'EOD'
+Here comes some text.
+EOD
+) );
+
+/*
+ * Test forbidding a comma after the last array item.
+ */
+// phpcs:set NormalizedArrays.Arrays.CommaAfterLast singleLine forbid
+
+$good = array( 1, 2, 3 );
+$good = [ 'a', 'b', 'c' ];
+
+$found = array( 1, 2, 3, );
+$found = [ 'a', 'b', 'c', ];
+
+// phpcs:set NormalizedArrays.Arrays.CommaAfterLast multiLine forbid
+
+$good = array(
+    1,
+    3
+);
+$good = [
+    'a',
+    'c'
+];
+
+$goodNowdoc = function_call()->method_name( array(
+        'phrase'        => <<<'EOD'
+Here comes some text.
+EOD
+) );
+
+$found = array(
+    1,
+    3,/* Comment. */
+);
+$found = [
+    'a',
+    'c',
+];
+
+$foundInNested = array(
+    1 => 'value' ,
+    2 => [
+        'a' => 'value'     ,// phpcs:disable Standard.Category.Sniff - the extra spacing is fine, might be for alignment with other comments.
+        'b' => array(
+            1,
+        ),
+        'c' => apply_filters( 'filter', $input, $var ),
+    ],
+    3 => apply_filters( 'filter', $input, $var ), /* phpcs:ignore Standard.Category.Sniff */
+);
+
+$foundHeredoc = function_call()->method_name( array(
+        'phrase'        => <<<"EOD"
+Here comes some text.
+EOD
+,
+) );
+
+$foundHeredoc = function_call()->method_name( array(
+        'phrase'        => <<<"EOD"
+Here comes some text.
+EOD
+, /*comment*/
+) );
+
+// Reset the properties to the defaults.
+// phpcs:set NormalizedArrays.Arrays.CommaAfterLast singleLine forbid
+// phpcs:set NormalizedArrays.Arrays.CommaAfterLast multiLine enforce
+
+/*
+ * Test live coding. This should be the last test in the file.
+ */
+// Intentional parse error.
+$ignore = array(

--- a/NormalizedArrays/Tests/Arrays/CommaAfterLastUnitTest.inc.fixed
+++ b/NormalizedArrays/Tests/Arrays/CommaAfterLastUnitTest.inc.fixed
@@ -1,0 +1,177 @@
+<?php
+
+/*
+ * Verify that non-arrays are not touched by the sniff.
+ * - square brackets, not short array.
+ * - short lists.
+ */
+$a['array_access'] = 123;
+
+// Short list, not short array.
+[,,] = $array;
+[$var1, , [$var2, $var3,], $var4,] = $array;
+
+/*
+ * Empty arrays should be ignored.
+ */
+$empty = array();
+$empty = [ /* comment */ ];
+
+/*
+ * Test skipping the checks when 'skip' has been passed.
+ */
+// phpcs:set NormalizedArrays.Arrays.CommaAfterLast singleLine skip
+// phpcs:set NormalizedArrays.Arrays.CommaAfterLast multiLine skip
+
+$ignore = array(1, 2, 3,);
+$ignore = [
+    1,
+    3
+];
+
+/*
+ * Test skipping the checks when invalid property settings have been passed.
+ */
+// phpcs:set NormalizedArrays.Arrays.CommaAfterLast singleLine disallow
+// phpcs:set NormalizedArrays.Arrays.CommaAfterLast multiLine demand
+
+$ignore = array(1, 2, 3,);
+$ignore = [
+    1,
+    3
+];
+
+/*
+ * Test enforcing a comma after the last array item.
+ */
+// phpcs:set NormalizedArrays.Arrays.CommaAfterLast singleLine enforce
+
+$good = array( 1, 2, 3, );
+$good = [ 'a', 'b', 'c', ];
+
+$missing = array( 1, 2, 3, );
+$missing = [ 'a', 'b', 'c', ];
+
+// phpcs:set NormalizedArrays.Arrays.CommaAfterLast multiLine enforce
+
+$good = array(
+    1,
+    3,
+);
+$good = [
+    'a',
+    'c',
+];
+
+$goodHeredoc = function_call()->method_name( array(
+        'phrase'        => <<<EOD
+Here comes some text.
+EOD
+,
+) );
+
+$missing = array(
+    1,
+    3,
+);
+$missing = [
+    'a',
+    'c',/* Comment. */
+];
+
+$missingInNested = array(
+    1 => 'value' ,
+    2 => [
+        'a' => 'value'     ,// phpcs:disable Standard.Category.Sniff - the extra spacing is fine, might be for alignment with other comments.
+        'b' => array(
+            1,
+        ),
+        'c' => apply_filters( 'filter', $input, $var ),
+    ],
+    3 => apply_filters( 'filter', $input, $var ),/* phpcs:ignore Standard.Category.Sniff */
+);
+
+$missing = array(
+         'first',
+         'second',
+         //'third',
+        );
+
+$missingNowdoc = function_call()->method_name( array(
+        'phrase'        => <<<'EOD'
+Here comes some text.
+EOD
+,
+) );
+
+/*
+ * Test forbidding a comma after the last array item.
+ */
+// phpcs:set NormalizedArrays.Arrays.CommaAfterLast singleLine forbid
+
+$good = array( 1, 2, 3 );
+$good = [ 'a', 'b', 'c' ];
+
+$found = array( 1, 2, 3 );
+$found = [ 'a', 'b', 'c' ];
+
+// phpcs:set NormalizedArrays.Arrays.CommaAfterLast multiLine forbid
+
+$good = array(
+    1,
+    3
+);
+$good = [
+    'a',
+    'c'
+];
+
+$goodNowdoc = function_call()->method_name( array(
+        'phrase'        => <<<'EOD'
+Here comes some text.
+EOD
+) );
+
+$found = array(
+    1,
+    3/* Comment. */
+);
+$found = [
+    'a',
+    'c'
+];
+
+$foundInNested = array(
+    1 => 'value' ,
+    2 => [
+        'a' => 'value'     ,// phpcs:disable Standard.Category.Sniff - the extra spacing is fine, might be for alignment with other comments.
+        'b' => array(
+            1
+        ),
+        'c' => apply_filters( 'filter', $input, $var )
+    ],
+    3 => apply_filters( 'filter', $input, $var ) /* phpcs:ignore Standard.Category.Sniff */
+);
+
+$foundHeredoc = function_call()->method_name( array(
+        'phrase'        => <<<"EOD"
+Here comes some text.
+EOD
+) );
+
+$foundHeredoc = function_call()->method_name( array(
+        'phrase'        => <<<"EOD"
+Here comes some text.
+EOD
+ /*comment*/
+) );
+
+// Reset the properties to the defaults.
+// phpcs:set NormalizedArrays.Arrays.CommaAfterLast singleLine forbid
+// phpcs:set NormalizedArrays.Arrays.CommaAfterLast multiLine enforce
+
+/*
+ * Test live coding. This should be the last test in the file.
+ */
+// Intentional parse error.
+$ignore = array(

--- a/NormalizedArrays/Tests/Arrays/CommaAfterLastUnitTest.php
+++ b/NormalizedArrays/Tests/Arrays/CommaAfterLastUnitTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\NormalizedArrays\Tests\Arrays;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the CommaAfterLast sniff.
+ *
+ * @covers PHPCSExtra\NormalizedArrays\Sniffs\Arrays\CommaAfterLastSniff
+ *
+ * @since 1.0.0
+ */
+class CommaAfterLastUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getErrorList()
+    {
+        return [
+            52  => 1,
+            53  => 1,
+            75  => 1,
+            79  => 1,
+            87  => 1,
+            89  => 1,
+            91  => 1,
+            96  => 1,
+            103 => 1,
+            114 => 1,
+            115 => 1,
+            136 => 1,
+            140 => 1,
+            148 => 1,
+            150 => 1,
+            152 => 1,
+            159 => 1,
+            166 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array <int line number> => <int number of warnings>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Configurable sniff to enforce/forbid a comma after the last array item.

By default, this sniff will:
- forbid a comma after the last array item for _single-line arrays_.
- enforce a comma after the last array item for _multi-line arrays_.

This can be changed for each type or array individually by setting the `singleLine` or `multiLine` properties in a custom ruleset.
The valid values are: `enforce`, `forbid` or `skip` to not check the comma after the last array item for a particular type of array.

Includes fixers.
Includes unit tests.
Includes documentation.
Includes metrics.