### PR TITLE
New `Universal.Arrays.DuplicateArrayKey` sniff

### DIFF
--- a/Universal/Docs/Arrays/DuplicateArrayKeyStandard.xml
+++ b/Universal/Docs/Arrays/DuplicateArrayKeyStandard.xml
@@ -1,0 +1,40 @@
+<documentation title="Duplicate Array Key">
+    <standard>
+    <![CDATA[
+        When a second array item with the same key is declared, it will overwrite the first.
+        This sniff detects when this is happening in array declarations.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Arrays with unique keys.">
+        <![CDATA[
+$args = array(
+    <em>'foo'</em> => 22,
+    <em>'bar'</em> => 25,
+    <em>'baz'</em> => 28,
+);
+
+$args = array(
+    22,
+    25,
+    2 => 28,
+);
+        ]]>
+        </code>
+        <code title="Invalid: Array with duplicate keys.">
+        <![CDATA[
+$args = array(
+    <em>'foo'</em> => 22,
+    <em>'bar'</em> => 25,
+    <em>'bar'</em> => 28,
+);
+
+$args = array(
+    22,
+    25,
+    1 => 28,
+);
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/Arrays/DuplicateArrayKeySniff.php
+++ b/Universal/Sniffs/Arrays/DuplicateArrayKeySniff.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\Arrays;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff;
+
+/**
+ * Detect duplicate array keys in array declarations.
+ *
+ * This sniff will detect duplicate keys with high precision, though any array key
+ * set via a variable/constant/function call is excluded from the examination.
+ *
+ * @since 1.0.0
+ */
+class DuplicateArrayKeySniff extends AbstractArrayDeclarationSniff
+{
+
+    /**
+     * Keep track of which array keys have been seen already.
+     *
+     * @since 1.0.0
+     *
+     * @var array
+     */
+    private $keysSeen = [];
+
+    /**
+     * Keep track of the maximum seen integer key to know what the next value will be for
+     * array items without a key.
+     *
+     * @since 1.0.0
+     *
+     * @var int
+     */
+    private $currentMaxIntKey = -1;
+
+    /**
+     * Process every part of the array declaration.
+     *
+     * This contains the default logic for the sniff, but can be overloaded in a concrete child class
+     * if needed.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where the
+     *                                               token was found.
+     *
+     * @return void
+     */
+    public function processArray(File $phpcsFile)
+    {
+        // Reset properties before processing this array.
+        $this->keysSeen         = [];
+        $this->currentMaxIntKey = -1;
+
+        parent::processArray($phpcsFile);
+    }
+
+    /**
+     * Process the tokens in an array key.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where the
+     *                                               token was found.
+     * @param int                         $startPtr  The stack pointer to the first token in the "key" part of
+     *                                               an array item.
+     * @param int                         $endPtr    The stack pointer to the last token in the "key" part of
+     *                                               an array item.
+     * @param int                         $itemNr    Which item in the array is being handled.
+     *
+     * @return void
+     */
+    public function processKey(File $phpcsFile, $startPtr, $endPtr, $itemNr)
+    {
+        $key = $this->getActualArrayKey($phpcsFile, $startPtr, $endPtr);
+
+        if (isset($key) === false) {
+            // Key could not be determined.
+            return;
+        }
+
+        $integerKey = \is_int($key);
+
+        /*
+         * Check if we've seen it before.
+         */
+        if (isset($this->keysSeen[$key]) === true) {
+            $firstSeen              = $this->keysSeen[$key];
+            $firstNonEmptyFirstSeen = $phpcsFile->findNext(Tokens::$emptyTokens, $firstSeen['ptr'], null, true);
+            $firstNonEmpty          = $phpcsFile->findNext(Tokens::$emptyTokens, $startPtr, null, true);
+
+            $data = [
+                ($integerKey === true) ? 'integer' : 'string',
+                $key,
+                $firstSeen['item'],
+                $this->tokens[$firstNonEmptyFirstSeen]['line'],
+            ];
+
+            $phpcsFile->addError(
+                'Duplicate array key found. The value will be overwritten.'
+                    . ' The %s array key "%s" was first seen for array item %d on line %d',
+                $firstNonEmpty,
+                'Found',
+                $data
+            );
+
+            return;
+        }
+
+        /*
+         * Key not seen before. Add to array.
+         */
+        $this->keysSeen[$key] = [
+            'item' => $itemNr,
+            'ptr'  => $startPtr,
+        ];
+
+        if ($integerKey === true && $key > $this->currentMaxIntKey) {
+            $this->currentMaxIntKey = $key;
+        }
+    }
+
+    /**
+     * Process an array item without an array key.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where the
+     *                                               token was found.
+     * @param int                         $startPtr  The stack pointer to the first token in the array item,
+     *                                               which in this case will be the first token of the array
+     *                                               value part of the array item.
+     * @param int                         $itemNr    Which item in the array is being handled.
+     *
+     * @return void
+     */
+    public function processNoKey(File $phpcsFile, $startPtr, $itemNr)
+    {
+        ++$this->currentMaxIntKey;
+        $this->keysSeen[$this->currentMaxIntKey] = [
+            'item' => $itemNr,
+            'ptr'  => $startPtr,
+        ];
+    }
+}

--- a/Universal/Tests/Arrays/DuplicateArrayKeyUnitTest.inc
+++ b/Universal/Tests/Arrays/DuplicateArrayKeyUnitTest.inc
@@ -1,0 +1,153 @@
+<?php
+
+/*
+ * These will not be analysed as determining runtime value of variables, constants and function
+ * calls is not supported.
+ */
+$excluded = [
+    $var                        => 'excluded',
+    MY_CONSTANT                 => 'excluded',
+    PHP_INT_MAX                 => 'excluded',
+    str_replace('.', '', '1.1') => 'excluded',
+    self::CONSTANT              => 'excluded',
+    $obj->get_key()             => 'excluded',
+    $obj->prop                  => 'excluded',
+    "my $var text"              => 'excluded',
+    <<<EOD
+my $var text
+EOD
+                                => 'excluded',
+    $var['key']{1}              => 'excluded',
+];
+
+/*
+ * Let's find some duplicates.
+ */
+
+$emptyStringKey = array(
+    ''             => 'empty',
+    // All below will error.
+    null           => 'null',
+    (string) false => 'false',
+);
+
+$everythingZero = [
+    '0',
+    // All below will error.
+    0                => 'a',
+    0.0              => 'b',
+    '0'              => 'c',
+    0b0              => 'd',
+    0x0              => 'e',
+    00               => 'f',
+    false            => 'g',
+    0.4              => 'h',
+    -0.8             => 'i',
+    0e0              => 'j',
+    0_0              => 'k',
+    -1 + 1           => 'l',
+    3 * 0            => 'm',
+    00.00            => 'n',
+    (int) 'nothing'  => 'o',
+    15 > 200         => 'p',
+    "0"              => 'q',
+    0.               => 'r',
+    .0               => 's',
+    (true) ? 0 : 1   => 't',
+    ! true           => 'u',
+];
+
+$everythingOne = [
+    '0',
+    '1',
+    // All below will error.
+    1                => 'a',
+    1.1              => 'b',
+    '1'              => 'c',
+    0b1              => 'd',
+    0x1              => 'e',
+    01               => 'f',
+    true             => 'g',
+    1.2              => 'h',
+    1e0              => 'i',
+    0_1              => 'j',
+    -1 + 2           => 'k',
+    3 * 0.5          => 'l',
+    01.00            => 'm',
+    (int) '1 penny'  => 'n',
+    15 < 200         => 'o',
+    "1"              => 'p',
+    1.               => 'q',
+    001.             => 'r',
+    (true) ? 1 : 0   => 's',
+    ! false          => 't',
+    (string) true    => 'u',
+];
+
+$everythingEleven = [
+    11               => 'a',
+    // All below will error.
+    11.0             => 'b',
+    '11'             => 'c',
+    0b1011           => 'd',
+    0Xb              => 'e',
+    013              => 'f',
+    11.8             => 'g',
+    1.1e1            => 'h',
+    1_1              => 'i',
+    0_13             => 'j',
+    -1 + 12          => 'k',
+    22 / 2           => 'l',
+    0011.0011        => 'm',
+    (int) '11 lane'  => 'n',
+    "11"             => 'o',
+    11.              => 'p',
+    35 % 12          => 'q',
+];
+
+$textualStringKeyVariations = [
+    'abc'      => 1,
+    'def'      => 2,
+    'ghi'      => 3,
+    // All below will error.
+    'ab' . 'c' => 4, // Error.
+    <<<EOT
+def
+EOT
+               => 5, // Error.
+    <<< 'NOW'
+ghi
+NOW
+               => 6, // Error.
+    "abc"      => 7, // Error.
+];
+
+$testKeepingTrackOfHighestIntKey = array(
+    ''         => 'empty',
+    'a',                  // Int 0
+    'b',                  // Int 1
+    1          => 'c',    // Int 1 - Error.
+    5          => 'd',    // Int 5
+    'e',                  // Int 6
+    6          => 'f',    // Int 6 - Error.
+    false      => 'g',    // Int 0 - Error.
+    true       => 'h',    // Int 1 - Error.
+    1.1        => 'i',    // Int 1 - Error.
+    6.5        => 'j',    // Int 6 - Error.
+    05         => 'k',    // Int 5 - Error.
+    0_6        => 'l',    // Int 6 - Error. PHP 7.4 octal numeric literal.
+    0x1        => 'm',    // Int 1 - Error.
+    0b0        => 'n',    // Int 0 - Error.
+    null       => 'o',    // Empty string - Error.
+    02.6e7     => 'p',    // Int 26000000
+    '96'       => 'q',    // Int 96
+    'r',                  // Int 26000001
+    '26000001' => 's',    // Int 26000001 - Error.
+    '96.3'     => 't',    // String '96.3'
+    1 + 0      => 'u',    // Int 1 - Error.
+    1.1 - 0.5  => 'v',    // Int 0 - Error.
+    -1         => 'w',    // Int -1
+    'x',                  // Int 26000002
+    '9' . '6'  => 'y',    // Int 96 - Error.
+    '1.'       => 'z',    // String '1.'
+);

--- a/Universal/Tests/Arrays/DuplicateArrayKeyUnitTest.php
+++ b/Universal/Tests/Arrays/DuplicateArrayKeyUnitTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\Arrays;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the DuplicateArrayKey sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\Arrays\DuplicateArrayKeySniff
+ *
+ * @since 1.0.0
+ */
+class DuplicateArrayKeyUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getErrorList()
+    {
+        return [
+            30  => 1,
+            31  => 1,
+            37  => 1,
+            38  => 1,
+            39  => 1,
+            40  => 1,
+            41  => 1,
+            42  => 1,
+            43  => 1,
+            44  => 1,
+            45  => 1,
+            46  => 1,
+            47  => 1,
+            48  => 1,
+            49  => 1,
+            50  => 1,
+            51  => 1,
+            52  => 1,
+            53  => 1,
+            54  => 1,
+            55  => 1,
+            56  => 1,
+            57  => 1,
+            64  => 1,
+            65  => 1,
+            66  => 1,
+            67  => 1,
+            68  => 1,
+            69  => 1,
+            70  => 1,
+            71  => 1,
+            72  => 1,
+            73  => 1,
+            74  => 1,
+            75  => 1,
+            76  => 1,
+            77  => 1,
+            78  => 1,
+            79  => 1,
+            80  => 1,
+            81  => 1,
+            82  => 1,
+            83  => 1,
+            84  => 1,
+            90  => 1,
+            91  => 1,
+            92  => 1,
+            93  => 1,
+            94  => 1,
+            95  => 1,
+            96  => 1,
+            97  => 1,
+            98  => 1,
+            99  => 1,
+            100 => 1,
+            101 => 1,
+            102 => 1,
+            103 => 1,
+            104 => 1,
+            105 => 1,
+            113 => 1,
+            114 => 1,
+            118 => 1,
+            122 => 1,
+            129 => 1,
+            132 => 1,
+            133 => 1,
+            134 => 1,
+            135 => 1,
+            136 => 1,
+            137 => 1,
+            138 => 1,
+            139 => 1,
+            140 => 1,
+            141 => 1,
+            145 => 1,
+            147 => 1,
+            148 => 1,
+            151 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array <int line number> => <int number of warnings>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Best practice sniff: detects duplicate array keys in array declarations.

Includes unit tests.
Includes documentation.