### PR TITLE
Universal/DisallowShortListSyntax: add additional test

### DIFF
--- a/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.inc
+++ b/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.inc
@@ -18,3 +18,6 @@ list($a, list($b, $c, $d)) = $array;
         $d,
     ],
 ] = $array;
+
+// Intentional parse error. This has to be the last test in the file.
+[ $a, $b

--- a/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.inc.fixed
+++ b/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.inc.fixed
@@ -18,3 +18,6 @@ list(
         $d,
     ),
 ) = $array;
+
+// Intentional parse error. This has to be the last test in the file.
+[ $a, $b


### PR DESCRIPTION
... to safeguard parse error protection within the sniff.