### PR TITLE
QA/CI: change the way the CS check is run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ env:
 # See: https://docs.travis-ci.com/user/conditions-v1
 stages:
   - name: sniff
+  - name: validate
   - name: quicktest
     if: type = push AND branch NOT IN (master, develop)
   - name: test
@@ -46,6 +47,14 @@ jobs:
     #### SNIFF STAGE ####
     - stage: sniff
       php: 7.4
+      install: skip
+      before_script: skip
+      script:
+        # Check the code style of the code base.
+        - composer travis-checkcs
+
+    - stage: validate
+      php: 7.4
       env: PHPCS_VERSION="dev-master"
       addons:
         apt:
@@ -55,9 +64,6 @@ jobs:
         # Validate the composer.json file.
         # @link https://getcomposer.org/doc/03-cli.md#validate
         - composer validate --no-check-all --strict
-
-        # Check the code style of the code base.
-        - composer travis-checkcs
 
         # Validate the xml files.
         # @link http://xmlsoft.org/xmllint.html
@@ -151,8 +157,7 @@ install:
       composer require --no-update --no-suggest --no-scripts php-coveralls/php-coveralls:${COVERALLS_VERSION}
     fi
   - |
-    if [[ "${TRAVIS_BUILD_STAGE_NAME^}" == "Sniff" || $PHPCS_VERSION == "n/a" ]]; then
-      # The sniff stage doesn't run the unit tests, so no need for PHPUnit.
+    if [[ $PHPCS_VERSION == "n/a" ]]; then
       # The build on nightly also doesn't run the tests (yet).
       composer remove --dev phpunit/phpunit --no-update --no-scripts
     fi

--- a/composer.json
+++ b/composer.json
@@ -41,24 +41,24 @@
             "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
         ],
         "install-devcs": [
-            "composer require --dev phpcsstandards/phpcsdevcs:\"^1.0\" --no-suggest"
+            "composer global require --dev phpcsstandards/phpcsdevcs:\"^1.0\" --no-suggest"
         ],
         "remove-devcs": [
-            "composer remove --dev phpcsstandards/phpcsdevcs"
+            "composer global remove --dev phpcsstandards/phpcsdevcs"
         ],
         "checkcs": [
             "@install-devcs",
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
+            "phpcs",
             "@remove-devcs"
         ],
         "fixcs": [
             "@install-devcs",
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf",
+            "phpcbf",
             "@remove-devcs"
         ],
         "travis-checkcs": [
             "@install-devcs",
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
+            "/home/travis/.composer/vendor/bin/phpcs"
         ],
         "check-complete": [
             "@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./NormalizedArrays ./Universal"


### PR DESCRIPTION
Use `composer global` instead of a project local install for the CS check as PHPCSExtra will become a dependency of PHPCSDevCS and it would otherwise create a conflicting, circular dependency.

To make this simpler, split the old "Sniff" stage into "Sniff" and "Validate" and skip the `install` and `before_script` steps for the "Sniff" stage.