### PR TITLE
DisallowUseClass/Function/Const: make the error codes more modular.

### DIFF
--- a/Universal/Sniffs/UseStatements/DisallowUseClassSniff.php
+++ b/Universal/Sniffs/UseStatements/DisallowUseClassSniff.php
@@ -14,6 +14,7 @@ use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\Namespaces;
 use PHPCSUtils\Utils\UseStatements;
 
 /**
@@ -29,6 +30,42 @@ class DisallowUseClassSniff implements Sniff
 {
 
     /**
+     * Name of the "Use import source" metric.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const METRIC_NAME_SRC = 'Use import statement source for class/interface/trait';
+
+    /**
+     * Name of the "Use import with/without alias" metric.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const METRIC_NAME_ALIAS = 'Use import statement for class/interface/trait';
+
+    /**
+     * Keep track of which file is being scanned.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    private $currentFile = '';
+
+    /**
+     * Keep track of the current namespace.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    private $currentNamespace = '';
+
+    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @since 1.0.0
@@ -37,7 +74,10 @@ class DisallowUseClassSniff implements Sniff
      */
     public function register()
     {
-        return [\T_USE];
+        return [
+            \T_USE,
+            \T_NAMESPACE,
+        ];
     }
 
     /**
@@ -53,6 +93,26 @@ class DisallowUseClassSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
+        $file = $phpcsFile->getFilename();
+        if ($file !== $this->currentFile) {
+            // Reset the current namespace for each new file.
+            $this->currentFile      = $file;
+            $this->currentNamespace = '';
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        // Get the name of the current namespace.
+        if ($tokens[$stackPtr]['code'] === \T_NAMESPACE) {
+            $namespaceName = Namespaces::getDeclaredName($phpcsFile, $stackPtr);
+            if ($namespaceName !== false) {
+                $this->currentNamespace = $namespaceName;
+            }
+
+            return;
+        }
+
+        // Ok, so this is a T_USE token.
         try {
             $statements = UseStatements::splitImportUseStatement($phpcsFile, $stackPtr);
         } catch (RuntimeException $e) {
@@ -65,7 +125,6 @@ class DisallowUseClassSniff implements Sniff
             return;
         }
 
-        $tokens         = $phpcsFile->getTokens();
         $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($stackPtr + 1));
 
         foreach ($statements['name'] as $alias => $fullName) {
@@ -79,29 +138,74 @@ class DisallowUseClassSniff implements Sniff
 
                 $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($reportPtr + 1), $endOfStatement, true);
                 if ($next !== false && $tokens[$next]['code'] === \T_NS_SEPARATOR) {
-                    // Namespace level with same name. Continue searching
+                    // Namespace level with same name. Continue searching.
                     continue;
                 }
 
                 break;
             } while (true);
 
-            $error  = 'Use import statements for classes/traits/interfaces are not allowed.';
-            $error .= ' Found import statement for: "%s"';
-            $data   = [$fullName, $alias];
+            /*
+             * Build the error message and code.
+             *
+             * Check whether this is a non-namespaced (global) import and check whether this is an
+             * import from within the same namespace.
+             *
+             * Takes incorrect use statements with leading backslash into account.
+             * Takes case-INsensitivity of namespaces names into account.
+             *
+             * The "GlobalNamespace" error code takes precedence over the "SameNamespace" error code
+             * in case this is a non-namespaced file.
+             */
 
-            $offsetFromEnd = (\strlen($alias) + 1);
-            if (\substr($fullName, -$offsetFromEnd) === '\\' . $alias) {
-                $phpcsFile->recordMetric($reportPtr, 'Use import statement for class/interface/trait', 'without alias');
+            $error     = 'Use import statements for class/interface/trait%s are not allowed.';
+            $error    .= ' Found import statement for: "%s"';
+            $errorCode = 'Found';
+            $data      = [
+                '',
+                $fullName,
+            ];
 
-                $phpcsFile->addError($error, $reportPtr, 'FoundWithoutAlias', $data);
-                continue;
+            $globalNamespace = false;
+            $sameNamespace   = false;
+            if (\strpos($fullName, '\\', 1) === false) {
+                $globalNamespace = true;
+                $errorCode       = 'FromGlobalNamespace';
+                $data[0]         = ' from the global namespace';
+
+                $phpcsFile->recordMetric($reportPtr, self::METRIC_NAME_SRC, 'global namespace');
+            } elseif ($this->currentNamespace !== ''
+                && (\stripos($fullName, $this->currentNamespace . '\\') === 0
+                    || \stripos($fullName, '\\' . $this->currentNamespace . '\\') === 0)
+            ) {
+                $sameNamespace = true;
+                $errorCode     = 'FromSameNamespace';
+                $data[0]       = ' from the same namespace';
+
+                $phpcsFile->recordMetric($reportPtr, self::METRIC_NAME_SRC, 'same namespace');
+            } else {
+                $phpcsFile->recordMetric($reportPtr, self::METRIC_NAME_SRC, 'different namespace');
             }
 
-            $phpcsFile->recordMetric($reportPtr, 'Use import statement for class/interface/trait', 'with alias');
+            $hasAlias = false;
+            $lastLeaf = \strtolower(\substr($fullName, -(\strlen($alias) + 1)));
+            $aliasLC  = \strtolower($alias);
+            if ($lastLeaf !== $aliasLC && $lastLeaf !== '\\' . $aliasLC) {
+                $hasAlias   = true;
+                $error     .= ' with alias: "%s"';
+                $errorCode .= 'WithAlias';
+                $data[]     = $alias;
 
-            $error .= ' with alias: "%s"';
-            $phpcsFile->addError($error, $reportPtr, 'FoundWithAlias', $data);
+                $phpcsFile->recordMetric($reportPtr, self::METRIC_NAME_ALIAS, 'with alias');
+            } else {
+                $phpcsFile->recordMetric($reportPtr, self::METRIC_NAME_ALIAS, 'without alias');
+            }
+
+            if ($errorCode === 'Found') {
+                $errorCode = 'FoundWithoutAlias';
+            }
+
+            $phpcsFile->addError($error, $reportPtr, $errorCode, $data);
         }
     }
 }

--- a/Universal/Sniffs/UseStatements/DisallowUseConstSniff.php
+++ b/Universal/Sniffs/UseStatements/DisallowUseConstSniff.php
@@ -14,6 +14,7 @@ use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\Namespaces;
 use PHPCSUtils\Utils\UseStatements;
 
 /**
@@ -29,6 +30,42 @@ class DisallowUseConstSniff implements Sniff
 {
 
     /**
+     * Name of the "Use import source" metric.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const METRIC_NAME_SRC = 'Use import statement source for constant';
+
+    /**
+     * Name of the "Use import with/without alias" metric.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const METRIC_NAME_ALIAS = 'Use import statement for constant';
+
+    /**
+     * Keep track of which file is being scanned.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    private $currentFile = '';
+
+    /**
+     * Keep track of the current namespace.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    private $currentNamespace = '';
+
+    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @since 1.0.0
@@ -37,7 +74,10 @@ class DisallowUseConstSniff implements Sniff
      */
     public function register()
     {
-        return [\T_USE];
+        return [
+            \T_USE,
+            \T_NAMESPACE,
+        ];
     }
 
     /**
@@ -53,6 +93,26 @@ class DisallowUseConstSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
+        $file = $phpcsFile->getFilename();
+        if ($file !== $this->currentFile) {
+            // Reset the current namespace for each new file.
+            $this->currentFile      = $file;
+            $this->currentNamespace = '';
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        // Get the name of the current namespace.
+        if ($tokens[$stackPtr]['code'] === \T_NAMESPACE) {
+            $namespaceName = Namespaces::getDeclaredName($phpcsFile, $stackPtr);
+            if ($namespaceName !== false) {
+                $this->currentNamespace = $namespaceName;
+            }
+
+            return;
+        }
+
+        // Ok, so this is a T_USE token.
         try {
             $statements = UseStatements::splitImportUseStatement($phpcsFile, $stackPtr);
         } catch (RuntimeException $e) {
@@ -65,7 +125,6 @@ class DisallowUseConstSniff implements Sniff
             return;
         }
 
-        $tokens         = $phpcsFile->getTokens();
         $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($stackPtr + 1));
 
         foreach ($statements['const'] as $alias => $fullName) {
@@ -79,29 +138,74 @@ class DisallowUseConstSniff implements Sniff
 
                 $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($reportPtr + 1), $endOfStatement, true);
                 if ($next !== false && $tokens[$next]['code'] === \T_NS_SEPARATOR) {
-                    // Namespace level with same name. Continue searching
+                    // Namespace level with same name. Continue searching.
                     continue;
                 }
 
                 break;
             } while (true);
 
-            $error  = 'Use import statements for constants are not allowed.';
-            $error .= ' Found import statement for: "%s"';
-            $data   = [$fullName, $alias];
+            /*
+             * Build the error message and code.
+             *
+             * Check whether this is a non-namespaced (global) import and check whether this is an
+             * import from within the same namespace.
+             *
+             * Takes incorrect use statements with leading backslash into account.
+             * Takes case-INsensitivity of namespaces names into account.
+             *
+             * The "GlobalNamespace" error code takes precedence over the "SameNamespace" error code
+             * in case this is a non-namespaced file.
+             */
 
-            $offsetFromEnd = (\strlen($alias) + 1);
-            if (\substr($fullName, -$offsetFromEnd) === '\\' . $alias) {
-                $phpcsFile->recordMetric($reportPtr, 'Use import statement for constant', 'without alias');
+            $error     = 'Use import statements for constants%s are not allowed.';
+            $error    .= ' Found import statement for: "%s"';
+            $errorCode = 'Found';
+            $data      = [
+                '',
+                $fullName,
+            ];
 
-                $phpcsFile->addError($error, $reportPtr, 'FoundWithoutAlias', $data);
-                continue;
+            $globalNamespace = false;
+            $sameNamespace   = false;
+            if (\strpos($fullName, '\\', 1) === false) {
+                $globalNamespace = true;
+                $errorCode       = 'FromGlobalNamespace';
+                $data[0]         = ' from the global namespace';
+
+                $phpcsFile->recordMetric($reportPtr, self::METRIC_NAME_SRC, 'global namespace');
+            } elseif ($this->currentNamespace !== ''
+                && (\stripos($fullName, $this->currentNamespace . '\\') === 0
+                    || \stripos($fullName, '\\' . $this->currentNamespace . '\\') === 0)
+            ) {
+                $sameNamespace = true;
+                $errorCode     = 'FromSameNamespace';
+                $data[0]       = ' from the same namespace';
+
+                $phpcsFile->recordMetric($reportPtr, self::METRIC_NAME_SRC, 'same namespace');
+            } else {
+                $phpcsFile->recordMetric($reportPtr, self::METRIC_NAME_SRC, 'different namespace');
             }
 
-            $phpcsFile->recordMetric($reportPtr, 'Use import statement for constant', 'with alias');
+            $hasAlias = false;
+            $lastLeaf = \strtolower(\substr($fullName, -(\strlen($alias) + 1)));
+            $aliasLC  = \strtolower($alias);
+            if ($lastLeaf !== $aliasLC && $lastLeaf !== '\\' . $aliasLC) {
+                $hasAlias   = true;
+                $error     .= ' with alias: "%s"';
+                $errorCode .= 'WithAlias';
+                $data[]     = $alias;
 
-            $error .= ' with alias: "%s"';
-            $phpcsFile->addError($error, $reportPtr, 'FoundWithAlias', $data);
+                $phpcsFile->recordMetric($reportPtr, self::METRIC_NAME_ALIAS, 'with alias');
+            } else {
+                $phpcsFile->recordMetric($reportPtr, self::METRIC_NAME_ALIAS, 'without alias');
+            }
+
+            if ($errorCode === 'Found') {
+                $errorCode = 'FoundWithoutAlias';
+            }
+
+            $phpcsFile->addError($error, $reportPtr, $errorCode, $data);
         }
     }
 }

--- a/Universal/Tests/UseStatements/DisallowUseClassUnitTest.1.inc
+++ b/Universal/Tests/UseStatements/DisallowUseClassUnitTest.1.inc
@@ -10,7 +10,7 @@ use My\NS\SomeClass as OtherClass;
 
 use Vendor\Foo\ClassA as ClassABC,
     Vendor\Bar\InterfaceB,
-	Vendor\Bar\Bar, // Testing finding the correct line to report on.
+    Vendor\Bar\Bar, // Testing finding the correct line to report on.
     Vendor\Baz\ClassC;
 
 use some\namespacing\{
@@ -27,6 +27,13 @@ use Some\NS\{
     function SubLevel\AnotherName,
     AnotherLevel, // Error.
 };
+
+// Test handling of alias as part of the last leaf of the imported name, including case-insensitivity.
+// While aliasing to itself doesn't make much sense, the sniff should handle it correctly.
+use My\AwesomeClassA as classa;
+use My\AwesomeClassB as AweSomeclassB;
+use AwesomeClassC as someclassc; // Alias for global import.
+use AwesomeClassD as AWESOMECLASSD; // Alias for global import to same name.
 
 // Ignore as not import use.
 $closure = function() use($bar) {

--- a/Universal/Tests/UseStatements/DisallowUseClassUnitTest.2.inc
+++ b/Universal/Tests/UseStatements/DisallowUseClassUnitTest.2.inc
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * First namespace.
+ */
+namespace MyProject;
+
+// Same namespace.
+use MyProject\SomeClass;
+use \myproject\SomeOtherClass as OtherClass; // Test leading backslash tolerance & case-insensitivity.
+
+// Not the same namespace.
+use Vendor\MyProject\ClassABC,
+    MyProjectXYZ\ClassDEF;
+
+// Another namespace.
+use AnotherProject\Bar\Foo\InterfaceA,
+    AnotherProject\Foo\Bar\ClassXYZ as FooBar,
+    \AnotherProject\Foo\Bar\ClassKLM; // Test leading backslash tolerance.
+
+// Global namespace.
+use Reflection;
+
+
+/*
+ * Second namespace.
+ */
+namespace AnotherProject\Foo\Bar;
+
+// Another namespace. Test against bleed through from first namespace.
+use MyProject\SomeClass;
+use \MyProject\SomeOtherClass as OtherClass; // Test leading backslash tolerance.
+
+// Not the same namespace.
+use Vendor\MyProject\ClassABC;
+
+use AnotherProject\Bar\Foo\InterfaceA,
+    // Same namespace.
+    AnotherProject\Foo\Bar\ClassXYZ as FooBar,
+    \AnotHerProJect\foo\BAR\ClassKLM; // Test leading backslash tolerance & case-insensitivity.
+
+// Global namespace.
+use \ReflectionClass; // Test leading backslash tolerance.

--- a/Universal/Tests/UseStatements/DisallowUseClassUnitTest.3.inc
+++ b/Universal/Tests/UseStatements/DisallowUseClassUnitTest.3.inc
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * First (scoped) namespace.
+ */
+namespace MyProject {
+
+    // Same namespace.
+    use MyProject\SomeClass;
+    use \myproject\SomeOtherClass as OtherClass; // Test leading backslash tolerance & case-insensitivity.
+
+    // Not the same namespace.
+    use Vendor\MyProject\ClassABC,
+        MyProjectXYZ\ClassDEF;
+
+    // Another namespace.
+    use AnotherProject\Bar\Foo\InterfaceA,
+        AnotherProject\Foo\Bar\ClassXYZ as FooBar,
+        \AnotherProject\Foo\Bar\ClassKLM; // Test leading backslash tolerance.
+
+    // Global namespace.
+    use Reflection;
+}
+
+/*
+ * Second (scoped) namespace - no name.
+ */
+namespace {
+
+    // Another namespace. Test against bleed through from first namespace.
+    use MyProject\SomeClass;
+    use \MyProject\SomeOtherClass as OtherClass; // Test leading backslash tolerance.
+
+    // Not the same namespace.
+    use Vendor\MyProject\ClassABC;
+
+    use AnotherProject\Bar\Foo\InterfaceA as FooBar,
+        \AnotherProject\Foo\Bar\ClassKLM; // Test leading backslash tolerance.
+
+    // Global namespace.
+    use \ReflectionType; // Test leading backslash tolerance.
+}
+
+/*
+ * Third (scoped) namespace.
+ */
+namespace AnotherProject\Foo\Bar {
+
+    // Another namespace.
+    use MyProject\SomeClass;
+    use \MyProject\SomeOtherClass as OtherClass; // Test leading backslash tolerance.
+
+    // Not the same namespace.
+    use Vendor\MyProject\ClassABC;
+
+    use AnotherProject\Bar\Foo\InterfaceA,
+        // Same namespace.
+        AnotherProject\Foo\Bar\ClassXYZ as FooBar,
+        \AnotHerProJect\foo\BAR\ClassKLM; // Test leading backslash tolerance & case-insensitivity.
+
+    // Global namespace.
+    use \ReflectionClass; // Test leading backslash tolerance.
+}
+
+// Will throw an error as if it is still within the `AnotherProject` scoped namespace.
+// As this is a parse error anyway, as no code is allowed outside of the namespace brackets,
+// this is not something we should be concerned about.
+use AnotherProject\Foo\Bar\RandomClass;

--- a/Universal/Tests/UseStatements/DisallowUseClassUnitTest.4.inc
+++ b/Universal/Tests/UseStatements/DisallowUseClassUnitTest.4.inc
@@ -1,0 +1,6 @@
+<?php
+
+// Make sure there is no namespace bleed-through between files.
+
+// Same namespace as the last one used in the previous test case file.
+use AnotherProject\Foo\Bar\ClassXYZ as FooBar;

--- a/Universal/Tests/UseStatements/DisallowUseClassUnitTest.php
+++ b/Universal/Tests/UseStatements/DisallowUseClassUnitTest.php
@@ -15,6 +15,9 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the DisallowUseClass sniff.
  *
+ * {@internal The current tests are imprecise and not good enough as they don't test that
+ * the correct error code is being thrown, which is what some of the tests are about.}
+ *
  * @covers PHPCSExtra\Universal\Sniffs\UseStatements\DisallowUseClassSniff
  *
  * @since 1.0.0
@@ -25,23 +28,85 @@ class DisallowUseClassUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
+     * @param string $testFile The name of the file being tested.
+     *
      * @return array <int line number> => <int number of errors>
      */
-    public function getErrorList()
+    public function getErrorList($testFile = '')
     {
-        return [
-            8  => 1,
-            9  => 1,
-            11 => 1,
-            12 => 1,
-            13 => 1,
-            14 => 1,
-            17 => 1,
-            18 => 1,
-            19 => 1,
-            24 => 1,
-            28 => 1,
-        ];
+        switch ($testFile) {
+            case 'DisallowUseClassUnitTest.1.inc':
+                return [
+                    8  => 1,
+                    9  => 1, // WithAlias.
+                    11 => 1, // WithAlias.
+                    12 => 1,
+                    13 => 1,
+                    14 => 1,
+                    17 => 1,
+                    18 => 1,
+                    19 => 1, // WithAlias.
+                    24 => 1,
+                    28 => 1,
+                    33 => 1, // WithAlias.
+                    34 => 1,
+                    35 => 1, // GlobalNamespaceWithAlias.
+                    36 => 1, // GlobalNamespace. Note: alias same as name, so not counted as aliased.
+                ];
+
+            case 'DisallowUseClassUnitTest.2.inc':
+                return [
+                    9  => 1, // SameNamespace.
+                    10 => 1, // SameNamespaceWithAlias.
+                    13 => 1,
+                    14 => 1,
+                    17 => 1,
+                    18 => 1, // WithAlias.
+                    19 => 1,
+                    22 => 1, // GlobalNamespace.
+                    31 => 1,
+                    32 => 1, // WithAlias.
+                    35 => 1,
+                    37 => 1,
+                    39 => 1, // SameNamespaceWithAlias.
+                    40 => 1, // SameNamespace.
+                    43 => 1, // GlobalNamespace.
+                ];
+
+            case 'DisallowUseClassUnitTest.3.inc':
+                return [
+                    9  => 1, // SameNamespace.
+                    10 => 1, // SameNamespaceWithAlias.
+                    13 => 1,
+                    14 => 1,
+                    17 => 1,
+                    18 => 1, // WithAlias.
+                    19 => 1,
+                    22 => 1, // GlobalNamespace.
+                    31 => 1,
+                    32 => 1, // WithAlias.
+                    35 => 1,
+                    37 => 1, // WithAlias.
+                    38 => 1,
+                    41 => 1, // GlobalNamespace.
+                    50 => 1,
+                    51 => 1, // WithAlias.
+                    54 => 1,
+                    56 => 1,
+                    58 => 1, // SameNamespaceWithAlias.
+                    59 => 1, // SameNamespace.
+                    62 => 1, // GlobalNamespace.
+                    68 => 1, // SameNamespace. Note: well, not really, but parse error.
+                ];
+
+            case 'DisallowUseClassUnitTest.4.inc':
+                return [
+                    6 => 1,
+                ];
+
+            default:
+                return [];
+        }
     }
 
     /**

--- a/Universal/Tests/UseStatements/DisallowUseConstUnitTest.1.inc
+++ b/Universal/Tests/UseStatements/DisallowUseConstUnitTest.1.inc
@@ -25,6 +25,13 @@ use Some\NS\{
     AnotherLevel,
 };
 
+// Test handling of alias as part of the last leaf of the imported name, including case-insensitivity.
+// While aliasing to itself doesn't make much sense, the sniff should handle it correctly.
+use const My\PHP_MINOR_VERSION as Minor_version;
+use const My\PHP_MAJOR_VERSION as Php_Major_Version;
+use const PHP_VERSION_ID as version_id; // Alias for global import.
+use const PHP_VERSION as php_version; // Alias for global import to same name.
+
 // Ignore as not import use.
 $closure = function() use($bar) {
     return $bar;

--- a/Universal/Tests/UseStatements/DisallowUseConstUnitTest.2.inc
+++ b/Universal/Tests/UseStatements/DisallowUseConstUnitTest.2.inc
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * First namespace.
+ */
+namespace MyProject;
+
+// Same namespace.
+use CONST MyProject\MY_CONST;
+use const \MYProJect\YOUR_CONST as CONST_ALIAS; // Test leading backslash tolerance & case-insensitivity.
+
+// Not the same namespace.
+use const Vendor\MyProject\PIP;
+use const MyProjectXYZ\RATIO;
+
+// Another namespace.
+use const foo\math\PI,
+    \foo\math\GOLDEN_RATIO as MATH_GOLDEN; // Test leading backslash tolerance.
+
+// Global namespace.
+use const PHP_VERSION_ID;
+
+/*
+ * Second namespace.
+ */
+namespace foo\math;
+
+// Another namespace. Test against bleed through from first namespace.
+use CONST MyProject\MY_CONST;
+use const \MyProject\YOUR_CONST as CONST_ALIAS; // Test leading backslash tolerance.
+
+// Not the same namespace.
+use const Vendor\MyProject\PIP;
+
+// Same namespace.
+use const foo\math\PI,
+    \FOO\Math\GOLDEN_RATIO as MATH_GOLDEN; // Test leading backslash tolerance & case-insensitivity.
+
+// Global namespace.
+use const \PHP_VERSION; // Test leading backslash tolerance.

--- a/Universal/Tests/UseStatements/DisallowUseConstUnitTest.3.inc
+++ b/Universal/Tests/UseStatements/DisallowUseConstUnitTest.3.inc
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * First (scoped) namespace.
+ */
+namespace MyProject {
+
+    // Same namespace.
+    use Const MyProject\MY_CONST;
+    use const \myproject\YOUR_CONST as CONST_ALIAS; // Test leading backslash tolerance & case-insensitivity.
+
+    // Not the same namespace.
+    use const Vendor\MyProject\PIP;
+    use const MyProjectXYZ\RATIO;
+
+    // Another namespace.
+    use const foo\math\PI,
+        \foo\math\GOLDEN_RATIO as MATH_GOLDEN; // Test leading backslash tolerance.
+
+    // Global namespace.
+    use const PHP_VERSION_ID;
+}
+
+/*
+ * Second (scoped) namespace - no name.
+ */
+namespace {
+
+    // Another namespace. Test against bleed through from first namespace.
+    use const MyProject\MY_CONST;
+    use const MyProject\YOUR_CONST as CONST_ALIAS;
+
+    // Not the same namespace.
+    use const Vendor\MyProject\PIP;
+
+    use const AnotherProject\Bar\Foo\functionName,
+        AnotherProject\Foo\Bar\functionName as FooCos,
+        \AnotHerProJect\foo\BAR\functionDecl; // Test leading backslash tolerance.
+
+    // Global namespace.
+    use const \PHP_MAJOR_VERSION; // Test leading backslash tolerance.
+}
+
+/*
+ * Third (scoped) namespace.
+ */
+namespace AnotherProject\Foo\Bar {
+
+    // Another namespace.
+    use CONST MyProject\MY_CONST;
+    use const \MyProject\YOUR_CONST as CONST_ALIAS; // Test leading backslash tolerance.
+
+    // Not the same namespace.
+    use const Vendor\AnotherProject\PIP;
+
+    // Same namespace.
+    use const AnotherProject\Foo\Bar\PI,
+        \AnotHerProJect\foo\BAR\GOLDEN_RATIO as MATH_GOLDEN; // Test leading backslash tolerance & case-insensitivity.
+
+    // Global namespace.
+    use const PHP_VERSION;
+}
+
+// Will throw an error as if it is still within the `AnotherProject` scoped namespace.
+// As this is a parse error anyway, as no code is allowed outside of the namespace brackets,
+// this is not something we should be concerned about.
+use const AnotherProject\Foo\Bar\DIDDLE;

--- a/Universal/Tests/UseStatements/DisallowUseConstUnitTest.4.inc
+++ b/Universal/Tests/UseStatements/DisallowUseConstUnitTest.4.inc
@@ -1,0 +1,6 @@
+<?php
+
+// Make sure there is no namespace bleed-through between files.
+
+// Same namespace as the last one used in the previous test case file.
+use const AnotherProject\Foo\Bar\PIP;

--- a/Universal/Tests/UseStatements/DisallowUseConstUnitTest.php
+++ b/Universal/Tests/UseStatements/DisallowUseConstUnitTest.php
@@ -15,6 +15,9 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the DisallowUseConst sniff.
  *
+ * {@internal The current tests are imprecise and not good enough as they don't test that
+ * the correct error code is being thrown, which is what some of the tests are about.}
+ *
  * @covers PHPCSExtra\Universal\Sniffs\UseStatements\DisallowUseConstSniff
  *
  * @since 1.0.0
@@ -25,19 +28,80 @@ class DisallowUseConstUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
+     * @param string $testFile The name of the file being tested.
+     *
      * @return array <int line number> => <int number of errors>
      */
-    public function getErrorList()
+    public function getErrorList($testFile = '')
     {
-        return [
-            8  => 1,
-            9  => 1,
-            11 => 1,
-            12 => 1,
-            15 => 1,
-            16 => 1,
-            23 => 1,
-        ];
+        switch ($testFile) {
+            case 'DisallowUseConstUnitTest.1.inc':
+                return [
+                    8  => 1,
+                    9  => 1, // WithAlias.
+                    11 => 1,
+                    12 => 1, // WithAlias.
+                    15 => 1, // WithAlias.
+                    16 => 1,
+                    23 => 1, // WithAlias.
+                    30 => 1, // WithAlias.
+                    31 => 1, // Note: alias same as name, so not counted as aliased.
+                    32 => 1, // GlobalNamespaceWithAlias.
+                    33 => 1, // GlobalNamespace. Note: alias same as name, so not counted as aliased.
+                ];
+
+            case 'DisallowUseConstUnitTest.2.inc':
+                return [
+                    9  => 1, // SameNamespace.
+                    10 => 1, // SameNamespaceWithAlias.
+                    13 => 1,
+                    14 => 1,
+                    17 => 1,
+                    18 => 1, // WithAlias.
+                    21 => 1, // GlobalNamespace.
+                    29 => 1,
+                    30 => 1, // WithAlias.
+                    33 => 1,
+                    36 => 1, // SameNamespace.
+                    37 => 1, // SameNamespaceWithAlias.
+                    40 => 1, // GlobalNamespace.
+                ];
+
+            case 'DisallowUseConstUnitTest.3.inc':
+                return [
+                    9  => 1, // SameNamespace.
+                    10 => 1, // SameNamespaceWithAlias.
+                    13 => 1,
+                    14 => 1,
+                    17 => 1,
+                    18 => 1, // WithAlias.
+                    21 => 1, // GlobalNamespace.
+
+                    30 => 1,
+                    31 => 1, // WithAlias.
+                    34 => 1,
+                    36 => 1,
+                    37 => 1, // WithAlias.
+                    38 => 1,
+                    41 => 1, // GlobalNamespace.
+
+                    50 => 1,
+                    51 => 1, // WithAlias.
+                    54 => 1,
+                    57 => 1, // SameNamespace.
+                    58 => 1, // SameNamespaceWithAlias.
+                    61 => 1, // GlobalNamespace.
+                    67 => 1, // SameNamespace. Note: well, not really, but parse error.
+                ];
+
+            case 'DisallowUseConstUnitTest.4.inc':
+                return [
+                    6 => 1,
+                ];
+
+            default:
+                return [];
+        }
     }
 
     /**

--- a/Universal/Tests/UseStatements/DisallowUseFunctionUnitTest.1.inc
+++ b/Universal/Tests/UseStatements/DisallowUseFunctionUnitTest.1.inc
@@ -27,6 +27,14 @@ use Some\NS\{
     AnotherLevel,
 };
 
+// Test handling of alias as part of the last leaf of the imported name, including case-insensitivity
+// and tolerance for leading backslashes.
+// While aliasing to itself doesn't make much sense, the sniff should handle it correctly.
+use function My\preg_match as Match;
+use function My\preg_replace as Preg_Replace;
+use function str_pos as Pos; // Alias for global import.
+use function \str_pad as STR_PAD; // Alias for global import to same name.
+
 // Ignore as not import use.
 $closure = function() use($bar) {
     return $bar;

--- a/Universal/Tests/UseStatements/DisallowUseFunctionUnitTest.2.inc
+++ b/Universal/Tests/UseStatements/DisallowUseFunctionUnitTest.2.inc
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * First namespace.
+ */
+namespace MyProject;
+
+// Same namespace.
+use function MyProject\myFunction;
+use function \myproject\yourFunction as FunctionAlias; // Test leading backslash tolerance & case-insensitivity.
+
+// Not the same namespace.
+use function Vendor\MyProject\myOtherFunction;
+use function MyProjectXYZ\myRelatedFunction;
+
+// Another namespace.
+use function AnotherProject\Bar\Foo\functionName,
+    AnotherProject\Foo\Bar\functionName as FooCos,
+    \AnotherProject\Foo\Bar\functionDecl; // Test leading backslash tolerance.
+
+// Global namespace.
+use function preg_match;
+
+
+/*
+ * Second namespace.
+ */
+namespace AnotherProject\Foo\Bar;
+
+// Another namespace. Test against bleed through from first namespace.
+use function MyProject\myFunction;
+use function \MyProject\yourFunction as FunctionAlias; // Test leading backslash tolerance.
+
+// Not the same namespace.
+use function Vendor\MyProject\myOtherFunction;
+
+use function AnotherProject\Bar\Foo\functionName,
+    // Same namespace.
+    AnotherProject\Foo\Bar\functionName as FooCos,
+    \AnotHerProJect\foo\BAR\functionDecl; // Test leading backslash tolerance & case-insensitivity.
+
+// Global namespace.
+use function \str_pos; // Test leading backslash tolerance.

--- a/Universal/Tests/UseStatements/DisallowUseFunctionUnitTest.3.inc
+++ b/Universal/Tests/UseStatements/DisallowUseFunctionUnitTest.3.inc
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * First (scoped) namespace.
+ */
+namespace MyProject {
+
+    // Same namespace.
+    use function MyProject\myFunction;
+    use function \myproject\Sub\yourFunction as FunctionAlias; // Test leading backslash tolerance & case-insensitivity.
+
+    // Not the same namespace.
+    use function Vendor\MyProject\myOtherFunction;
+    use function MyProjectXYZ\myRelatedFunction;
+
+    // Another namespace.
+    use function AnotherProject\Bar\Foo\functionName,
+        AnotherProject\Foo\Bar\functionName as FooCos,
+        \AnotherProject\Foo\Bar\functionDecl; // Test leading backslash tolerance.
+
+    // Global namespace.
+    use function preg_match;
+}
+
+/*
+ * Second (scoped) namespace - no name.
+ */
+namespace {
+
+    // Another namespace. Test against bleed through from first namespace.
+    use function MyProject\myFunction;
+    use function \MyProject\yourFunction as FunctionAlias; // Test leading backslash tolerance.
+
+    // Not the same namespace.
+    use function Vendor\MyProject\myOtherFunction;
+
+    use function AnotherProject\Bar\Foo\functionName,
+        AnotherProject\Foo\Bar\functionName as FooCos,
+        \AnotHerProJect\foo\BAR\functionDecl; // Test leading backslash tolerance.
+
+    // Global namespace.
+    use function \str_pos; // Test leading backslash tolerance.
+}
+
+/*
+ * Third (scoped) namespace.
+ */
+namespace AnotherProject\Foo\Bar {
+
+    // Another namespace.
+    use function MyProject\myFunction;
+    use function \MyProject\yourFunction as FunctionAlias; // Test leading backslash tolerance.
+
+    // Not the same namespace.
+    use function Vendor\AnotherProject\myOtherFunction;
+
+    use function AnotherProject\Bar\Foo\functionName,
+        // Same namespace.
+        AnotherProject\Foo\Bar\functionName as FooCos,
+        \AnotHerProJect\foo\BAR\functionDecl; // Test leading backslash tolerance & case-insensitivity.
+
+    // Global namespace.
+    use function preg_replace;
+}
+
+// Will throw an error as if it is still within the `AnotherProject` scoped namespace.
+// As this is a parse error anyway, as no code is allowed outside of the namespace brackets,
+// this is not something we should be concerned about.
+use function AnotherProject\Foo\Bar\someFunction;

--- a/Universal/Tests/UseStatements/DisallowUseFunctionUnitTest.4.inc
+++ b/Universal/Tests/UseStatements/DisallowUseFunctionUnitTest.4.inc
@@ -1,0 +1,6 @@
+<?php
+
+// Make sure there is no namespace bleed-through between files.
+
+// Same namespace as the last one used in the previous test case file.
+use function AnotherProject\Foo\Bar\functionName as FooCos;

--- a/Universal/Tests/UseStatements/DisallowUseFunctionUnitTest.php
+++ b/Universal/Tests/UseStatements/DisallowUseFunctionUnitTest.php
@@ -15,6 +15,9 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the DisallowUseFunction sniff.
  *
+ * {@internal The current tests are imprecise and not good enough as they don't test that
+ * the correct error code is being thrown, which is what some of the tests are about.}
+ *
  * @covers PHPCSExtra\Universal\Sniffs\UseStatements\DisallowUseFunctionSniff
  *
  * @since 1.0.0
@@ -25,22 +28,85 @@ class DisallowUseFunctionUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
+     * @param string $testFile The name of the file being tested.
+     *
      * @return array <int line number> => <int number of errors>
      */
-    public function getErrorList()
+    public function getErrorList($testFile = '')
     {
-        return [
-            8  => 1,
-            9  => 1,
-            11 => 1,
-            12 => 1,
-            13 => 1,
-            16 => 1,
-            17 => 1,
-            18 => 1,
-            24 => 1,
-            26 => 1,
-        ];
+        switch ($testFile) {
+            case 'DisallowUseFunctionUnitTest.1.inc':
+                return [
+                    8  => 1,
+                    9  => 1, // WithAlias.
+                    11 => 1,
+                    12 => 1, // WithAlias.
+                    13 => 1,
+                    16 => 1,
+                    17 => 1, // WithAlias.
+                    18 => 1,
+                    24 => 1,
+                    26 => 1,
+                    33 => 1, // WithAlias.
+                    34 => 1, // Note: alias same as name, so not counted as aliased.
+                    35 => 1, // GlobalNamespaceWithAlias.
+                    36 => 1, // GlobalNamespace. Note: alias same as name, so not counted as aliased.
+                ];
+
+            case 'DisallowUseFunctionUnitTest.2.inc':
+                return [
+                    9  => 1, // SameNamespace.
+                    10 => 1, // SameNamespaceWithAlias.
+                    13 => 1,
+                    14 => 1,
+                    17 => 1,
+                    18 => 1, // WithAlias.
+                    19 => 1,
+                    22 => 1, // GlobalNamespace.
+                    31 => 1,
+                    32 => 1, // WithAlias.
+                    35 => 1,
+                    37 => 1,
+                    39 => 1, // SameNamespaceWithAlias.
+                    40 => 1, // SameNamespace.
+                    43 => 1, // GlobalNamespace.
+                ];
+
+            case 'DisallowUseFunctionUnitTest.3.inc':
+                return [
+                    9  => 1, // SameNamespace.
+                    10 => 1, // SameNamespaceWithAlias.
+                    13 => 1,
+                    14 => 1,
+                    17 => 1,
+                    18 => 1, // WithAlias.
+                    19 => 1,
+                    22 => 1, // GlobalNamespace.
+                    31 => 1,
+                    32 => 1, // WithAlias.
+                    35 => 1,
+                    37 => 1,
+                    38 => 1, // WithAlias.
+                    39 => 1,
+                    42 => 1, // GlobalNamespace.
+                    51 => 1,
+                    52 => 1, // WithAlias.
+                    55 => 1,
+                    57 => 1,
+                    59 => 1, // SameNamespaceWithAlias.
+                    60 => 1, // SameNamespace.
+                    63 => 1, // GlobalNamespace.
+                    69 => 1, // SameNamespace. Note: well, not really, but parse error.
+                ];
+
+            case 'DisallowUseFunctionUnitTest.4.inc':
+                return [
+                    6 => 1, // WithAlias.
+                ];
+
+            default:
+                return [];
+        }
     }
 
     /**


### PR DESCRIPTION
This adds four new error codes to each of the sniffs:
- `FoundSameNamespace`, `FoundSameNamespaceWithAlias` for `use` statements importing from the same namespace;
- `FoundGlobalNamespace`, `FoundGlobalNamespaceWithAlias` for `use` statements importing from the global namespace, like import statements for PHP native classes, functions and constants.

In all other circumstances, the existing error codes `FoundWithAlias` and `FoundWithoutAlias` will continue to be used.

This commit also contains three bug fixes applied to each of these sniffs:
* In PHP, both namespace names, as well as aliases, are case-insensitive, so any comparison of them should be done in a case-insensitive manner.
* An import from the global namespace would previously always be seen as non-aliased, even when it was aliased.
* Tolerance for `use` import statements with leading backslashes.

Includes:
* Additional metrics about the import source: different namespace / same namespace / global namespace.
* Additional unit tests.

Closes #1