### PR TITLE
QA: enable code coverage recording & checking

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,3 @@
+coverage_clover: build/logs/clover.xml
+json_path: build/logs/coveralls-upload.json
+service_name: travis-ci

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 # https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production
 # https://blog.madewithlove.be/post/gitattributes/
 #
+/.coveralls.yml export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.travis.yml export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,11 @@ cache:
     - $HOME/.cache/composer/files
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0
   - 7.1
   - 7.2
-  - 7.3
 
 env:
   jobs:
@@ -37,6 +35,8 @@ stages:
   - name: quicktest
     if: type = push AND branch NOT IN (master, develop)
   - name: test
+    if: branch IN (master, develop)
+  - name: coverage
     if: branch IN (master, develop)
 
 jobs:
@@ -74,6 +74,8 @@ jobs:
     #### QUICK TEST STAGE ####
     # This is a much quicker test which only runs the unit tests and linting against the low/high
     # supported PHP/PHPCS combinations.
+    # These are basically the same builds as in the Coverage stage, but then without doing
+    # the code-coverage.
     - stage: quicktest
       php: 7.4
       env: PHPCS_VERSION="dev-master" LINT=1
@@ -88,14 +90,29 @@ jobs:
     #### TEST STAGE ####
     # Additional builds to prevent issues with PHPCS versions incompatible with certain PHP versions.
     - stage: test
+      # PHPCS is only compatible with PHP 7.4 as of version 3.5.0.
       php: 7.4
-      env: PHPCS_VERSION="dev-master" LINT=1
-    # PHPCS is only compatible with PHP 7.4 as of version 3.5.0.
-    - php: 7.4
       env: PHPCS_VERSION="3.5.0"
+    - php: 7.3
+      env: PHPCS_VERSION="dev-master" LINT=1
 
     - php: "nightly"
       env: PHPCS_VERSION="n/a" LINT=1
+
+    #### CODE COVERAGE STAGE ####
+    # N.B.: Coverage is only checked on the lowest and highest stable PHP versions for all PHPCS versions.
+    # These builds are left out off the "test" stage so as not to duplicate test runs.
+    # The script used is the default script below, the same as for the `test` stage.
+    - stage: coverage
+      php: 7.4
+      env: PHPCS_VERSION="dev-master" LINT=1 COVERALLS_VERSION="^2.0"
+    - php: 7.3
+      env: PHPCS_VERSION="3.3.1" COVERALLS_VERSION="^2.0"
+
+    - php: 5.4
+      env: PHPCS_VERSION="dev-master" LINT=1 COVERALLS_VERSION="^1.0"
+    - php: 5.4
+      env: PHPCS_VERSION="3.3.1" COVERALLS_VERSION="^1.0"
 
   allow_failures:
     # Allow failures for unstable builds.
@@ -104,7 +121,10 @@ jobs:
 
 before_install:
   # Speed up build time by disabling Xdebug when its not needed.
-  - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
+  - |
+    if [[ "$TRAVIS_BUILD_STAGE_NAME" != "Coverage" ]]; then
+      phpenv config-rm xdebug.ini || echo 'No xdebug config.'
+    fi
 
   - export XMLLINT_INDENT="    "
 
@@ -123,6 +143,10 @@ install:
       composer require --no-update --no-scripts squizlabs/php_codesniffer:${PHPCS_VERSION}
     fi
   - |
+    if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Coverage" ]]; then
+      composer require --no-update --no-suggest --no-scripts php-coveralls/php-coveralls:${COVERALLS_VERSION}
+    fi
+  - |
     if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Sniff" || $PHPCS_VERSION == "n/a" ]]; then
       # The sniff stage doesn't run the unit tests, so no need for PHPUnit.
       # The build on nightly also doesn't run the tests (yet).
@@ -134,9 +158,29 @@ install:
   - composer install --prefer-dist --no-suggest
 
 
+before_script:
+  - if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Coverage" ]]; then mkdir -p build/logs; fi
+  - phpenv rehash
+
+
 script:
   # Lint PHP files against parse errors.
   - if [[ "$LINT" == "1" ]]; then composer lint; fi
 
-  # Run the tests.
-  - if [[ $PHPCS_VERSION != "n/a" ]]; then composer test; fi
+  # Run the unit tests.
+  - |
+    if [[ $PHPCS_VERSION != "n/a" && "$TRAVIS_BUILD_STAGE_NAME" != "Coverage" ]]; then
+      composer test
+    elif [[ $PHPCS_VERSION != "n/a" && "$TRAVIS_BUILD_STAGE_NAME" == "Coverage" ]]; then
+      composer coverage
+    fi
+
+after_success:
+  - |
+    if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Coverage" && $COVERALLS_VERSION == "^1.0" ]]; then
+      php vendor/bin/coveralls -v -x build/logs/clover.xml
+    fi
+  - |
+    if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Coverage" && $COVERALLS_VERSION == "^2.0" ]]; then
+      php vendor/bin/php-coveralls -v -x build/logs/clover.xml
+    fi

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ PHPCSExtra
 
 [![Minimum PHP Version](https://img.shields.io/packagist/php-v/phpcsstandards/phpcsextra.svg?maxAge=3600)](https://packagist.org/packages/phpcsstandards/phpcsextra)
 [![Tested on PHP 5.4 to 7.4](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4-brightgreen.svg?maxAge=2419200)](https://travis-ci.com/PHPCSStandards/PHPCSExtra)
+[![Coverage Status](https://coveralls.io/repos/github/PHPCSStandards/PHPCSExtra/badge.svg)](https://coveralls.io/github/PHPCSStandards/PHPCSExtra)
 
 [![License: LGPLv3](https://poser.pugx.org/phpcsstandards/phpcsextra/license)](https://github.com/PHPCSStandards/PHPCSExtra/blob/master/LICENSE)
 ![Awesome](https://img.shields.io/badge/awesome%3F-yes!-brightgreen.svg)

--- a/composer.json
+++ b/composer.json
@@ -64,8 +64,13 @@
             "@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./NormalizedArrays ./Universal"
         ],
         "test": [
-            "@php ./vendor/phpunit/phpunit/phpunit --filter NormalizedArrays ./vendor/squizlabs/php_codesniffer/tests/AllTests.php",
-            "@php ./vendor/phpunit/phpunit/phpunit --filter Universal ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
+            "@php ./vendor/phpunit/phpunit/phpunit --filter PHPCSExtra --no-coverage ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
+        ],
+        "coverage": [
+            "@php ./vendor/phpunit/phpunit/phpunit --filter PHPCSExtra ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
+        ],
+        "coverage-local": [
+            "@php ./vendor/phpunit/phpunit/phpunit --filter PHPCSExtra ./vendor/squizlabs/php_codesniffer/tests/AllTests.php --coverage-html ./build/coverage-html"
         ]
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,4 +15,15 @@
         </testsuite>
     </testsuites>
 
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./NormalizedArrays/Sniffs/</directory>
+            <directory suffix=".php">./Universal/Sniffs/</directory>
+        </whitelist>
+    </filter>
+
+    <logging>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
+
 </phpunit>


### PR DESCRIPTION
Enable Coveralls for code coverage checking.

Includes:
* Composer: convenience script for code coverage checking, including generating the HTML output for local runs.
* Composer: adjusting the existing Composer `test` script to run without generating coverage data.
    Includes simplifying the `filter` used.
* Travis: adding a separate `coverage` stage to the Travis script and adjusting the script to handle this in an as optimal way as possible.
* Readme: adding a code coverage badge.