### PR TITLE
IfElseDeclaration: respect tab indentation

### DIFF
--- a/Universal/Sniffs/ControlStructures/IfElseDeclarationSniff.php
+++ b/Universal/Sniffs/ControlStructures/IfElseDeclarationSniff.php
@@ -134,6 +134,11 @@ class IfElseDeclarationSniff implements Sniff
 
             if ($tokens[$firstOnIndentLine]['code'] === \T_WHITESPACE) {
                 $indent = $tokens[$firstOnIndentLine]['content'];
+
+                // If tabs were replaced, use the original content.
+                if (isset($tokens[$firstOnIndentLine]['orig_content']) === true) {
+                    $indent = $tokens[$firstOnIndentLine]['orig_content'];
+                }
             }
         }
 

--- a/Universal/Tests/ControlStructures/IfElseDeclarationUnitTest.inc
+++ b/Universal/Tests/ControlStructures/IfElseDeclarationUnitTest.inc
@@ -130,6 +130,13 @@ if ( true ) {
     // Test fixer with single-line control structure.
     if ( $a === 1 ) { echo $a; } elseif ( $a === 2 ) { echo $b; } else { echo $c; } // Error x 2.
 
+	// Test fixer with TAB indentation.
+	if ( true ) {
+		// Code.
+	} else { // Error.
+		// Code.
+	}
+
 // Live coding.
 // Intentional parse error. This test has to be the last in the file.
     if ($a) {

--- a/Universal/Tests/ControlStructures/IfElseDeclarationUnitTest.inc.fixed
+++ b/Universal/Tests/ControlStructures/IfElseDeclarationUnitTest.inc.fixed
@@ -142,6 +142,14 @@ else { // Error.
     elseif ( $a === 2 ) { echo $b; }
     else { echo $c; } // Error x 2.
 
+	// Test fixer with TAB indentation.
+	if ( true ) {
+		// Code.
+	}
+	else { // Error.
+		// Code.
+	}
+
 // Live coding.
 // Intentional parse error. This test has to be the last in the file.
     if ($a) {

--- a/Universal/Tests/ControlStructures/IfElseDeclarationUnitTest.php
+++ b/Universal/Tests/ControlStructures/IfElseDeclarationUnitTest.php
@@ -42,6 +42,7 @@ class IfElseDeclarationUnitTest extends AbstractSniffUnitTest
             119 => 1,
             126 => 1,
             131 => 2,
+            136 => 1,
         ];
     }
 


### PR DESCRIPTION
If tabs were replaced in the file on which the sniff was used, use the original content to make sure the inserted indentation will be in tabs.

Includes unit test.