### PR TITLE
Composer: update PHPCS Composer plugin dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require" : {
         "php" : ">=5.4",
         "squizlabs/php_codesniffer" : "^3.3.1",
-        "dealerdirect/phpcodesniffer-composer-installer" : "^0.4.1 || ^0.5 || ^0.6",
+        "dealerdirect/phpcodesniffer-composer-installer" : "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
         "phpcsstandards/phpcsutils" : "^1.0 || dev-develop"
     },
     "require-dev" : {


### PR DESCRIPTION
The DealerDirect Composer plugin has just released version `0.7.0`.
As Composer treats minors < 1.0 as majors, updating to this version requires an update to the `composer.json` requirements.

> For pre-1.0 versions it also acts with safety in mind and treats `^0.3` as `>=0.3.0 <0.4.0`.

Refs:
* https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases/tag/v0.7.0
* https://getcomposer.org/doc/articles/versions.md#caret-version-range-