### PR TITLE
New `Universal.Namespaces.DisallowDeclarationWithoutName` sniff

### DIFF
--- a/Universal/Docs/Namespaces/DisallowDeclarationWithoutNameStandard.xml
+++ b/Universal/Docs/Namespaces/DisallowDeclarationWithoutNameStandard.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<documentation title="Disallow Namespace Declaration Without Name">
+    <standard>
+    <![CDATA[
+    Namespace declarations without a namespace name are not allowed.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Named namespace declaration.">
+        <![CDATA[
+namespace <em>Vendor\Name</em> {
+}
+        ]]>
+        </code>
+        <code title="Invalid: Namespace declaration without a name (=global namespace).">
+        <![CDATA[
+namespace<em> </em>{
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/Namespaces/DisallowDeclarationWithoutNameSniff.php
+++ b/Universal/Sniffs/Namespaces/DisallowDeclarationWithoutNameSniff.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\Namespaces;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\Namespaces;
+
+/**
+ * Forbids the use of namespace declarations without a namespace name.
+ *
+ * @since 1.0.0
+ */
+class DisallowDeclarationWithoutNameSniff implements Sniff
+{
+
+    /**
+     * Name of the metric.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const METRIC_NAME = 'Namespace declaration declares a name';
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [\T_NAMESPACE];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $name = Namespaces::getDeclaredName($phpcsFile, $stackPtr);
+        if ($name === false) {
+            // Use of the namespace keyword as an operator or live coding/parse error.
+            return;
+        }
+
+        if ($name !== '') {
+            // Named namespace.
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'yes');
+
+            return;
+        }
+
+        $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'no');
+
+        // Namespace declaration without namespace name (= global namespace).
+        $phpcsFile->addError(
+            'Namespace declarations without a namespace name are not allowed.',
+            $stackPtr,
+            'Forbidden'
+        );
+    }
+}

--- a/Universal/Tests/Namespaces/DisallowDeclarationWithoutNameUnitTest.1.inc
+++ b/Universal/Tests/Namespaces/DisallowDeclarationWithoutNameUnitTest.1.inc
@@ -1,0 +1,11 @@
+<?php
+
+/*
+ * Valid namespace declaration(s).
+ */
+namespace Vendor\ValidDeclaration;
+
+echo namespace\ClassName::$property; // Ok, not namespace declaration.
+
+// Intentional parse error. This has to be the last test in the file.
+namespace

--- a/Universal/Tests/Namespaces/DisallowDeclarationWithoutNameUnitTest.2.inc
+++ b/Universal/Tests/Namespaces/DisallowDeclarationWithoutNameUnitTest.2.inc
@@ -1,0 +1,11 @@
+<?php
+
+/*
+ * Invalid (no name) namespace declarations.
+ */
+namespace {}
+
+namespace /* some comment */ {}
+
+// Intentional parse error. Ignore. Non-named namespace declarations must have curly braces.
+namespace /* some comment */;

--- a/Universal/Tests/Namespaces/DisallowDeclarationWithoutNameUnitTest.php
+++ b/Universal/Tests/Namespaces/DisallowDeclarationWithoutNameUnitTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\Namespaces;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the DisallowDeclarationWithoutName sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\Namespaces\DisallowDeclarationWithoutNameSniff
+ *
+ * @since 1.0.0
+ */
+class DisallowDeclarationWithoutNameUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @param string $testFile The name of the file being tested.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList($testFile = '')
+    {
+        switch ($testFile) {
+            case 'DisallowDeclarationWithoutNameUnitTest.2.inc':
+                return [
+                    6 => 1,
+                    8 => 1,
+                ];
+
+            default:
+                return [];
+        }
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
New sniff to disallow the use of namespace declarations without a namespace name.

Declaring a namespace declaration without a namespace name is only possible using the curly brace syntax and makes it so the code within the braces is considered to be in the global namespace.

A namespace declaration without curly braces without a name would be a parse error and will be ignored for the purposes of this sniff.

Includes unit tests.
Includes documentation.
Includes metrics.