### PR TITLE
New `Universal.UseStatements.NoLeadingBackslash` sniff

### DIFF
--- a/Universal/Docs/UseStatements/NoLeadingBackslashStandard.xml
+++ b/Universal/Docs/UseStatements/NoLeadingBackslashStandard.xml
@@ -1,0 +1,19 @@
+<documentation title="No Leading Backslash">
+    <standard>
+    <![CDATA[
+    Import `use` statements must never begin with a leading backslash as they should always be fully qualified.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Import use statement without leading backslash.">
+        <![CDATA[
+<em>use Package</em>\ClassName;
+        ]]>
+        </code>
+        <code title="Invalid: Import use statement with leading backslash.">
+        <![CDATA[
+use <em>\</em>Package\ClassName;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/UseStatements/NoLeadingBackslashSniff.php
+++ b/Universal/Sniffs/UseStatements/NoLeadingBackslashSniff.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\UseStatements;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\UseStatements;
+
+/**
+ * Verifies that names being imported in import use statements do not start with a leading backslash.
+ *
+ * This sniff handles all types of import use statements supported by PHP, in contrast to any
+ * of the other sniffs for the same in, for instance, the PSR12 or the Slevomat standard,
+ * all of which are incomplete.
+ *
+ * @since 1.0.0
+ */
+class NoLeadingBackslashSniff implements Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [\T_USE];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (UseStatements::isImportUse($phpcsFile, $stackPtr) === false) {
+            // Trait or closure use statement.
+            return;
+        }
+
+        $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG, \T_OPEN_USE_GROUP], ($stackPtr + 1));
+        if ($endOfStatement === false) {
+            // Live coding or parse error.
+            return;
+        }
+
+        $tokens  = $phpcsFile->getTokens();
+        $current = $stackPtr;
+
+        do {
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($current + 1), $endOfStatement, true);
+            if ($nextNonEmpty === false) {
+                // Reached the end of the statement.
+                return;
+            }
+
+            // Skip past 'function'/'const' keyword.
+            $contentLC = \strtolower($tokens[$nextNonEmpty]['content']);
+            if ($tokens[$nextNonEmpty]['code'] === \T_STRING
+                && ($contentLC === 'function' || $contentLC === 'const')
+            ) {
+                $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonEmpty + 1), $endOfStatement, true);
+                if ($nextNonEmpty === false) {
+                    // Reached the end of the statement.
+                    return;
+                }
+            }
+
+            if ($tokens[$nextNonEmpty]['code'] === \T_NS_SEPARATOR) {
+                $error = 'An import use statement should never start with a leading backslash';
+                $fix   = $phpcsFile->addFixableError($error, $nextNonEmpty, 'LeadingBackslashFound');
+
+                if ($fix === true) {
+                    if ($tokens[$nextNonEmpty - 1]['code'] !== \T_WHITESPACE) {
+                        $phpcsFile->fixer->replaceToken($nextNonEmpty, ' ');
+                    } else {
+                        $phpcsFile->fixer->replaceToken($nextNonEmpty, '');
+                    }
+                }
+            }
+
+            // Move the stackPtr forward to the next part of the use statement, if any.
+            $current = $phpcsFile->findNext(\T_COMMA, ($current + 1), $endOfStatement);
+        } while ($current !== false);
+    }
+}

--- a/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.1.inc
+++ b/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.1.inc
@@ -1,0 +1,32 @@
+<?php
+
+// Import use statements.
+use Util\MyClass;
+use \Util\MyOtherClass;
+
+use function Util\functionA;
+use FUNCTION \Util\functionB as functionC;
+
+use const Util\MyClass\CONSTANT_X;
+use Const\Util\MyClass\CONSTANT_Y;
+
+use Vendor\Foo\ClassA as ClassABC,
+    /*comment*/ \Vendor\Bar\InterfaceB,
+    Vendor\Baz\ClassC as C_Class,
+    \Vendor\Baz\ClassD ?>
+
+<?php
+
+use \some\namespacing\{
+    \SomeClassA, // Intentional parse error. Should be ignored.
+    function \another\level\function_name as my_function, // Intentional parse error. Should be ignored.
+    const \another\level\CONSTANT_NAME, // Intentional parse error. Should be ignored.
+};
+
+// Not the use statements we're looking for.
+class ClassUsingTrait {
+    use \SomeTrait;
+    use AnotherTrait;
+}
+
+$closure = function($param) use ($var) {};

--- a/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.2.inc
+++ b/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.2.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error test.
+use \ClassName

--- a/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.3.inc
+++ b/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.3.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error test.
+use     ;

--- a/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.4.inc
+++ b/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.4.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error test.
+use function /* function name tbd */;

--- a/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.inc.fixed
+++ b/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.inc.fixed
@@ -1,0 +1,32 @@
+<?php
+
+// Import use statements.
+use Util\MyClass;
+use Util\MyOtherClass;
+
+use function Util\functionA;
+use FUNCTION Util\functionB as functionC;
+
+use const Util\MyClass\CONSTANT_X;
+use Const Util\MyClass\CONSTANT_Y;
+
+use Vendor\Foo\ClassA as ClassABC,
+    /*comment*/ Vendor\Bar\InterfaceB,
+    Vendor\Baz\ClassC as C_Class,
+    Vendor\Baz\ClassD ?>
+
+<?php
+
+use some\namespacing\{
+    \SomeClassA, // Intentional parse error. Should be ignored.
+    function \another\level\function_name as my_function, // Intentional parse error. Should be ignored.
+    const \another\level\CONSTANT_NAME, // Intentional parse error. Should be ignored.
+};
+
+// Not the use statements we're looking for.
+class ClassUsingTrait {
+    use \SomeTrait;
+    use AnotherTrait;
+}
+
+$closure = function($param) use ($var) {};

--- a/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.php
+++ b/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\UseStatements;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the NoLeadingBackslash sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\UseStatements\NoLeadingBackslashSniff
+ *
+ * @since 1.0.0
+ */
+class NoLeadingBackslashUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @param string $testFile The name of the file being tested.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList($testFile = '')
+    {
+        switch ($testFile) {
+            case 'NoLeadingBackslashUnitTest.1.inc':
+                return [
+                    5  => 1,
+                    8  => 1,
+                    11 => 1,
+                    14 => 1,
+                    16 => 1,
+                    20 => 1,
+                ];
+
+            default:
+                return [];
+        }
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
New sniff to verify that a name being imported in an import use statement does not start with a leading backslash.

Names in import `use` statements should always be fully qualified, so a leading backslash is not needed and it is strongly recommended not to use one.

This sniff handles all types of import use statements supported by PHP, in contrast to any of the other sniffs for the same in, for instance, the PSR12 or the Slevomat standard, all of which are incomplete.

Includes fixer.
Includes unit tests.
Includes documentation.