### PR TITLE
DisallowShort[Array|List]Syntax: register fewer tags

### DIFF
--- a/Universal/Sniffs/Arrays/DisallowShortArraySyntaxSniff.php
+++ b/Universal/Sniffs/Arrays/DisallowShortArraySyntaxSniff.php
@@ -39,8 +39,7 @@ class DisallowShortArraySyntaxSniff implements Sniff
     public function register()
     {
         return [
-            \T_OPEN_SHORT_ARRAY,
-            \T_OPEN_SQUARE_BRACKET,
+            \T_OPEN_SHORT_ARRAY
         ];
     }
 

--- a/Universal/Sniffs/Lists/DisallowShortListSyntaxSniff.php
+++ b/Universal/Sniffs/Lists/DisallowShortListSyntaxSniff.php
@@ -32,8 +32,7 @@ class DisallowShortListSyntaxSniff implements Sniff
     public function register()
     {
         return [
-            \T_OPEN_SHORT_ARRAY,
-            \T_OPEN_SQUARE_BRACKET, // BC for PHPCS < 3.3.0.
+            \T_OPEN_SHORT_ARRAY
         ];
     }
 


### PR DESCRIPTION
The minimum supported version for this standard is PHPCS 3.3.1, while the bugs which necessitate sniffing for `T_OPEN_SQUARE_BRACKET` are from before that time, so just sniffing for `T_OPEN_SHORT_ARRAY` should work just fine.