### PR TITLE
New `Universal.ControlStructures.DisallowAlternativeSyntax` sniff

### DIFF
--- a/Universal/Docs/ControlStructures/DisallowAlternativeSyntaxStandard.xml
+++ b/Universal/Docs/ControlStructures/DisallowAlternativeSyntaxStandard.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<documentation title="Disallow Alternative Control Structure Syntax">
+    <standard>
+    <![CDATA[
+    The use of the alternative syntax for control structures is not allowed.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: using curly brace syntax for control structures.">
+        <![CDATA[
+if ($foo) <em>{</em>
+    $var = 1;
+<em>}</em>
+
+while (++$i < 10) <em>{</em>
+    echo $i;
+<em>}</em>
+        ]]>
+        </code>
+        <code title="Invalid: using the alternative syntax for control structures.">
+        <![CDATA[
+if ($foo) <em>:</em>
+    $var = 1;
+<em>endif;</em>
+
+while (++$i < 10)<em>:</em>
+    echo $i;
+<em>endwhile;</em>
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/ControlStructures/DisallowAlternativeSyntaxSniff.php
+++ b/Universal/Sniffs/ControlStructures/DisallowAlternativeSyntaxSniff.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\ControlStructures;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\ControlStructures;
+
+/**
+ * Forbid the use of the alternative syntax for control structures.
+ *
+ * @since 1.0.0
+ */
+class DisallowAlternativeSyntaxSniff implements Sniff
+{
+
+    /**
+     * Whether to allow the alternative syntax when it is wrapped around
+     * inline HTML, as is often seen in views.
+     *
+     * @var bool
+     */
+    public $allowWithInlineHTML = false;
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [
+            \T_IF,
+            \T_ELSE,
+            \T_ELSEIF,
+            \T_FOR,
+            \T_FOREACH,
+            \T_SWITCH,
+            \T_WHILE,
+            \T_DECLARE,
+        ];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        /*
+         * Deal with `else if`.
+         */
+        if ($tokens[$stackPtr]['code'] === \T_ELSE
+            && isset($tokens[$stackPtr]['scope_opener']) === false
+            && ControlStructures::isElseIf($phpcsFile, $stackPtr) === true
+        ) {
+            // This is an `else if` - this will be dealt with on the `if` token.
+            return;
+        }
+
+        /*
+         * Ignore control structures without body.
+         */
+        if (ControlStructures::hasBody($phpcsFile, $stackPtr) === false) {
+            return;
+        }
+
+        /*
+         * Deal with declare. Declare with alternative syntax does not get the scope opener/closer
+         * assigned in the tokens array prior to PHPCS 3.5.4, so let's set those ourselves.
+         *
+         * @link https://github.com/squizlabs/PHP_CodeSniffer/pull/2843
+         */
+        if ($tokens[$stackPtr]['code'] === \T_DECLARE && isset($tokens[$stackPtr]['scope_opener']) === false) {
+            $declareOpenClose = ControlStructures::getDeclareScopeOpenClose($phpcsFile, $stackPtr);
+            if ($declareOpenClose !== false) {
+                // Overrule the scope indexes in our local copy of the $tokens array.
+                $tokens[$stackPtr]['scope_opener'] = $declareOpenClose['opener'];
+                $tokens[$stackPtr]['scope_closer'] = $declareOpenClose['closer'];
+            }
+        }
+
+        /*
+         * Now check if the control structure uses alternative syntax.
+         */
+        if (isset($tokens[$stackPtr]['scope_opener'], $tokens[$stackPtr]['scope_closer']) === false) {
+            // No scope opener found: inline control structure or parse error.
+            $phpcsFile->recordMetric($stackPtr, 'Control structure style', 'inline');
+            return;
+        }
+
+        $opener = $tokens[$stackPtr]['scope_opener'];
+        $closer = $tokens[$stackPtr]['scope_closer'];
+
+        if ($tokens[$opener]['code'] !== \T_COLON) {
+            // Curly brace syntax (not our concern).
+            $phpcsFile->recordMetric($stackPtr, 'Control structure style', 'curly braces');
+            return;
+        }
+
+        $hasInlineHTML = $phpcsFile->findNext(
+            \T_INLINE_HTML,
+            $opener,
+            $closer
+        );
+
+        if ($hasInlineHTML !== false) {
+            $phpcsFile->recordMetric($stackPtr, 'Control structure style', 'alternative syntax with inline HTML');
+        } else {
+            $phpcsFile->recordMetric($stackPtr, 'Control structure style', 'alternative syntax');
+        }
+
+        if ($this->allowWithInlineHTML === true) {
+            return;
+        }
+
+        $error = 'Using control structures with the alternative syntax - %1$s(): ... end%1$s; - is not allowed.';
+        $code  = 'Found' . \ucfirst($tokens[$stackPtr]['content']);
+        $data  = [$tokens[$stackPtr]['content']];
+        if ($tokens[$stackPtr]['code'] === \T_ELSEIF || $tokens[$stackPtr]['code'] === \T_ELSE) {
+            $data = ['if'];
+        }
+
+        if ($hasInlineHTML !== false) {
+            $code .= 'WithInlineHTML';
+        }
+
+        $fix = $phpcsFile->addFixableError($error, $tokens[$stackPtr]['scope_opener'], $code, $data);
+        if ($fix === false) {
+            return;
+        }
+
+        /*
+         * Fix it.
+         */
+        $phpcsFile->fixer->beginChangeset();
+        $phpcsFile->fixer->replaceToken($opener, '{');
+
+        if (isset(Collections::$alternativeControlStructureSyntaxCloserTokens[$tokens[$closer]['code']]) === true) {
+            $phpcsFile->fixer->replaceToken($closer, '}');
+
+            $semicolon = $phpcsFile->findNext(Tokens::$emptyTokens, ($closer + 1), null, true);
+            if ($semicolon !== false && $tokens[$semicolon]['code'] === \T_SEMICOLON) {
+                $phpcsFile->fixer->replaceToken($semicolon, '');
+            }
+        } else {
+            // This must be an if/else using alternative syntax. The closer will be the next control structure keyword.
+            $phpcsFile->fixer->addContentBefore($closer, '} ');
+        }
+
+        $phpcsFile->fixer->endChangeset();
+    }
+}

--- a/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.inc
+++ b/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.inc
@@ -1,0 +1,184 @@
+<?php
+
+/*
+ * Control structures without braces. Ignore.
+ */
+if (true)
+    function_call($a);
+elseif (false)
+    function_call($a);
+else
+    function_call($a);
+
+for ($i = 1; $i <= 10; $i++)
+    echo $i;
+
+foreach ($a as $k => $v)
+    echo "Key: $k; Current value of \$a: $v.\n";
+
+while (++$i <= 10)
+    echo $i;
+
+// Single line for.
+for ($i = 1, $j = 0; $i <= 10; $j += $i, print $i, $i++);
+
+// Single line while.
+while (++$i <= 10) /*comment*/ ;
+
+// Single line declare.
+declare(ticks=1);
+
+/*
+ * Control structures using curly braces. Ignore.
+ */
+if ( true ) {
+    // Code.
+} elseif (false) {
+    // Code.
+}
+else if (false) {
+    // Code.
+} else {
+    // Code.
+}
+
+for ($i = 1; $i <= 10; $i++) {
+    echo $i;
+}
+
+foreach ($a as $k => $v) {
+    echo "Key: $k; Current value of \$a: $v.\n";
+}
+
+while (++$i <= 10) {
+    echo $i;
+}
+
+switch ($foo) {
+    case 1:
+        echo '<div>something</div>';
+        break;
+    default;
+        echo '<div>something</div>';
+        break;
+}
+
+declare(ticks=1) {
+    echo 'ticking';
+}
+
+/*
+ * Alternative control structure syntax.
+ */
+if (true):
+    // Code.
+elseif (false):
+    // Code.
+else:
+    // Code.
+endif;
+
+for ($i = 1; $i <= 10; $i++)
+    :
+    echo $i;
+endfor;
+
+foreach ($a as $k => $v):
+    echo "Key: $k; Current value of \$a: $v.\n";
+endforeach;
+
+while (++$i <= 10):
+    echo $i;
+endwhile /*comment*/ ;
+
+switch ($foo) :
+    case 1:
+        echo '<div>something</div>';
+        break;
+    default;
+        echo '<div>something</div>';
+        break;
+endswitch;
+
+declare (ticks = 1):
+    echo 'ticking';
+enddeclare;
+
+/*
+ * Alternative control structure syntax in views/within inline HTML.
+ */
+?>
+<?php if ($a == 5): ?>
+A is equal to 5
+<?php elseif ($a == 7): ?>
+A is equal to 7
+<?php else: ?>
+A is something else
+<?php endif; ?>
+
+<?php for ($i = 1; $i <= 10; $i++) : ?>
+    <div id="<?= $i ?>">something</div>
+<?php endfor; ?>
+
+<?php foreach ($a as $k => $v): ?>
+    <p>Key: <?= $k ?>; Current value of $a: <?= $v ?></p>
+<?php endforeach; ?>
+
+<?php while (++$i <= 10): ?>
+    <div id="<?php $i ?>">something</div>
+<?php endwhile ?>
+
+<?php switch ($foo): ?>
+<?php case 1: ?>
+    <div>something</div>
+<?php default; ?>
+    <div>something</div>
+<?php endswitch; ?>
+
+<?php declare (ticks = 1): ?>
+    ticking
+<?php enddeclare; ?>
+
+<?php
+// phpcs:set Universal.ControlStructures.DisallowAlternativeSyntax allowWithInlineHTML true
+?>
+<?php if ($a == 5): ?>
+A is equal to 5
+<?php elseif ($a == 7): ?>
+A is equal to 7
+<?php else: ?>
+A is something else
+<?php endif; ?>
+
+<?php for ($i = 1; $i <= 10; $i++) : ?>
+    <div id="<?= $i ?>">something</div>
+<?php endfor; ?>
+
+<?php foreach ($a as $k => $v): ?>
+    <p>Key: <?= $k ?>; Current value of $a: <?= $v ?></p>
+<?php endforeach; ?>
+
+<?php while (++$i <= 10): ?>
+    <div id="<?php $i ?>">something</div>
+<?php endwhile ?>
+
+<?php switch ($foo): ?>
+<?php case 1: ?>
+    <div>something</div>
+<?php default; ?>
+    <div>something</div>
+<?php endswitch; ?>
+
+<?php declare (ticks = 1): ?>
+    ticking
+<?php enddeclare; ?>
+
+<?php
+// phpcs:set Universal.ControlStructures.DisallowAlternativeSyntax allowWithInlineHTML false
+
+// Live coding.
+// Intentional parse error. This test has to be the last in the file.
+    if ($a) {
+        // Code.
+    } else {
+        // Code.

--- a/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.inc.fixed
+++ b/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.inc.fixed
@@ -1,0 +1,184 @@
+<?php
+
+/*
+ * Control structures without braces. Ignore.
+ */
+if (true)
+    function_call($a);
+elseif (false)
+    function_call($a);
+else
+    function_call($a);
+
+for ($i = 1; $i <= 10; $i++)
+    echo $i;
+
+foreach ($a as $k => $v)
+    echo "Key: $k; Current value of \$a: $v.\n";
+
+while (++$i <= 10)
+    echo $i;
+
+// Single line for.
+for ($i = 1, $j = 0; $i <= 10; $j += $i, print $i, $i++);
+
+// Single line while.
+while (++$i <= 10) /*comment*/ ;
+
+// Single line declare.
+declare(ticks=1);
+
+/*
+ * Control structures using curly braces. Ignore.
+ */
+if ( true ) {
+    // Code.
+} elseif (false) {
+    // Code.
+}
+else if (false) {
+    // Code.
+} else {
+    // Code.
+}
+
+for ($i = 1; $i <= 10; $i++) {
+    echo $i;
+}
+
+foreach ($a as $k => $v) {
+    echo "Key: $k; Current value of \$a: $v.\n";
+}
+
+while (++$i <= 10) {
+    echo $i;
+}
+
+switch ($foo) {
+    case 1:
+        echo '<div>something</div>';
+        break;
+    default;
+        echo '<div>something</div>';
+        break;
+}
+
+declare(ticks=1) {
+    echo 'ticking';
+}
+
+/*
+ * Alternative control structure syntax.
+ */
+if (true){
+    // Code.
+} elseif (false){
+    // Code.
+} else{
+    // Code.
+}
+
+for ($i = 1; $i <= 10; $i++)
+    {
+    echo $i;
+}
+
+foreach ($a as $k => $v){
+    echo "Key: $k; Current value of \$a: $v.\n";
+}
+
+while (++$i <= 10){
+    echo $i;
+} /*comment*/ 
+
+switch ($foo) {
+    case 1:
+        echo '<div>something</div>';
+        break;
+    default;
+        echo '<div>something</div>';
+        break;
+}
+
+declare (ticks = 1){
+    echo 'ticking';
+}
+
+/*
+ * Alternative control structure syntax in views/within inline HTML.
+ */
+?>
+<?php if ($a == 5){ ?>
+A is equal to 5
+<?php } elseif ($a == 7){ ?>
+A is equal to 7
+<?php } else{ ?>
+A is something else
+<?php } ?>
+
+<?php for ($i = 1; $i <= 10; $i++) { ?>
+    <div id="<?= $i ?>">something</div>
+<?php } ?>
+
+<?php foreach ($a as $k => $v){ ?>
+    <p>Key: <?= $k ?>; Current value of $a: <?= $v ?></p>
+<?php } ?>
+
+<?php while (++$i <= 10){ ?>
+    <div id="<?php $i ?>">something</div>
+<?php } ?>
+
+<?php switch ($foo){ ?>
+<?php case 1: ?>
+    <div>something</div>
+<?php default; ?>
+    <div>something</div>
+<?php } ?>
+
+<?php declare (ticks = 1){ ?>
+    ticking
+<?php } ?>
+
+<?php
+// phpcs:set Universal.ControlStructures.DisallowAlternativeSyntax allowWithInlineHTML true
+?>
+<?php if ($a == 5): ?>
+A is equal to 5
+<?php elseif ($a == 7): ?>
+A is equal to 7
+<?php else: ?>
+A is something else
+<?php endif; ?>
+
+<?php for ($i = 1; $i <= 10; $i++) : ?>
+    <div id="<?= $i ?>">something</div>
+<?php endfor; ?>
+
+<?php foreach ($a as $k => $v): ?>
+    <p>Key: <?= $k ?>; Current value of $a: <?= $v ?></p>
+<?php endforeach; ?>
+
+<?php while (++$i <= 10): ?>
+    <div id="<?php $i ?>">something</div>
+<?php endwhile ?>
+
+<?php switch ($foo): ?>
+<?php case 1: ?>
+    <div>something</div>
+<?php default; ?>
+    <div>something</div>
+<?php endswitch; ?>
+
+<?php declare (ticks = 1): ?>
+    ticking
+<?php enddeclare; ?>
+
+<?php
+// phpcs:set Universal.ControlStructures.DisallowAlternativeSyntax allowWithInlineHTML false
+
+// Live coding.
+// Intentional parse error. This test has to be the last in the file.
+    if ($a) {
+        // Code.
+    } else {
+        // Code.

--- a/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.php
+++ b/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\ControlStructures;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the DisallowAlternativeSyntax sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\ControlStructures\DisallowAlternativeSyntaxSniff
+ *
+ * @since 1.0.0
+ */
+class DisallowAlternativeSyntaxUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getErrorList()
+    {
+        return [
+            73  => 1,
+            75  => 1,
+            77  => 1,
+            82  => 1,
+            86  => 1,
+            90  => 1,
+            94  => 1,
+            103 => 1,
+            111 => 1,
+            113 => 1,
+            115 => 1,
+            119 => 1,
+            123 => 1,
+            127 => 1,
+            131 => 1,
+            138 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array <int line number> => <int number of warnings>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
New sniff to disallow using the alternative syntax for control structures.

Notes:
* This sniff contains a public `allowWithInlineHTML` property to allow alternative syntax when inline HTML is used within the control structure. In all other cases, the use of the alternative syntax will still be disallowed.
* The sniff has modular error codes to allow for making exceptions based on specific control structures and/or specific control structures in combination with inline HTML.

Refs:
* https://www.php.net/manual/en/control-structures.alternative-syntax.php
* squizlabs/PHP_CodeSniffer#2842 - feature request by @jrchamp

Includes fixer.
Includes unit tests.
Includes documentation.
Includes metrics.