### PR TITLE
New `Universal.UseStatements.LowercaseFunctionConst` sniff

### DIFF
--- a/Universal/Docs/UseStatements/LowercaseFunctionConstStandard.xml
+++ b/Universal/Docs/UseStatements/LowercaseFunctionConstStandard.xml
@@ -1,0 +1,21 @@
+<documentation title="Lowercase Function Const">
+    <standard>
+    <![CDATA[
+    `function` and `const` keywords in import `use` statements should be in lowercase.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Lowercase keywords.">
+        <![CDATA[
+use <em>function</em> strpos;
+use <em>const</em> PHP_EOL;
+        ]]>
+        </code>
+        <code title="Invalid: Non-lowercase keywords.">
+        <![CDATA[
+use <em>Function</em> strpos;
+use <em>CONST</em> PHP_EOL;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/UseStatements/LowercaseFunctionConstSniff.php
+++ b/Universal/Sniffs/UseStatements/LowercaseFunctionConstSniff.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\UseStatements;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\UseStatements;
+
+/**
+ * Verify that the `function` and `const` keyword in import `use` statements are lowercase.
+ *
+ * Companion sniff to the upstream `Generic.PHP.LowerCaseKeyword` sniff which doesn't cover
+ * these keywords as they are not tokenized as `T_FUNCTION`/`T_CONST`, but as `T_STRING`.
+ *
+ * @since 1.0.0
+ */
+class LowercaseFunctionConstSniff implements Sniff
+{
+
+    /**
+     * Name of the metric.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const METRIC_NAME = 'Import use statement %s keyword case';
+
+    /**
+     * A list of keywords that can follow use statements.
+     *
+     * @since 1.0.0
+     *
+     * @var array(string => string)
+     */
+    protected $keywords = [
+        'const'    => true,
+        'function' => true,
+    ];
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [\T_USE];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (UseStatements::isImportUse($phpcsFile, $stackPtr) === false) {
+            // Trait or closure use statement.
+            return;
+        }
+
+        $tokens       = $phpcsFile->getTokens();
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($nextNonEmpty === false) {
+            // Live coding or parse error.
+            return;
+        }
+
+        if (isset($this->keywords[\strtolower($tokens[$nextNonEmpty]['content'])]) === true) {
+            // Keyword found at start of statement, applies to whole statement.
+            $this->processKeyword($phpcsFile, $nextNonEmpty, $tokens[$nextNonEmpty]['content']);
+            return;
+        }
+
+        // This may still be a group use statement with function/const substatements.
+        $openGroup = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG, \T_OPEN_USE_GROUP], ($stackPtr + 1));
+        if ($openGroup === false || $tokens[$openGroup]['code'] !== \T_OPEN_USE_GROUP) {
+            // Not a group use statement.
+            return;
+        }
+
+        $closeGroup = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG, \T_CLOSE_USE_GROUP], ($openGroup + 1));
+        if ($closeGroup === false || $tokens[$closeGroup]['code'] !== \T_CLOSE_USE_GROUP) {
+            // Live coding or parse error.
+            return;
+        }
+
+        $current = $openGroup;
+        do {
+            $current = $phpcsFile->findNext(Tokens::$emptyTokens, ($current + 1), $closeGroup, true);
+            if ($current === false) {
+                return;
+            }
+
+            if (isset($this->keywords[\strtolower($tokens[$current]['content'])]) === true) {
+                $this->processKeyword($phpcsFile, $current, $tokens[$current]['content']);
+            }
+
+            // We're within the use group, so find the next comma.
+            $current = $phpcsFile->findNext(\T_COMMA, ($current + 1), $closeGroup);
+        } while ($current !== false);
+    }
+
+    /**
+     * Processes a found keyword.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the keyword in the token stack.
+     * @param string                      $content   The keyword as found.
+     *
+     * @return void
+     */
+    public function processKeyword(File $phpcsFile, $stackPtr, $content)
+    {
+        $contentLC  = \strtolower($content);
+        $metricName = \sprintf(self::METRIC_NAME, $contentLC);
+        if ($contentLC === $content) {
+            // Already lowercase. Bow out.
+            $phpcsFile->recordMetric($stackPtr, $metricName, 'lowercase');
+            return;
+        }
+
+        if (\strtoupper($content) === $content) {
+            $phpcsFile->recordMetric($stackPtr, $metricName, 'uppercase');
+        } else {
+            $phpcsFile->recordMetric($stackPtr, $metricName, 'mixed case');
+        }
+
+        $error = 'The "%s" keyword when used in an import use statements must be lowercase.';
+        $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NotLowercase', [$contentLC]);
+
+        if ($fix === true) {
+            $phpcsFile->fixer->replaceToken($stackPtr, $contentLC);
+        }
+    }
+}

--- a/Universal/Tests/UseStatements/LowercaseFunctionConstUnitTest.inc
+++ b/Universal/Tests/UseStatements/LowercaseFunctionConstUnitTest.inc
@@ -1,0 +1,32 @@
+<?php
+
+// Class import use statements.
+use Util\MyClass;
+use \Util\MyOtherClass;
+
+// Function/const import use statements.
+use function Util\functionA;
+use FuncTion\Util\functionB;
+use FUNCTION \Util\functionC;
+
+use const Util\MyClass\CONSTANT_X;
+use Const\Util\MyClass\CONSTANT_Y;
+use CONST Util\MyClass\CONSTANT_Z;
+
+use \some\namespacing\{
+    Function another\level\function_name,
+    SomeClassA,
+    Const another\level\CONSTANT_NAME,
+};
+
+// Not the use statements we're looking for.
+class ClassUsingTrait {
+    use \SomeTrait;
+    use AnotherTrait;
+}
+
+$closure = function($param) use ($var) {};
+
+// Not the const/function keywords we're looking for.
+const ABC = false;
+function Foo() {}

--- a/Universal/Tests/UseStatements/LowercaseFunctionConstUnitTest.inc.fixed
+++ b/Universal/Tests/UseStatements/LowercaseFunctionConstUnitTest.inc.fixed
@@ -1,0 +1,32 @@
+<?php
+
+// Class import use statements.
+use Util\MyClass;
+use \Util\MyOtherClass;
+
+// Function/const import use statements.
+use function Util\functionA;
+use function\Util\functionB;
+use function \Util\functionC;
+
+use const Util\MyClass\CONSTANT_X;
+use const\Util\MyClass\CONSTANT_Y;
+use const Util\MyClass\CONSTANT_Z;
+
+use \some\namespacing\{
+    function another\level\function_name,
+    SomeClassA,
+    const another\level\CONSTANT_NAME,
+};
+
+// Not the use statements we're looking for.
+class ClassUsingTrait {
+    use \SomeTrait;
+    use AnotherTrait;
+}
+
+$closure = function($param) use ($var) {};
+
+// Not the const/function keywords we're looking for.
+const ABC = false;
+function Foo() {}

--- a/Universal/Tests/UseStatements/LowercaseFunctionConstUnitTest.php
+++ b/Universal/Tests/UseStatements/LowercaseFunctionConstUnitTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\UseStatements;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the LowercaseFunctionConst sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\UseStatements\LowercaseFunctionConstSniff
+ *
+ * @since 1.0.0
+ */
+class LowercaseFunctionConstUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [
+            9  => 1,
+            10 => 1,
+            13 => 1,
+            14 => 1,
+            17 => 1,
+            19 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
New sniff to verify that `function` and `const` keywords when used in an import `use` statement are always lowercase.

Companion sniff to the upstream `Generic.PHP.LowerCaseKeyword` sniff which doesn't cover these keywords as they are not tokenized as `T_FUNCTION`/`T_CONST`, but as `T_STRING`.

Includes fixer.
Includes unit tests.
Includes documentation.
Includes metrics.

Related:
* squizlabs/PHP_CodeSniffer#2963