### PR TITLE
Composer: add PHPCSDevCS dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ jobs:
         - composer validate --no-check-all --strict
 
         # Check the code style of the code base.
-        - composer checkcs
+        - composer travis-checkcs
 
         # Validate the xml files.
         # @link http://xmlsoft.org/xmllint.html

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require-dev" : {
         "jakub-onderka/php-parallel-lint": "^1.0",
         "jakub-onderka/php-console-highlighter": "^0.4",
-        "phpcsstandards/phpcsdevtools": "^1.0 || dev-develop",
+        "phpcsstandards/phpcsdevtools": "^1.0",
         "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0"
     },
     "minimum-stability": "dev",
@@ -40,11 +40,25 @@
         "lint": [
             "@php ./vendor/jakub-onderka/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
         ],
+        "install-devcs": [
+            "composer require --dev phpcsstandards/phpcsdevcs:\"^1.0\" --no-suggest"
+        ],
+        "remove-devcs": [
+            "composer remove --dev phpcsstandards/phpcsdevcs"
+        ],
         "checkcs": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
+            "@install-devcs",
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
+            "@remove-devcs"
         ],
         "fixcs": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
+            "@install-devcs",
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf",
+            "@remove-devcs"
+        ],
+        "travis-checkcs": [
+            "@install-devcs",
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
         ],
         "check-complete": [
             "@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./NormalizedArrays ./Universal"


### PR DESCRIPTION
The `PHPCSDev` ruleset has been split off from PHPCSDevTools to its own package.

The new `PHPCSDevCS` package has a minimum PHPCS requirement of PHPCS 3.5.0 (this was previously also the case, but not enforced).
To prevent issues with Composer refusing to install a PHPCS version below 3.5.0, the dependency has not been added to `require-dev`, but instead is pulled in via a `composer require` in a composer script.

Also: `PHPCSDevTools` 1.0.0 has been released :tada:

Refs:
* https://github.com/PHPCSStandards/PHPCSDevCS
* PHPCSStandards/PHPCSDevTools#29