### PR TITLE
Travis: fix the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,7 @@ jobs:
 before_install:
   # Speed up build time by disabling Xdebug when its not needed.
   - |
-    if [[ "$TRAVIS_BUILD_STAGE_NAME" != "Coverage" ]]; then
+    if [[ "${TRAVIS_BUILD_STAGE_NAME^}" != "Coverage" ]]; then
       phpenv config-rm xdebug.ini || echo 'No xdebug config.'
     fi
 
@@ -135,7 +135,7 @@ before_install:
   # On stable PHPCS versions, allow for PHP deprecation notices.
   # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
   - |
-    if [[ "$TRAVIS_BUILD_STAGE_NAME" != "Sniff" && $PHPCS_BRANCH != "dev-master" && "$PHPCS_VERSION" != "n/a" ]]; then
+    if [[ "${TRAVIS_BUILD_STAGE_NAME^}" != "Sniff" && $PHPCS_BRANCH != "dev-master" && "$PHPCS_VERSION" != "n/a" ]]; then
       echo 'error_reporting = E_ALL & ~E_DEPRECATED' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
     fi
 
@@ -147,11 +147,11 @@ install:
       composer require --no-update --no-scripts squizlabs/php_codesniffer:${PHPCS_VERSION}
     fi
   - |
-    if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Coverage" ]]; then
+    if [[ "${TRAVIS_BUILD_STAGE_NAME^}" == "Coverage" ]]; then
       composer require --no-update --no-suggest --no-scripts php-coveralls/php-coveralls:${COVERALLS_VERSION}
     fi
   - |
-    if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Sniff" || $PHPCS_VERSION == "n/a" ]]; then
+    if [[ "${TRAVIS_BUILD_STAGE_NAME^}" == "Sniff" || $PHPCS_VERSION == "n/a" ]]; then
       # The sniff stage doesn't run the unit tests, so no need for PHPUnit.
       # The build on nightly also doesn't run the tests (yet).
       composer remove --dev phpunit/phpunit --no-update --no-scripts
@@ -172,7 +172,7 @@ install:
 
 
 before_script:
-  - if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Coverage" ]]; then mkdir -p build/logs; fi
+  - if [[ "${TRAVIS_BUILD_STAGE_NAME^}" == "Coverage" ]]; then mkdir -p build/logs; fi
   - phpenv rehash
 
 
@@ -182,18 +182,18 @@ script:
 
   # Run the unit tests.
   - |
-    if [[ $PHPCS_VERSION != "n/a" && "$TRAVIS_BUILD_STAGE_NAME" != "Coverage" ]]; then
+    if [[ $PHPCS_VERSION != "n/a" && "${TRAVIS_BUILD_STAGE_NAME^}" != "Coverage" ]]; then
       composer test
-    elif [[ $PHPCS_VERSION != "n/a" && "$TRAVIS_BUILD_STAGE_NAME" == "Coverage" ]]; then
+    elif [[ $PHPCS_VERSION != "n/a" && "${TRAVIS_BUILD_STAGE_NAME^}" == "Coverage" ]]; then
       composer coverage
     fi
 
 after_success:
   - |
-    if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Coverage" && $COVERALLS_VERSION == "^1.0" ]]; then
+    if [[ "${TRAVIS_BUILD_STAGE_NAME^}" == "Coverage" && $COVERALLS_VERSION == "^1.0" ]]; then
       php vendor/bin/coveralls -v -x build/logs/clover.xml
     fi
   - |
-    if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Coverage" && $COVERALLS_VERSION == "^2.0" ]]; then
+    if [[ "${TRAVIS_BUILD_STAGE_NAME^}" == "Coverage" && $COVERALLS_VERSION == "^2.0" ]]; then
       php vendor/bin/php-coveralls -v -x build/logs/clover.xml
     fi


### PR DESCRIPTION
The Travis docs say that `$TRAVIS_BUILD_STAGE_NAME` is in "proper case" form:

> TRAVIS_BUILD_STAGE_NAME: The build stage in capitalized form, e.g. Test or Deploy. If a build does not use build stages, this variable is empty ("").

However, it looks like they made an (undocumented) change (probably a bug in their script handling) which means that the `$TRAVIS_BUILD_STAGE_NAME` name is now in the case as given, which in this case is _lowercase_.

This means that some of the comparisons are failing and the wrong things are executed for certain builds.

As I expect this to be a bug in Travis, I'm not changing the case for the comparisons at this time.
Instead I'm fixing this by inline fixing the case of the variable for the comparisons.

Refs:
* https://docs.travis-ci.com/user/environment-variables#default-environment-variables (near the bottom of the list)