### PR TITLE
New `Universal.Operators.DisallowShortTernary` sniff

### DIFF
--- a/Universal/Docs/Operators/DisallowShortTernaryStandard.xml
+++ b/Universal/Docs/Operators/DisallowShortTernaryStandard.xml
@@ -1,0 +1,22 @@
+<documentation title="Disallow Short Ternary">
+    <standard>
+    <![CDATA[
+    Using short ternaries is not allowed.
+
+    While short ternaries are useful when used correctly, the principle of them is often misunderstood and they are more often than not used incorrectly, leading to hard to debug issues and/or PHP warnings/notices.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Full ternary.">
+        <![CDATA[
+echo !empty($a) <em>?</em> $a <em>:</em> 'default';
+        ]]>
+        </code>
+        <code title="Invalid: Short ternary.">
+        <![CDATA[
+echo !empty($a) <em>?:</em> 'default';
+echo $a <em>? :</em> 'default';
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/Operators/DisallowShortTernarySniff.php
+++ b/Universal/Sniffs/Operators/DisallowShortTernarySniff.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\Operators;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHPCSUtils\Utils\Operators;
+
+/**
+ * Disallow the use of short ternaries.
+ *
+ * While short ternaries are useful when used correctly, the principle of them is
+ * often misunderstood and they are more often than not used incorrectly, leading to
+ * hard to debug issues and/or PHP warnings/notices.
+ *
+ * @since 1.0.0
+ */
+class DisallowShortTernarySniff implements Sniff
+{
+
+    /**
+     * Registers the tokens that this sniff wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return int[]
+     */
+    public function register()
+    {
+        return [\T_INLINE_THEN];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (Operators::isShortTernary($phpcsFile, $stackPtr) === false) {
+            $phpcsFile->recordMetric($stackPtr, 'Ternary usage', 'long');
+            return;
+        }
+
+        $phpcsFile->recordMetric($stackPtr, 'Ternary usage', 'short');
+
+        $phpcsFile->addError(
+            'Using short ternaries is not allowed as they are rarely used correctly',
+            $stackPtr,
+            'Found'
+        );
+    }
+}

--- a/Universal/Tests/Operators/DisallowShortTernaryUnitTest.inc
+++ b/Universal/Tests/Operators/DisallowShortTernaryUnitTest.inc
@@ -1,0 +1,11 @@
+<?php
+
+$long = $compare ? 'a' : 'b';
+
+$short = isset($a) ? : 0; // Bad.
+$short = !empty($b) ?: !empty($c) ?: 0; // Bad.
+$short = $compare ? /* intentionally left empty */
+    : 0; // Bad.
+
+/* Intentional parse error. This should be the last test in the file. */
+$unfinished = $compare ? /* comment */

--- a/Universal/Tests/Operators/DisallowShortTernaryUnitTest.php
+++ b/Universal/Tests/Operators/DisallowShortTernaryUnitTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\Operators;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the DisallowShortTernary sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\Operators\DisallowShortTernarySniff
+ *
+ * @since 1.0.0
+ */
+class DisallowShortTernaryUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [
+            5 => 1,
+            6 => 2,
+            7 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
New sniff to disallow using short ternaries.

While short ternaries are useful when used correctly, the principle of them is often misunderstood and they are more often than not used incorrectly, leading to hard to debug issues and/or PHP warnings/notices.

Includes unit tests.
Includes documentation.
Includes metrics.