### PR TITLE
New `Universal.Operators.DisallowLogicalAndOr` sniff

### DIFF
--- a/Universal/Docs/Operators/DisallowLogicalAndOrStandard.xml
+++ b/Universal/Docs/Operators/DisallowLogicalAndOrStandard.xml
@@ -1,0 +1,26 @@
+<documentation title="Disallow Logical And Or">
+    <standard>
+    <![CDATA[
+    Using the logical "and" and "or" operators is not allowed.
+
+    The logical "and" and "or" operators have a significantly lower operator precedence than their boolean "&&" and "||" counter-parts, which often leads to unexpected bugs.
+    The boolean "&&" and "||" operators are nearly always the better choice.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Using boolean operators.">
+        <![CDATA[
+if (isset($var) <em>&&</em> $var > 10) {}
+
+if (empty($var) <em>||</em> $var < 0) {}
+        ]]>
+        </code>
+        <code title="Invalid: Using logical operators.">
+        <![CDATA[
+if (isset($var) <em>and</em> $var > 10) {}
+
+if (empty($var) <em>or</em> $var < 0) {}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/Operators/DisallowLogicalAndOrSniff.php
+++ b/Universal/Sniffs/Operators/DisallowLogicalAndOrSniff.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\Operators;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Enforce the use of the boolean `&&` and `||` operators instead of the logical `and`/`or` operators.
+ *
+ * Note: as the {@link https://www.php.net/manual/en/language.operators.precedence.php operator precedence}
+ * of the logical operators is significantly lower than the operator precedence of boolean operators,
+ * this sniff does not contain an auto-fixer.
+ *
+ * @since 1.0.0
+ */
+class DisallowLogicalAndOrSniff implements Sniff
+{
+
+    /**
+     * The tokens this sniff records metrics for.
+     *
+     * @since 1.0.0
+     *
+     * @var array
+     */
+    private $metricType = [
+        \T_LOGICAL_AND => 'logical (and/or)',
+        \T_LOGICAL_OR  => 'logical (and/or)',
+        \T_BOOLEAN_AND => 'boolean (&&/||)',
+        \T_BOOLEAN_OR  => 'boolean (&&/||)',
+    ];
+
+    /**
+     * The tokens this sniff targets with error code and replacements.
+     *
+     * @since 1.0.0
+     *
+     * @var array
+     */
+    private $targetTokenInfo = [
+        \T_LOGICAL_AND => [
+            'error_code'  => 'LogicalAnd',
+            'replacement' => '&&',
+        ],
+        \T_LOGICAL_OR  => [
+            'error_code'  => 'LogicalOr',
+            'replacement' => '||',
+        ],
+    ];
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return \array_keys($this->metricType);
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens    = $phpcsFile->getTokens();
+        $tokenCode = $tokens[$stackPtr]['code'];
+
+        $phpcsFile->recordMetric($stackPtr, 'Type of and/or operator used', $this->metricType[$tokenCode]);
+
+        if (isset($this->targetTokenInfo[$tokenCode]) === false) {
+            // Already using boolean operator.
+            return;
+        }
+
+        $error = 'Using logical operators is not allowed. Expected: "%s"; Found: "%s"';
+        $data  = [
+            $this->targetTokenInfo[$tokenCode]['replacement'],
+            $tokens[ $stackPtr ]['content'],
+        ];
+
+        $phpcsFile->addError($error, $stackPtr, $this->targetTokenInfo[$tokenCode]['error_code'], $data);
+    }
+}

--- a/Universal/Tests/Operators/DisallowLogicalAndOrUnitTest.inc
+++ b/Universal/Tests/Operators/DisallowLogicalAndOrUnitTest.inc
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This is ok.
+ */
+if ( true && $true ) {
+    echo 'True';
+} elseif ($true || false) {
+    echo 'False';
+}
+
+/*
+ * Using Logical operators
+ */
+if ( true and $true ) {
+    echo 'True';
+} elseif ($true or true) {
+    echo 'False';
+}

--- a/Universal/Tests/Operators/DisallowLogicalAndOrUnitTest.php
+++ b/Universal/Tests/Operators/DisallowLogicalAndOrUnitTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\Operators;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the DisallowLogicalAndOr sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\Operators\DisallowLogicalAndOrSniff
+ *
+ * @since 1.0.0
+ */
+class DisallowLogicalAndOrUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [
+            15 => 1,
+            17 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
New sniff to enforce the use of the boolean `&&` and `||` operators instead of the logical `and`/`or` operators.

Note: as the [operator precedence](https://www.php.net/manual/en/language.operators.precedence.php) of the logical operators is significantly lower than the operator precedence of boolean operators, this sniff does not contain an auto-fixer.

Includes unit tests.
Includes documentation.
Includes metrics.