### PR TITLE
DisallowInlineTabs: bug fix / indentation vs annotation

### DIFF
--- a/Universal/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
+++ b/Universal/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
@@ -12,6 +12,7 @@ namespace PHPCSExtra\Universal\Sniffs\WhiteSpace;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSExtra\Universal\Helpers\DummyTokenizer;
 use PHPCSUtils\BackCompat\Helper;
 
@@ -117,9 +118,11 @@ class DisallowInlineTabsSniff implements Sniff
             $origContent = $token['orig_content'];
 
             $multiLineComment = false;
-            if ($tokens[$i]['code'] === \T_COMMENT
+            if (($tokens[$i]['code'] === \T_COMMENT
+                || isset(Tokens::$phpcsCommentTokens[$tokens[$i]['code']]))
                  && $tokens[$i]['column'] === 1
-                 && $tokens[($i - 1)]['code'] === \T_COMMENT
+                 && ($tokens[($i - 1)]['code'] === \T_COMMENT
+                 || isset(Tokens::$phpcsCommentTokens[$tokens[($i - 1)]['code']]))
             ) {
                 $multiLineComment = true;
             }

--- a/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.1.inc
+++ b/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.1.inc
@@ -51,3 +51,11 @@ $aaaaaaaa = true;
 
 		// Tab indented		and inline tabs.
 		// Tab indented		and inline tabs.
+
+		/*
+		 * @phpcs:ignore Stnd.Cat.SniffName -- testing mixed comment + annotations don't trigger on indentation.
+		 */
+
+		// Tab indented, no tabs.
+		// phpcs:ignore Stnd.Cat.SniffName -- testing mixed comment + annotations don't trigger on indentation.
+		// Tab indented, no tabs.

--- a/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.1.inc.fixed
+++ b/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.1.inc.fixed
@@ -51,3 +51,11 @@ $aaaaaaaa = true;
 
 		// Tab indented     and inline tabs.
 		// Tab indented     and inline tabs.
+
+		/*
+		 * @phpcs:ignore Stnd.Cat.SniffName -- testing mixed comment + annotations don't trigger on indentation.
+		 */
+
+		// Tab indented, no tabs.
+		// phpcs:ignore Stnd.Cat.SniffName -- testing mixed comment + annotations don't trigger on indentation.
+		// Tab indented, no tabs.


### PR DESCRIPTION
When PHPCS annotations are part of a comment, they get a different token, which led to the sniff triggering on the indentation of the comment line following the annotation.

Fixed now.

Includes unit test safeguarding the fix.