### PR TITLE
New `Universal.Constants.UppercaseMagicConstants` sniff

### DIFF
--- a/Universal/Docs/Constants/UppercaseMagicConstantsStandard.xml
+++ b/Universal/Docs/Constants/UppercaseMagicConstantsStandard.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<documentation title="Uppercase Magic Constants">
+    <standard>
+    <![CDATA[
+    The PHP native `__...__` magic constant should be in uppercase.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: using uppercase.">
+        <![CDATA[
+echo <em>__LINE__</em>;
+include <em>__DIR__</em> . '/file.php';
+        ]]>
+        </code>
+        <code title="Invalid: using lowercase or mixed case.">
+        <![CDATA[
+echo <em>__NameSpace__</em>;
+include dirname(<em>__file__</em>) . '/file.php';
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/Constants/UppercaseMagicConstantsSniff.php
+++ b/Universal/Sniffs/Constants/UppercaseMagicConstantsSniff.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\Constants;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHPCSUtils\Tokens\Collections;
+
+/**
+ * Verifies that PHP native `__...__` magic constants are in uppercase when used.
+ *
+ * @link https://www.php.net/manual/en/language.constants.predefined.php
+ *
+ * @since 1.0.0
+ */
+class UppercaseMagicConstantsSniff implements Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return Collections::$magicConstants;
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens    = $phpcsFile->getTokens();
+        $content   = $tokens[$stackPtr]['content'];
+        $contentUC = \strtoupper($content);
+        if ($contentUC === $content) {
+            $phpcsFile->recordMetric($stackPtr, 'Magic constant case', 'uppercase');
+            return;
+        }
+
+        $error     = 'Magic constants should be in uppercase. Expected: %s; found: %s';
+        $errorCode = '';
+        $data      = [
+            $contentUC,
+            $content,
+        ];
+
+        if (\strtolower($content) === $content) {
+            $errorCode = 'Lowercase';
+            $phpcsFile->recordMetric($stackPtr, 'Magic constant case', 'lowercase');
+        } else {
+            $errorCode = 'Mixedcase';
+            $phpcsFile->recordMetric($stackPtr, 'Magic constant case', 'mixed case');
+        }
+
+        $fix = $phpcsFile->addFixableError($error, $stackPtr, $errorCode, $data);
+        if ($fix === true) {
+            $phpcsFile->fixer->replaceToken($stackPtr, $contentUC);
+        }
+    }
+}

--- a/Universal/Tests/Constants/UppercaseMagicConstantsUnitTest.inc
+++ b/Universal/Tests/Constants/UppercaseMagicConstantsUnitTest.inc
@@ -1,0 +1,36 @@
+<?php
+
+namespace A\B;
+
+class Foo {
+    public static function bar() {
+        // OK.
+        echo __LINE__;
+        echo __FILE__;
+        echo __DIR__;
+        echo __FUNCTION__;
+        echo __CLASS__;
+        echo __TRAIT__;
+        echo __METHOD__;
+        echo __NAMESPACE__;
+
+        // Not ok.
+        echo __line__;
+        echo __file__;
+        echo __dir__;
+        echo __function__;
+        echo __class__;
+        echo __trait__;
+        echo __method__;
+        echo __namespace__;
+
+        echo __Line__;
+        echo __FiLe__;
+        echo __DiR__;
+        echo __Function__;
+        echo __ClasS__;
+        echo __tRAIT__;
+        echo __Method__;
+        echo __NameSpace__;
+    }
+}

--- a/Universal/Tests/Constants/UppercaseMagicConstantsUnitTest.inc.fixed
+++ b/Universal/Tests/Constants/UppercaseMagicConstantsUnitTest.inc.fixed
@@ -1,0 +1,36 @@
+<?php
+
+namespace A\B;
+
+class Foo {
+    public static function bar() {
+        // OK.
+        echo __LINE__;
+        echo __FILE__;
+        echo __DIR__;
+        echo __FUNCTION__;
+        echo __CLASS__;
+        echo __TRAIT__;
+        echo __METHOD__;
+        echo __NAMESPACE__;
+
+        // Not ok.
+        echo __LINE__;
+        echo __FILE__;
+        echo __DIR__;
+        echo __FUNCTION__;
+        echo __CLASS__;
+        echo __TRAIT__;
+        echo __METHOD__;
+        echo __NAMESPACE__;
+
+        echo __LINE__;
+        echo __FILE__;
+        echo __DIR__;
+        echo __FUNCTION__;
+        echo __CLASS__;
+        echo __TRAIT__;
+        echo __METHOD__;
+        echo __NAMESPACE__;
+    }
+}

--- a/Universal/Tests/Constants/UppercaseMagicConstantsUnitTest.php
+++ b/Universal/Tests/Constants/UppercaseMagicConstantsUnitTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\Constants;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the UppercaseMagicConstants sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\Constants\UppercaseMagicConstantsSniff
+ *
+ * @since 1.0.0
+ */
+class UppercaseMagicConstantsUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getErrorList()
+    {
+        return [
+            18 => 1,
+            19 => 1,
+            20 => 1,
+            21 => 1,
+            22 => 1,
+            23 => 1,
+            24 => 1,
+            25 => 1,
+            27 => 1,
+            28 => 1,
+            29 => 1,
+            30 => 1,
+            31 => 1,
+            32 => 1,
+            33 => 1,
+            34 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array <int line number> => <int number of warnings>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
New sniff to verify that the PHP native magic constants are in uppercase when used.

Refs:
* https://www.php.net/manual/en/language.constants.predefined.php

Includes fixer.
Includes unit tests.
Includes documentation.
Includes metrics.