### PR TITLE
New `NormalizedArrays.Arrays.ArrayBraceSpacing` sniff

### DIFF
--- a/NormalizedArrays/Docs/Arrays/ArrayBraceSpacingStandard.xml
+++ b/NormalizedArrays/Docs/Arrays/ArrayBraceSpacingStandard.xml
@@ -1,0 +1,93 @@
+<documentation title="Array Brace Spacing">
+    <standard>
+    <![CDATA[
+        There should be no space between the "array" keyword and the array open brace.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: No space between the keyword and the open brace.">
+        <![CDATA[
+$args = array(1, 2);
+        ]]>
+        </code>
+        <code title="Invalid: Space between the keyword and the open brace.">
+        <![CDATA[
+$args = array<em>  </em>(1, 2);
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+        There should be no space between the array open brace and the array close brace for an empty array.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: No space between the braces.">
+        <![CDATA[
+$args = array();
+
+$args = [];
+        ]]>
+        </code>
+        <code title="Invalid: Space between the braces.">
+        <![CDATA[
+$args = array(<em> </em>);
+
+$args = [<em>  </em>];
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+        There should be no space after the array open brace and before the array close brace in a single-line array.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: No space on the inside of the braces.">
+        <![CDATA[
+$args = array(1, 2);
+
+$args = [1, 2];
+        ]]>
+        </code>
+        <code title="Invalid: Space on the inside of the braces.">
+        <![CDATA[
+$args = array(<em> </em>1, 2<em> </em>);
+
+$args = [<em>  </em>1, 2<em>  </em>];
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+        There should be a new line after the array open brace and before the array close brace in a multi-line array.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: One new line after the open brace and before the close brace.">
+        <![CDATA[
+$args = array(<em>
+</em>    1,
+    2<em>
+</em>);
+
+$args = [<em>
+</em>    1,
+    2<em>
+</em>];
+        ]]>
+        </code>
+        <code title="Invalid: No new lines after the open brace and/or before the close brace.">
+        <![CDATA[
+$args = array(1,
+    2);
+
+$args = [1,
+    2<em>
+
+
+</em>];
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/NormalizedArrays/Sniffs/Arrays/ArrayBraceSpacingSniff.php
+++ b/NormalizedArrays/Sniffs/Arrays/ArrayBraceSpacingSniff.php
@@ -1,0 +1,294 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\NormalizedArrays\Sniffs\Arrays;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHPCSUtils\Fixers\SpacesFixer;
+use PHPCSUtils\Utils\Arrays;
+
+/**
+ * Enforce consistent spacing for the open/close braces of arrays.
+ *
+ * The sniff allows for having different settings for:
+ * - space between the `array` keyword and the open parenthesis for long arrays;
+ * - spaces on the inside of the braces for single-line arrays;
+ * - spaces on the inside of the braces for multi-line arrays;
+ * - spaces on the inside of the braces for empty arrays.
+ *
+ * Note: If 'newline' is expected and _no_ new line is encountered, a new line will be
+ * added, but no assumptions will be made about the intended indentation of the code.
+ * This should be handled by a (separate) indentation sniff.
+ *
+ * @since 1.0.0
+ */
+class ArrayBraceSpacingSniff implements Sniff
+{
+
+    /**
+     * Number of spaces which should be between the `array` keyword and the open parenthesis for long arrays.
+     *
+     * Accepted values:
+     * - (int) number of spaces.
+     * - or `false` to turn this check off.
+     *
+     * Defaults to 0 spaces.
+     *
+     * @since 1.0.0
+     *
+     * @var int|false
+     */
+    public $keywordSpacing = 0;
+
+    /**
+     * Number of spaces to enforce between the braces for an empty array.
+     *
+     * Accepted values:
+     * - (string) 'newline'
+     * - (int) number of spaces.
+     * - or `false` to turn this check off.
+     *
+     * Defaults to 0 spaces.
+     *
+     * @since 1.0.0
+     *
+     * @var string|int|false
+     */
+    public $spacesWhenEmpty = 0;
+
+    /**
+     * Number of spaces which should be on the inside of array braces for a single-line array.
+     *
+     * Accepted values:
+     * - (int) number of spaces.
+     * - or `false` to turn this check off.
+     *
+     * Defaults to 0 spaces.
+     *
+     * @since 1.0.0
+     *
+     * @var int|false
+     */
+    public $spacesSingleLine = 0;
+
+    /**
+     * Number of spaces which should be on the inside of array braces for a multi-line array.
+     *
+     * Accepted values:
+     * - (string) 'newline'
+     * - (int) number of spaces.
+     * - or `false` to turn this check off.
+     *
+     * Defaults to 'newline'.
+     *
+     * @since 1.0.0
+     *
+     * @var string|int|false
+     */
+    public $spacesMultiLine = 'newline';
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [
+            \T_ARRAY,
+            \T_OPEN_SHORT_ARRAY,
+            \T_OPEN_SQUARE_BRACKET,
+        ];
+    }
+
+   /**
+     * Processes this test when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where the
+     *                                               token was found.
+     * @param int                         $stackPtr  The position in the PHP_CodeSniffer
+     *                                               file's token stack where the token
+     *                                               was found.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        /*
+         * Normalize the public settings.
+         */
+        if ($this->keywordSpacing !== false) {
+            $this->keywordSpacing = \max((int) $this->keywordSpacing, 0);
+        }
+
+        if ($this->spacesSingleLine !== false) {
+            $this->spacesSingleLine = \max((int) $this->spacesSingleLine, 0);
+        }
+
+        if ($this->spacesMultiLine !== false && $this->spacesMultiLine !== 'newline') {
+            $this->spacesMultiLine = \max((int) $this->spacesMultiLine, 0);
+        }
+
+        if ($this->spacesWhenEmpty !== false && $this->spacesWhenEmpty !== 'newline') {
+            $this->spacesWhenEmpty = \max((int) $this->spacesWhenEmpty, 0);
+        }
+
+        if ($this->keywordSpacing === false
+            && $this->spacesSingleLine === false
+            && $this->spacesMultiLine === false
+            && $this->spacesWhenEmpty === false
+        ) {
+            // Nothing to do. Why was the sniff turned on at all ?
+            return;
+        }
+
+        $openClose = Arrays::getOpenClose($phpcsFile, $stackPtr);
+        if ($openClose === false) {
+            // Short list or real square brackets.
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        $opener = $openClose['opener'];
+        $closer = $openClose['closer'];
+
+        /*
+         * Check the spacing between the array keyword and the open parenthesis for long arrays.
+         */
+        if ($tokens[$stackPtr]['code'] === \T_ARRAY && $this->keywordSpacing !== false) {
+            $error = 'There should be %s between the "array" keyword and the open parenthesis. Found: %s';
+            $code  = 'SpaceAfterKeyword';
+
+            SpacesFixer::checkAndFix(
+                $phpcsFile,
+                $stackPtr,
+                $opener,
+                $this->keywordSpacing,
+                $error,
+                $code,
+                'error',
+                0,
+                'Space between array keyword and open brace'
+            );
+        }
+
+        /*
+         * Check for empty arrays.
+         */
+        $nextNonWhiteSpace = $phpcsFile->findNext(\T_WHITESPACE, ($opener + 1), null, true);
+        if ($nextNonWhiteSpace === $closer) {
+            if ($this->spacesWhenEmpty === false) {
+                // Check was turned off.
+                return;
+            }
+
+            $error = 'There should be %s between the array opener and closer for an empty array. Found: %s';
+            $code  = 'EmptyArraySpacing';
+
+            SpacesFixer::checkAndFix(
+                $phpcsFile,
+                $opener,
+                $closer,
+                $this->spacesWhenEmpty,
+                $error,
+                $code,
+                'error',
+                0,
+                'Space between open and close brace for an empty array'
+            );
+
+            return;
+        }
+
+        /*
+         * Check non-empty arrays.
+         */
+        if ($tokens[$opener]['line'] === $tokens[$closer]['line']) {
+            // Single line array.
+            if ($this->spacesSingleLine === false) {
+                // Check was turned off.
+                return;
+            }
+
+            $error = 'Expected %s after the array opener in a single line array. Found: %s';
+            $code  = 'SpaceAfterArrayOpenerSingleLine';
+
+            SpacesFixer::checkAndFix(
+                $phpcsFile,
+                $opener,
+                $phpcsFile->findNext(\T_WHITESPACE, ($opener + 1), null, true),
+                $this->spacesSingleLine,
+                $error,
+                $code,
+                'error',
+                0,
+                'Space after array opener, single line array'
+            );
+
+            $error = 'Expected %s before the array closer in a single line array. Found: %s';
+            $code  = 'SpaceBeforeArrayCloserSingleLine';
+
+            SpacesFixer::checkAndFix(
+                $phpcsFile,
+                $closer,
+                $phpcsFile->findPrevious(\T_WHITESPACE, ($closer - 1), null, true),
+                $this->spacesSingleLine,
+                $error,
+                $code,
+                'error',
+                0,
+                'Space before array closer, single line array'
+            );
+
+            return;
+        }
+
+        // Multi-line array.
+        if ($this->spacesMultiLine === false) {
+            // Check was turned off.
+            return;
+        }
+
+        $error = 'Expected %s after the array opener in a multi line array. Found: %s';
+        $code  = 'SpaceAfterArrayOpenerMultiLine';
+
+        SpacesFixer::checkAndFix(
+            $phpcsFile,
+            $opener,
+            $phpcsFile->findNext(\T_WHITESPACE, ($opener + 1), null, true),
+            $this->spacesMultiLine,
+            $error,
+            $code,
+            'error',
+            0,
+            'Space after array opener, multi-line array'
+        );
+
+        $error = 'Expected %s before the array closer in a multi line array. Found: %s';
+        $code  = 'SpaceBeforeArrayCloserMultiLine';
+
+        SpacesFixer::checkAndFix(
+            $phpcsFile,
+            $closer,
+            $phpcsFile->findPrevious(\T_WHITESPACE, ($closer - 1), null, true),
+            $this->spacesMultiLine,
+            $error,
+            $code,
+            'error',
+            0,
+            'Space before array closer, multi-line array'
+        );
+    }
+}

--- a/NormalizedArrays/Tests/Arrays/ArrayBraceSpacingUnitTest.inc
+++ b/NormalizedArrays/Tests/Arrays/ArrayBraceSpacingUnitTest.inc
@@ -1,0 +1,211 @@
+<?php
+
+// Not (short) array.
+$array['access'] = $foo;
+[$a, $b] = $array;
+
+/*
+ * Keyword spacing
+ */
+$foo = array();
+$foo = array (); // Error.
+$foo = array /*comment*/ (); // Error (non-fixable).
+$foo = array
+	   (); // Error.
+
+// Test incorrect setting of property.
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing keywordSpacing -10
+$foo = array    (); // Error for no spaces.
+
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing keywordSpacing 1
+$foo = array ();
+$foo = array(); // Error.
+$foo = array
+	   (); // Error.
+$foo = array    (); // Error.
+
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing keywordSpacing false
+$foo = array ();
+$foo = array();
+$foo = array
+	   ();
+$foo = array    ();
+
+// Reset to default.
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing keywordSpacing 0
+
+/*
+ * Empty arrays.
+ */
+$foo = array();
+$foo = [];
+
+$foo = array(  ); // Error.
+$foo = [
+
+]; // Error.
+
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesWhenEmpty 1
+$foo = array( );
+$foo = [ ];
+
+$foo = array(); // Error.
+$foo = []; // Error.
+$foo = array(
+
+); // Error.
+$foo = [      ]; // Error.
+
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesWhenEmpty newline
+$foo = array(
+);
+$foo = [
+];
+
+$foo = array(); // Error.
+$foo = []; // Error.
+$foo = array(     ); // Error.
+$foo = [ ]; // Error.
+$foo = array(
+
+
+); // Error.
+
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesWhenEmpty false
+$foo = array();
+$foo = [];
+$foo = array(     );
+$foo = [
+];
+
+// Reset to default.
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesWhenEmpty 0
+
+/*
+ * Non-empty single-line arrays.
+ */
+
+$foo = array($a, $b);
+$foo = [$a, $b];
+$foo = [/*comment*/];
+
+$foo = array( $a, $b ); // Error x 2.
+$foo = [    $a, $b      ]; // Error x 2.
+$foo = array(/* comment */ /* comment */   ); // Error x 1.
+
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesSingleLine 1
+$foo = array( $a, $b );
+$foo = [ $a, $b ];
+$foo = [ /* comment */ ];
+
+$foo = array($a, $b); // Error x 2.
+$foo = [$a, $b]; // Error x 2.
+$foo = array(   $a, $b      ); // Error x 2.
+$foo = [  $a, $b]; // Error x 2.
+
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesSingleLine false
+$foo = array($a, $b);
+$foo = [$a, $b];
+$foo = array(  $a, $b   );
+$foo = [ $a, $b ];
+
+// Reset to default.
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesSingleLine 0
+
+/*
+ * Non-empty multi-line arrays.
+ */
+
+$array = array(
+    $a,
+    $b
+);
+
+$array = [
+    $a,
+    $b
+];
+
+$array = array($a,
+    $b); // Error x 2.
+
+$array = [
+
+
+
+    $a,
+    $b]; // Error x 2.
+
+$array = array($a,
+    $b
+); // Error x 1.
+
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesMultiLine 0
+
+$array = [$a,
+    $b];
+$array = array($a,
+    $b);
+
+$array = [
+    $a,
+    $b
+]; // Error x 2.
+
+$array = [
+
+
+
+    $a,
+    $b]; // Error x 1.
+
+$array = array($a,
+    $b
+); // Error x 1.
+
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesMultiLine 1
+
+$array = [ $a,
+    $b ];
+$array = array( $a,
+    $b );
+
+$array = [
+    $a,
+    $b
+]; // Error x 2.
+
+$array = [
+
+
+
+    $a,
+    $b]; // Error x 2.
+
+$array = array($a,
+    $b
+); // Error x 2.
+
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesMultiLine false
+
+$array = array(
+    $a,
+    $b
+);
+
+$array = array($a,
+    $b);
+
+$array = [
+
+
+
+    $a,
+    $b];
+
+$array = array($a,
+    $b
+);
+
+// Reset to default.
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesMultiLine newline

--- a/NormalizedArrays/Tests/Arrays/ArrayBraceSpacingUnitTest.inc.fixed
+++ b/NormalizedArrays/Tests/Arrays/ArrayBraceSpacingUnitTest.inc.fixed
@@ -1,0 +1,199 @@
+<?php
+
+// Not (short) array.
+$array['access'] = $foo;
+[$a, $b] = $array;
+
+/*
+ * Keyword spacing
+ */
+$foo = array();
+$foo = array(); // Error.
+$foo = array /*comment*/ (); // Error (non-fixable).
+$foo = array(); // Error.
+
+// Test incorrect setting of property.
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing keywordSpacing -10
+$foo = array(); // Error for no spaces.
+
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing keywordSpacing 1
+$foo = array ();
+$foo = array (); // Error.
+$foo = array (); // Error.
+$foo = array (); // Error.
+
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing keywordSpacing false
+$foo = array ();
+$foo = array();
+$foo = array
+	   ();
+$foo = array    ();
+
+// Reset to default.
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing keywordSpacing 0
+
+/*
+ * Empty arrays.
+ */
+$foo = array();
+$foo = [];
+
+$foo = array(); // Error.
+$foo = []; // Error.
+
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesWhenEmpty 1
+$foo = array( );
+$foo = [ ];
+
+$foo = array( ); // Error.
+$foo = [ ]; // Error.
+$foo = array( ); // Error.
+$foo = [ ]; // Error.
+
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesWhenEmpty newline
+$foo = array(
+);
+$foo = [
+];
+
+$foo = array(
+); // Error.
+$foo = [
+]; // Error.
+$foo = array(
+); // Error.
+$foo = [
+]; // Error.
+$foo = array(
+
+
+); // Error.
+
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesWhenEmpty false
+$foo = array();
+$foo = [];
+$foo = array(     );
+$foo = [
+];
+
+// Reset to default.
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesWhenEmpty 0
+
+/*
+ * Non-empty single-line arrays.
+ */
+
+$foo = array($a, $b);
+$foo = [$a, $b];
+$foo = [/*comment*/];
+
+$foo = array($a, $b); // Error x 2.
+$foo = [$a, $b]; // Error x 2.
+$foo = array(/* comment */ /* comment */); // Error x 1.
+
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesSingleLine 1
+$foo = array( $a, $b );
+$foo = [ $a, $b ];
+$foo = [ /* comment */ ];
+
+$foo = array( $a, $b ); // Error x 2.
+$foo = [ $a, $b ]; // Error x 2.
+$foo = array( $a, $b ); // Error x 2.
+$foo = [ $a, $b ]; // Error x 2.
+
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesSingleLine false
+$foo = array($a, $b);
+$foo = [$a, $b];
+$foo = array(  $a, $b   );
+$foo = [ $a, $b ];
+
+// Reset to default.
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesSingleLine 0
+
+/*
+ * Non-empty multi-line arrays.
+ */
+
+$array = array(
+    $a,
+    $b
+);
+
+$array = [
+    $a,
+    $b
+];
+
+$array = array(
+$a,
+    $b
+); // Error x 2.
+
+$array = [
+
+
+
+    $a,
+    $b
+]; // Error x 2.
+
+$array = array(
+$a,
+    $b
+); // Error x 1.
+
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesMultiLine 0
+
+$array = [$a,
+    $b];
+$array = array($a,
+    $b);
+
+$array = [$a,
+    $b]; // Error x 2.
+
+$array = [$a,
+    $b]; // Error x 1.
+
+$array = array($a,
+    $b); // Error x 1.
+
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesMultiLine 1
+
+$array = [ $a,
+    $b ];
+$array = array( $a,
+    $b );
+
+$array = [ $a,
+    $b ]; // Error x 2.
+
+$array = [ $a,
+    $b ]; // Error x 2.
+
+$array = array( $a,
+    $b ); // Error x 2.
+
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesMultiLine false
+
+$array = array(
+    $a,
+    $b
+);
+
+$array = array($a,
+    $b);
+
+$array = [
+
+
+
+    $a,
+    $b];
+
+$array = array($a,
+    $b
+);
+
+// Reset to default.
+// phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesMultiLine newline

--- a/NormalizedArrays/Tests/Arrays/ArrayBraceSpacingUnitTest.php
+++ b/NormalizedArrays/Tests/Arrays/ArrayBraceSpacingUnitTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\NormalizedArrays\Tests\Arrays;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the ArrayBraceSpacing sniff.
+ *
+ * @covers PHPCSExtra\NormalizedArrays\Sniffs\Arrays\ArrayBraceSpacingSniff
+ *
+ * @since 1.0.0
+ */
+class ArrayBraceSpacingUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getErrorList()
+    {
+        return [
+            11  => 1,
+            12  => 1,
+            13  => 1,
+            18  => 1,
+            22  => 1,
+            23  => 1,
+            25  => 1,
+            43  => 1,
+            44  => 1,
+            52  => 1,
+            53  => 1,
+            54  => 1,
+            57  => 1,
+            65  => 1,
+            66  => 1,
+            67  => 1,
+            68  => 1,
+            92  => 2,
+            93  => 2,
+            94  => 1,
+            101 => 2,
+            102 => 2,
+            103 => 2,
+            104 => 2,
+            129 => 1,
+            130 => 1,
+            137 => 1,
+            139 => 1,
+            150 => 1,
+            153 => 1,
+            155 => 1,
+            164 => 1,
+            173 => 1,
+            176 => 1,
+            178 => 1,
+            183 => 1,
+            185 => 1,
+            187 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array <int line number> => <int number of warnings>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Enforce consistent spacing for the open/close braces of arrays.

The sniff allows for having different settings for:
* Space between the `array` keyword and the open parenthesis for long arrays via the `keywordSpacing` property.
    Accepted values: (int) number of spaces or `false` to turn this check off. Defaults to `0` spaces.
* Spaces on the inside of the braces for empty arrays via the `spacesWhenEmpty` property.
    Accepted values: (string) 'newline', (int) number of spaces or `false` to turn this check off. Defaults to `0` spaces.
* Spaces on the inside of the braces for single-line arrays via the `spacesSingleLine` property;
    Accepted values: (int) number of spaces or `false` to turn this check off. Defaults to `0` spaces.
* Spaces on the inside of the braces for multi-line arrays via the `spacesMultiLine` property.
    Accepted values: (string) 'newline', (int) number of spaces or `false` to turn this check off. Defaults to `newline`.

Note: if any of the above properties are set to `newline`, it is recommended to also include an array indentation sniff.
This sniff will not handle the indentation.

Includes fixers.
Includes unit tests.
Includes documentation.
Includes metrics via the SpacesFixer.