### PR TITLE
New `Universal.WhiteSpace.DisallowInlineTabs` sniff

### DIFF
--- a/Universal/Docs/WhiteSpace/DisallowInlineTabsStandard.xml
+++ b/Universal/Docs/WhiteSpace/DisallowInlineTabsStandard.xml
@@ -1,0 +1,21 @@
+<documentation title="Disallow Inline Tabs">
+    <standard>
+    <![CDATA[
+    Spaces must be used for mid-line alignment.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Spaces used for alignment.">
+        <![CDATA[
+echo $title;<em> </em>// Comment.
+echo $text;<em>  </em>// Comment.
+        ]]>
+        </code>
+        <code title="Invalid: Tabs used for alignment.">
+        <![CDATA[
+echo $title;<em>[tab]</em>// Comment.
+echo $text;<em>[tab]</em>// Comment.
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Helpers/DummyTokenizer.php
+++ b/Universal/Helpers/DummyTokenizer.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Helpers;
+
+use PHP_CodeSniffer\Tokenizers\Tokenizer;
+
+/**
+ * Dummy tokenizer class to allow for accessing the replaceTabsInToken() method.
+ *
+ * @codeCoverageIgnore
+ *
+ * @since 1.0.0
+ */
+class DummyTokenizer extends Tokenizer
+{
+
+    /**
+     * Initialise and (don't) run the tokenizer.
+     *
+     * @param string                         $content The content to tokenize,
+     * @param \PHP_CodeSniffer\Config | null $config  The config data for the run.
+     * @param string                         $eolChar The EOL char used in the content.
+     *
+     * @return void
+     */
+    public function __construct($content, $config, $eolChar = '\n')
+    {
+        $this->eolChar = $eolChar;
+        $this->config  = $config;
+    }
+
+    /**
+     * Creates an array of tokens when given some content.
+     *
+     * @param string $string The string to tokenize.
+     *
+     * @return array
+     */
+    protected function tokenize($string)
+    {
+    }
+
+    /**
+     * Performs additional processing after main tokenizing.
+     *
+     * @return void
+     */
+    protected function processAdditional()
+    {
+    }
+}

--- a/Universal/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
+++ b/Universal/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHPCSExtra\Universal\Helpers\DummyTokenizer;
+use PHPCSUtils\BackCompat\Helper;
+
+/**
+ * Enforces using spaces for mid-line alignment.
+ *
+ * While tab versus space based indentation is a question of preference, for mid-line
+ * alignment, spaces should always be preferred, as using tabs will result in inconsistent
+ * formatting depending on the dev-user's chosen tab width.
+ *
+ * This sniff is especially useful for tab-indentation based standards which use the
+ * `Generic.Whitespace.DisallowSpaceIndent` sniff to enforce this.
+ *
+ * **DO** make sure to set the PHPCS native `tab-width` configuration for the best results.
+ * <code>
+ *   <arg name="tab-width" value="4"/>
+ * </code>
+ *
+ * The PHPCS native `Generic.Whitespace.DisallowTabIndent` sniff oversteps its reach and silently
+ * does mid-line tab to space replacements as well.
+ * However, the sister-sniff `Generic.Whitespace.DisallowSpaceIndent` leaves mid-line tabs/spaces alone.
+ * This sniff fills that gap.
+ *
+ * @since 1.0.0
+ */
+class DisallowInlineTabsSniff implements Sniff
+{
+
+    /**
+     * The --tab-width CLI value that is being used.
+     *
+     * @since 1.0.0
+     *
+     * @var int
+     */
+    private $tabWidth;
+
+    /**
+     * Tokens to check for mid-line tabs.
+     *
+     * @since 1.0.0
+     *
+     * @var array
+     */
+    private $find = [
+        \T_WHITESPACE             => true,
+        \T_DOC_COMMENT_WHITESPACE => true,
+        \T_DOC_COMMENT_STRING     => true,
+        \T_COMMENT                => true,
+    ];
+
+    /**
+     * Registers the tokens that this sniff wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return int[]
+     */
+    public function register()
+    {
+        return [
+            \T_OPEN_TAG,
+            \T_OPEN_TAG_WITH_ECHO,
+        ];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return int Integer stack pointer to skip the rest of the file.
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (isset($this->tabWidth) === false) {
+            $this->tabWidth = Helper::getTabWidth($phpcsFile);
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        for ($i = 0; $i < $phpcsFile->numTokens; $i++) {
+            // Skip all non-whitespace tokens and skip whitespace at the start of a new line.
+            if (isset($this->find[$tokens[$i]['code']]) === false
+                || (($tokens[$i]['code'] === \T_WHITESPACE
+                    || $tokens[$i]['code'] === \T_DOC_COMMENT_WHITESPACE)
+                    && $tokens[$i]['column'] === 1)
+            ) {
+                continue;
+            }
+
+            // If tabs haven't been converted to spaces by the tokenizer, do so now.
+            $token = $tokens[$i];
+            if (isset($token['orig_content']) === false) {
+                $dummy = new DummyTokenizer('', $phpcsFile->config);
+                $dummy->replaceTabsInToken($token, ' ', ' ', $this->tabWidth);
+            }
+
+            $origContent = $token['orig_content'];
+
+            $multiLineComment = false;
+            if ($tokens[$i]['code'] === \T_COMMENT
+                 && $tokens[$i]['column'] === 1
+                 && $tokens[($i - 1)]['code'] === \T_COMMENT
+            ) {
+                $multiLineComment = true;
+            }
+
+            if ($multiLineComment === true) {
+                // This is the subsequent line of a multi-line comment. Account for indentation.
+                $commentOnly = \ltrim($origContent);
+                if ($commentOnly === '' || \strpos($commentOnly, "\t") === false) {
+                    continue;
+                }
+            } elseif ($origContent === '' || \strpos($origContent, "\t") === false) {
+                continue;
+            }
+
+            $fix = $phpcsFile->addFixableError(
+                'Spaces must be used for mid-line alignment; tabs are not allowed',
+                $i,
+                'NonIndentTabsUsed'
+            );
+
+            if ($fix === false) {
+                continue;
+            }
+
+            $indent = '';
+            if ($multiLineComment === true) {
+                // Take the original indent (tabs/spaces) and combine with the tab-replaced comment content.
+                $indent           = \str_replace($commentOnly, '', $origContent);
+                $token['content'] = \ltrim($token['content']);
+            }
+
+            $phpcsFile->fixer->replaceToken($i, $indent . $token['content']);
+        }
+
+        // Scanned the whole file in one go. Don't scan this file again.
+        return $phpcsFile->numTokens;
+    }
+}

--- a/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.1.inc
+++ b/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.1.inc
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @param int    $var    Description.
+ * @param string $string Another description.
+ */
+
+			$expected = ( $column - 1 );
+			$found    = ( $this->tokens[ $closer ]['column'] - 1 );
+			$error    = 'Array closer not aligned correctly; expected %s space(s) but found %s';
+			$data     = array(
+				$expected_value => 'data',
+				$found          => 'more_data',
+			);
+
+/**
+ * @param int	 $var	 Description - Bad: alignment using tabs.
+ * @param string $string Another description.
+ */
+
+			$expected = ( $column - 1 );
+			$found	  = ( $this->tokens[ $closer ]['column'] - 1 ); // Bad.
+			$error	  = 'Array closer not aligned correctly; expected %s space(s) but found %s'; // Bad.
+			$data	  = array( // Bad.
+				$expected_value => 'data',
+				$found			=> 'more_data', // Bad.
+			);
+
+/*
+ * Test that the tab replacements do not negatively influence existing mid-line alignments.
+ */
+$a		  = true;
+$aa		  = true;
+$aaa	  = true;
+$aaaa	  = true;
+$aaaaa	  = true;
+$aaaaaa	  = true;
+$aaaaaaa  = true;
+$aaaaaaaa = true;
+
+// Test tab replacement	in	inline comments.
+
+	/**
+	 * @param	int		$var	Description.
+	 * @param	string	$string	Another description.
+	 */
+
+		/*
+		 * Tab indented		and inline tabs.
+		 */
+
+		// Tab indented		and inline tabs.
+		// Tab indented		and inline tabs.

--- a/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.1.inc.fixed
+++ b/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.1.inc.fixed
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @param int    $var    Description.
+ * @param string $string Another description.
+ */
+
+			$expected = ( $column - 1 );
+			$found    = ( $this->tokens[ $closer ]['column'] - 1 );
+			$error    = 'Array closer not aligned correctly; expected %s space(s) but found %s';
+			$data     = array(
+				$expected_value => 'data',
+				$found          => 'more_data',
+			);
+
+/**
+ * @param int    $var    Description - Bad: alignment using tabs.
+ * @param string $string Another description.
+ */
+
+			$expected = ( $column - 1 );
+			$found    = ( $this->tokens[ $closer ]['column'] - 1 ); // Bad.
+			$error    = 'Array closer not aligned correctly; expected %s space(s) but found %s'; // Bad.
+			$data     = array( // Bad.
+				$expected_value => 'data',
+				$found          => 'more_data', // Bad.
+			);
+
+/*
+ * Test that the tab replacements do not negatively influence existing mid-line alignments.
+ */
+$a        = true;
+$aa       = true;
+$aaa      = true;
+$aaaa     = true;
+$aaaaa    = true;
+$aaaaaa   = true;
+$aaaaaaa  = true;
+$aaaaaaaa = true;
+
+// Test tab replacement in  inline comments.
+
+	/**
+	 * @param   int     $var    Description.
+	 * @param   string  $string Another description.
+	 */
+
+		/*
+		 * Tab indented     and inline tabs.
+		 */
+
+		// Tab indented     and inline tabs.
+		// Tab indented     and inline tabs.

--- a/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.2.inc
+++ b/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.2.inc
@@ -1,0 +1,7 @@
+<div>
+	<h1><?=	$title;		/* The title */			?></h1>
+	<p><?=	$text;		/* Paragraph text */	?></p>
+	<p><?=
+		$text;		/* Paragraph text */
+	?></p>
+</div>

--- a/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.2.inc.fixed
+++ b/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.2.inc.fixed
@@ -1,0 +1,7 @@
+<div>
+	<h1><?= $title;     /* The title */         ?></h1>
+	<p><?=  $text;      /* Paragraph text */    ?></p>
+	<p><?=
+		$text;      /* Paragraph text */
+	?></p>
+</div>

--- a/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.3.inc
+++ b/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.3.inc
@@ -1,0 +1,11 @@
+<div>
+	<h1><?=	$title;		/* The title */			?></h1>
+</div>
+
+<?php
+
+	/**
+	 * @param int	 $var	 Description - Bad: alignment using tabs.
+	 * @param string $string Another description.
+	 */
+	function doSomething() {}

--- a/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.3.inc.fixed
+++ b/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.3.inc.fixed
@@ -1,0 +1,11 @@
+<div>
+	<h1><?= $title;     /* The title */         ?></h1>
+</div>
+
+<?php
+
+	/**
+	 * @param int    $var    Description - Bad: alignment using tabs.
+	 * @param string $string Another description.
+	 */
+	function doSomething() {}

--- a/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.4.inc
+++ b/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.4.inc
@@ -1,0 +1,35 @@
+<?php
+/* *** TESTING WITH TAB WIDTH SET TO 2 *** */
+/**
+ * @param int		 $var		 Description - Bad: alignment using tabs.
+ * @param string $string Another description.
+ */
+
+			$expected = ( $column - 1 );
+			$found		= ( $this->tokens[ $closer ]['column'] - 1 ); // Bad.
+			$error		= 'Array closer not aligned correctly; expected %s space(s) but found %s'; // Bad.
+			$data			= array( // Bad.
+				$expected_value => 'data',
+				$found					=> 'more_data', // Bad.
+			);
+
+/*
+ * Test that the tab replacements do not negatively influence existing mid-line alignments.
+ */
+$a				= true;
+$aa				= true;
+$aaa			= true;
+$aaaa			= true;
+$aaaaa		= true;
+$aaaaaa		= true;
+$aaaaaaa	= true;
+$aaaaaaaa = true;
+
+// Test tab replacement	in	inline comments.
+
+		/*
+		 * Tab indented		and inline tabs.
+		 */
+
+		// Tab indented		and inline tabs.
+		// Tab indented		and inline tabs.

--- a/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.4.inc.fixed
+++ b/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.4.inc.fixed
@@ -1,0 +1,35 @@
+<?php
+/* *** TESTING WITH TAB WIDTH SET TO 2 *** */
+/**
+ * @param int    $var    Description - Bad: alignment using tabs.
+ * @param string $string Another description.
+ */
+
+			$expected = ( $column - 1 );
+			$found    = ( $this->tokens[ $closer ]['column'] - 1 ); // Bad.
+			$error    = 'Array closer not aligned correctly; expected %s space(s) but found %s'; // Bad.
+			$data     = array( // Bad.
+				$expected_value => 'data',
+				$found          => 'more_data', // Bad.
+			);
+
+/*
+ * Test that the tab replacements do not negatively influence existing mid-line alignments.
+ */
+$a        = true;
+$aa       = true;
+$aaa      = true;
+$aaaa     = true;
+$aaaaa    = true;
+$aaaaaa   = true;
+$aaaaaaa  = true;
+$aaaaaaaa = true;
+
+// Test tab replacement in  inline comments.
+
+		/*
+		 * Tab indented   and inline tabs.
+		 */
+
+		// Tab indented   and inline tabs.
+		// Tab indented   and inline tabs.

--- a/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.5.inc
+++ b/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.5.inc
@@ -1,0 +1,35 @@
+<?php
+/* *** TESTING WITHOUT A TAB WIDTH SET *** */
+/**
+ * @param int	 $var	 Description - Bad: alignment using tabs.
+ * @param string $string Another description.
+ */
+
+			$expected = ( $column - 1 );
+			$found	  = ( $this->tokens[ $closer ]['column'] - 1 ); // Bad.
+			$error	  = 'Array closer not aligned correctly; expected %s space(s) but found %s'; // Bad.
+			$data	  = array( // Bad.
+				$expected_value => 'data',
+				$found			=> 'more_data', // Bad.
+			);
+
+/*
+ * Test that the tab replacements do not negatively influence existing mid-line alignments.
+ */
+$a		  = true;
+$aa		  = true;
+$aaa	  = true;
+$aaaa	  = true;
+$aaaaa	  = true;
+$aaaaaa	  = true;
+$aaaaaaa  = true;
+$aaaaaaaa = true;
+
+// Test tab replacement	in	inline comments.
+
+		/*
+		 * Tab indented		and inline tabs.
+		 */
+
+		// Tab indented		and inline tabs.
+		// Tab indented		and inline tabs.

--- a/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.5.inc.fixed
+++ b/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.5.inc.fixed
@@ -1,0 +1,35 @@
+<?php
+/* *** TESTING WITHOUT A TAB WIDTH SET *** */
+/**
+ * @param int    $var    Description - Bad: alignment using tabs.
+ * @param string $string Another description.
+ */
+
+			$expected = ( $column - 1 );
+			$found     = ( $this->tokens[ $closer ]['column'] - 1 ); // Bad.
+			$error     = 'Array closer not aligned correctly; expected %s space(s) but found %s'; // Bad.
+			$data      = array( // Bad.
+				$expected_value => 'data',
+				$found          => 'more_data', // Bad.
+			);
+
+/*
+ * Test that the tab replacements do not negatively influence existing mid-line alignments.
+ */
+$a        = true;
+$aa       = true;
+$aaa      = true;
+$aaaa     = true;
+$aaaaa    = true;
+$aaaaaa   = true;
+$aaaaaaa  = true;
+$aaaaaaaa = true;
+
+// Test tab replacement in  inline comments.
+
+		/*
+		 * Tab indented     and inline tabs.
+		 */
+
+		// Tab indented       and inline tabs.
+		// Tab indented       and inline tabs.

--- a/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
+++ b/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\WhiteSpace;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the DisallowInlineTabs sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\WhiteSpace\DisallowInlineTabsSniff
+ *
+ * @since 1.0.0
+ */
+class DisallowInlineTabsUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Set CLI values before the file is tested.
+     *
+     * @param string                  $testFile The name of the file being tested.
+     * @param \PHP_CodeSniffer\Config $config   The config data for the test run.
+     *
+     * @return void
+     */
+    public function setCliValues($testFile, $config)
+    {
+        if ($testFile === 'DisallowInlineTabsUnitTest.4.inc') {
+            $config->tabWidth = 2;
+            return;
+        }
+
+        if ($testFile === 'DisallowInlineTabsUnitTest.5.inc') {
+            // Set to the default.
+            $config->tabWidth = 0;
+            return;
+        }
+
+        $config->tabWidth = 4;
+    }
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @param string $testFile The name of the file being tested.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getErrorList($testFile = '')
+    {
+        switch ($testFile) {
+            case 'DisallowInlineTabsUnitTest.1.inc':
+                return [
+                    17 => 1,
+                    22 => 1,
+                    23 => 1,
+                    24 => 1,
+                    26 => 1,
+                    32 => 1,
+                    33 => 1,
+                    34 => 1,
+                    35 => 1,
+                    36 => 1,
+                    37 => 1,
+                    41 => 1,
+                    44 => 2,
+                    45 => 2,
+                    49 => 1,
+                    52 => 1,
+                    53 => 1,
+                ];
+
+            case 'DisallowInlineTabsUnitTest.2.inc':
+                return [
+                    2 => 3,
+                    3 => 3,
+                    5 => 1,
+                ];
+
+            case 'DisallowInlineTabsUnitTest.3.inc':
+                return [
+                    2 => 3,
+                    8 => 1,
+                ];
+
+            case 'DisallowInlineTabsUnitTest.4.inc':
+                return [
+                    4  => 1,
+                    9  => 1,
+                    10 => 1,
+                    11 => 1,
+                    13 => 1,
+                    19 => 1,
+                    20 => 1,
+                    21 => 1,
+                    22 => 1,
+                    23 => 1,
+                    24 => 1,
+                    25 => 1,
+                    28 => 1,
+                    31 => 1,
+                    34 => 1,
+                    35 => 1,
+                ];
+
+            case 'DisallowInlineTabsUnitTest.5.inc':
+                return [
+                    4  => 1,
+                    9  => 1,
+                    10 => 1,
+                    11 => 1,
+                    13 => 1,
+                    19 => 1,
+                    20 => 1,
+                    21 => 1,
+                    22 => 1,
+                    23 => 1,
+                    24 => 1,
+                    28 => 1,
+                    31 => 1,
+                    34 => 1,
+                    35 => 1,
+                ];
+
+            default:
+                return [];
+        }
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
New sniff to enforce using spaces for mid-line alignment.

While tab versus space based indentation is a question of preference, for mid-line alignment, spaces should always be preferred, as using tabs will result in inconsistent formatting depending on the dev-user's chosen tab width.

> _This sniff is especially useful for tab-indentation based standards which use the `Generic.Whitespace.DisallowSpaceIndent` sniff to enforce this._
>
> **DO** make sure to set the PHPCS native `tab-width` configuration for the best results.
> ```xml
>    <arg name="tab-width" value="4"/>
> ```
>
> The PHPCS native `Generic.Whitespace.DisallowTabIndent` sniff (used for space-based standards) oversteps its reach and silently does mid-line tab to space replacements as well.
>
> However, the sister-sniff `Generic.Whitespace.DisallowSpaceIndent` leaves mid-line tabs/spaces alone.
> This sniff fills that gap.

Implementation notes:
* Includes a `DummyTokenizer` to allow use of the PHPCS native intelligent tabs to spaces replacement using the default tab-width if none was set.

Includes fixers.
Includes unit tests.
Includes documentation.