### PR TITLE
New `Universal.Arrays.DisallowShortArraySyntax` sniff

### DIFF
--- a/Universal/Docs/Arrays/DisallowShortArraySyntaxStandard.xml
+++ b/Universal/Docs/Arrays/DisallowShortArraySyntaxStandard.xml
@@ -1,0 +1,23 @@
+<documentation title="Disallow Short Array Syntax">
+    <standard>
+    <![CDATA[
+    The array keyword must be used to define arrays.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Using long form array syntax.">
+        <![CDATA[
+$arr = <em>array(</em>
+    'foo' => 'bar',
+<em>)</em>;
+        ]]>
+        </code>
+        <code title="Invalid: Using short array syntax.">
+        <![CDATA[
+$arr = <em>[</em>
+    'foo' => 'bar',
+<em>]</em>;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/Arrays/DisallowShortArraySyntaxSniff.php
+++ b/Universal/Sniffs/Arrays/DisallowShortArraySyntaxSniff.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\Arrays;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHPCSUtils\Utils\Arrays;
+
+/**
+ * Disallow the use of the short array syntax.
+ *
+ * Improved version of the upstream `Generic.Arrays.DisallowShortArraySyntax` sniff which does
+ * not account for short lists and because of this can cause parse errors when auto-fixing.
+ *
+ * Other related sniffs:
+ * - `Generic.Arrays.DisallowLongArraySyntax` Forbids the use of the long array syntax.
+ *
+ * @since 1.0.0 This sniff is loosely based on and inspired by the upstream
+ *              `Generic.Arrays.DisallowShortArraySyntax` sniff.
+ */
+class DisallowShortArraySyntaxSniff implements Sniff
+{
+
+    /**
+     * Registers the tokens that this sniff wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return int|string[]
+     */
+    public function register()
+    {
+        return [
+            \T_OPEN_SHORT_ARRAY,
+            \T_OPEN_SQUARE_BRACKET,
+        ];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (Arrays::isShortArray($phpcsFile, $stackPtr) === false) {
+            // No need to examine nested subs of this short list.
+            return $tokens[$stackPtr]['bracket_closer'];
+        }
+
+        $error = 'Short array syntax is not allowed';
+        $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'Found');
+
+        if ($fix === true) {
+            $phpcsFile->fixer->beginChangeset();
+            $phpcsFile->fixer->replaceToken($tokens[$stackPtr]['bracket_opener'], 'array(');
+            $phpcsFile->fixer->replaceToken($tokens[$stackPtr]['bracket_closer'], ')');
+            $phpcsFile->fixer->endChangeset();
+        }
+    }
+}

--- a/Universal/Tests/Arrays/DisallowShortArraySyntaxUnitTest.inc
+++ b/Universal/Tests/Arrays/DisallowShortArraySyntaxUnitTest.inc
@@ -1,0 +1,16 @@
+<?php
+
+$var = array();
+$var = [];
+$var = array(1,2,3);
+$var = [1,2,3];
+echo $var[1];
+$foo = [$var[1],$var[2]];
+$foo = [
+        1,
+        [2],
+        3
+       ];
+
+// Short list, not short array.
+[$a, [$b]] = $array;

--- a/Universal/Tests/Arrays/DisallowShortArraySyntaxUnitTest.inc.fixed
+++ b/Universal/Tests/Arrays/DisallowShortArraySyntaxUnitTest.inc.fixed
@@ -1,0 +1,16 @@
+<?php
+
+$var = array();
+$var = array();
+$var = array(1,2,3);
+$var = array(1,2,3);
+echo $var[1];
+$foo = array($var[1],$var[2]);
+$foo = array(
+        1,
+        array(2),
+        3
+       );
+
+// Short list, not short array.
+[$a, [$b]] = $array;

--- a/Universal/Tests/Arrays/DisallowShortArraySyntaxUnitTest.php
+++ b/Universal/Tests/Arrays/DisallowShortArraySyntaxUnitTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\Arrays;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the DisallowShortArraySyntax sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\Arrays\DisallowShortArraySyntaxSniff
+ *
+ * @since 1.0.0
+ */
+class DisallowShortArraySyntaxUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [
+            4  => 1,
+            6  => 1,
+            8  => 1,
+            9  => 1,
+            11 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
The upstream PHPCS `Generic.Arrays.DisallowShortArraySyntax` sniff does not account for short lists and will cause parse errors during auto-fixing when these are encountered.

As the utilities from PHPCSUtils were never merged into PHPCS itself, fixing it upstream would be tedious and would involve duplicating more code than I care to.

So instead, this duplicates the sniff, including the fix which was originally contained in the Refactor branch as pulled to PHPCS.

Includes fixer.
Includes unit tests.
Includes documentation.