### PR TITLE
New `Universal.Operators.StrictComparisons` sniff

### DIFF
--- a/Universal/Docs/Operators/StrictComparisonsStandard.xml
+++ b/Universal/Docs/Operators/StrictComparisonsStandard.xml
@@ -1,0 +1,25 @@
+<documentation title="Strict Comparisons">
+    <standard>
+    <![CDATA[
+    Using loose comparisons is not allowed.
+
+    Loose comparisons will type juggle the values being compared, which often results in bugs.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Using strict comparisons.">
+        <![CDATA[
+if ($var <em>===</em> 'text') {}
+
+if ($var <em>!==</em> true) {}
+        ]]>
+        </code>
+        <code title="Invalid: Using loose comparisons.">
+        <![CDATA[
+if ($var <em>==</em> 'text') {}
+
+if ($var <em>!=</em> true) {}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/Operators/StrictComparisonsSniff.php
+++ b/Universal/Sniffs/Operators/StrictComparisonsSniff.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\Operators;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Enforce the use of strict comparisons.
+ *
+ * Warning: the auto-fixer for this sniff _may_ cause bugs in applications and should be used with care!
+ * This is considered a _risky_ fix.
+ *
+ * @since 1.0.0
+ */
+class StrictComparisonsSniff implements Sniff
+{
+
+    /**
+     * The tokens this sniff targets with error code and replacements.
+     *
+     * @since 1.0.0
+     *
+     * @var array
+     */
+    private $targetTokenInfo = [
+        \T_IS_EQUAL     => [
+            'error_code'  => 'LooseEqual',
+            'replacement' => '===',
+        ],
+        \T_IS_NOT_EQUAL => [
+            'error_code'  => 'LooseNotEqual',
+            'replacement' => '!==',
+        ],
+    ];
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return \array_keys($this->targetTokenInfo);
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens    = $phpcsFile->getTokens();
+        $tokenCode = $tokens[$stackPtr]['code'];
+
+        $error = 'Loose comparisons are not allowed. Expected: "%s"; Found: "%s"';
+        $data  = [
+            $this->targetTokenInfo[$tokenCode]['replacement'],
+            $tokens[ $stackPtr ]['content'],
+        ];
+
+        $fix = $phpcsFile->addFixableError($error, $stackPtr, $this->targetTokenInfo[$tokenCode]['error_code'], $data);
+        if ($fix === false) {
+            return;
+        }
+
+        $phpcsFile->fixer->replaceToken($stackPtr, $this->targetTokenInfo[$tokenCode]['replacement']);
+    }
+}

--- a/Universal/Tests/Operators/StrictComparisonsUnitTest.inc
+++ b/Universal/Tests/Operators/StrictComparisonsUnitTest.inc
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This is ok.
+ */
+if ( true === $true ) {
+    echo 'True';
+} elseif ($true!==false) {
+    echo 'False';
+}
+
+/*
+ * Loose comparisons.
+ */
+if ( true != $true ) {
+    echo 'True';
+} elseif ($true <> true) {
+    echo 'False';
+}
+
+if ($true==true) {
+    echo 'True';
+}

--- a/Universal/Tests/Operators/StrictComparisonsUnitTest.inc.fixed
+++ b/Universal/Tests/Operators/StrictComparisonsUnitTest.inc.fixed
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This is ok.
+ */
+if ( true === $true ) {
+    echo 'True';
+} elseif ($true!==false) {
+    echo 'False';
+}
+
+/*
+ * Loose comparisons.
+ */
+if ( true !== $true ) {
+    echo 'True';
+} elseif ($true !== true) {
+    echo 'False';
+}
+
+if ($true===true) {
+    echo 'True';
+}

--- a/Universal/Tests/Operators/StrictComparisonsUnitTest.php
+++ b/Universal/Tests/Operators/StrictComparisonsUnitTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\Operators;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the StrictComparisons sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\Operators\StrictComparisonsSniff
+ *
+ * @since 1.0.0
+ */
+class StrictComparisonsUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [
+            15 => 1,
+            17 => 1,
+            21 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
New sniff to enforce the use of strict comparisons as loose type comparisons will type juggle the values being compared, which often results in bugs.

Warning: the auto-fixer for this sniff _may_ cause bugs in applications and should be used with care!
This is considered a _risky_ fixer.

Includes fixer.
Includes unit tests.
Includes documentation.