### PR TITLE
DuplicateArrayKey: improve error message

### DIFF
--- a/Universal/Sniffs/Arrays/DuplicateArrayKeySniff.php
+++ b/Universal/Sniffs/Arrays/DuplicateArrayKeySniff.php
@@ -109,7 +109,7 @@ class DuplicateArrayKeySniff extends AbstractArrayDeclarationSniff
 
             $phpcsFile->addError(
                 'Duplicate array key found. The value will be overwritten.'
-                    . ' The %s array key "%s" was first seen for array item %d on line %d',
+                    . ' The %s array key "%s" was first seen on line %d',
                 $firstNonEmpty,
                 'Found',
                 $data


### PR DESCRIPTION
The item nr doesn't really add value and can be confusing.