### PR TITLE
New `Universal.Operators.DisallowStandalonePostIncrementDecrement` sniff

### DIFF
--- a/Universal/Docs/Operators/DisallowStandalonePostIncrementDecrementStandard.xml
+++ b/Universal/Docs/Operators/DisallowStandalonePostIncrementDecrementStandard.xml
@@ -1,0 +1,40 @@
+<documentation title="Disallow Standalone Post-Increment/Decrement">
+    <standard>
+    <![CDATA[
+    In a stand-alone in/decrement statement, pre-in/decrement should always be favoured over post-in/decrement.
+
+    This reduces the chance of bugs when code gets moved around.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Pre-in/decrement in a stand-alone statement.">
+        <![CDATA[
+<em>++</em>$i;
+<em>--</em>$j;
+        ]]>
+        </code>
+        <code title="Invalid: Post-in/decrement in a stand-alone statement.">
+        <![CDATA[
+$i<em>++</em>;
+$j<em>--</em>;
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    Using multiple increment/decrement operators in a stand-alone statement is strongly discouraged.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Single in/decrement operator in a stand-alone statement.">
+        <![CDATA[
+<em>++</em>$i;
+        ]]>
+        </code>
+        <code title="Invalid: Multiple in/decrement operators in a stand-alone statement.">
+        <![CDATA[
+<em>--</em>$i<em>++</em><em>++</em>;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/Operators/DisallowStandalonePostIncrementDecrementSniff.php
+++ b/Universal/Sniffs/Operators/DisallowStandalonePostIncrementDecrementSniff.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\Operators;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\BackCompat\BCFile;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\GetTokensAsString;
+
+/**
+ * Disallow the use of post-in/decrements in stand-alone statements and discourage the use of
+ * multiple increment/decrement operators in a stand-alone statement.
+ *
+ * Post-in/decrement returns the value and in/decrements afterwards.
+ * Pre-in/decrement in/decrements the value and returns afterwards.
+ * Using pre-in/decrement is more in line with the principle of least astonishment
+ * and prevents bugs when code gets moved around at a later point in time.
+ *
+ * @since 1.0.0
+ */
+class DisallowStandalonePostIncrementDecrementSniff implements Sniff
+{
+
+    /**
+     * Tokens which can be expected in a stand-alone in/decrement statement.
+     *
+     * {@internal This array is enriched in the register() method.}
+     *
+     * @since 1.0.0
+     *
+     * @var array
+     */
+    private $allowedTokens = [
+        \T_VARIABLE => \T_VARIABLE,
+    ];
+
+    /**
+     * Registers the tokens that this sniff wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return int[]
+     */
+    public function register()
+    {
+        $this->allowedTokens += Collections::$OOHierarchyKeywords;
+        $this->allowedTokens += Collections::$objectOperators;
+        $this->allowedTokens += Collections::$OONameTokens;
+
+        return Collections::$incrementDecrementOperators;
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (empty($tokens[$stackPtr]['nested_parenthesis']) === false) {
+            // Not a stand-alone statement.
+            return;
+        }
+
+        $start = BCFile::findStartOfStatement($phpcsFile, $stackPtr);
+        $end   = BCFile::findEndOfStatement($phpcsFile, $stackPtr);
+
+        if ($tokens[$end]['code'] !== \T_SEMICOLON) {
+            // Not a stand-alone statement.
+            return $end;
+        }
+
+        $counter  = 0;
+        $lastCode = null;
+        for ($i = $start; $i < $end; $i++) {
+            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+                continue;
+            }
+
+            if (isset(Collections::$incrementDecrementOperators[$tokens[$i]['code']]) === true) {
+                $lastCode = $tokens[$i]['code'];
+                ++$counter;
+                continue;
+            }
+
+            if (isset($this->allowedTokens[$tokens[$i]['code']]) === true) {
+                $lastCode = $tokens[$i]['code'];
+                continue;
+            }
+
+            if ($tokens[$i]['code'] === \T_OPEN_SQUARE_BRACKET
+                && isset($tokens[$i]['bracket_closer'])
+                && ($lastCode === \T_VARIABLE || $lastCode === \T_STRING)
+            ) {
+                // Array access.
+                $i = $tokens[$i]['bracket_closer'];
+                continue;
+            }
+
+            // Came across an unexpected token. This is (probably) not a stand-alone statement.
+            return $end;
+        }
+
+        if ($counter > 1) {
+            $phpcsFile->addWarning(
+                'Using multiple increment/decrement operators in a stand-alone statement is strongly discouraged.'
+                    . ' Found: %s',
+                $stackPtr,
+                'MultipleOperatorsFound',
+                [GetTokensAsString::compact($phpcsFile, $start, ($end - 1), true)]
+            );
+
+            return $end;
+        }
+
+        $type = 'increment';
+        if ($tokens[$stackPtr]['code'] === \T_DEC) {
+            $type = 'decrement';
+        }
+
+        $lastNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($end - 1), $start, true);
+        if ($start === $stackPtr && $lastNonEmpty !== $stackPtr) {
+            // This is already pre-in/decrement.
+            $phpcsFile->recordMetric($stackPtr, 'In/decrement usage in stand-alone statements', 'pre-' . $type);
+            return $end;
+        }
+
+        if ($lastNonEmpty === false || $lastNonEmpty === $start || $lastNonEmpty !== $stackPtr) {
+            // Parse error or otherwise unsupported syntax. Ignore.
+            return $end;
+        }
+
+        $phpcsFile->recordMetric($stackPtr, 'In/decrement usage in stand-alone statements', 'post-' . $type);
+
+        $error        = 'Stand-alone post-%1$s statement found. Use pre-%1$s instead: %2$s.';
+        $errorCode    = 'Post' . \ucfirst($type) . 'Found';
+        $replacement  = $tokens[$stackPtr]['content'];
+        $replacement .= GetTokensAsString::compact($phpcsFile, $start, ($lastNonEmpty - 1), true);
+        $data         = [
+            $type,
+            $replacement,
+        ];
+
+        $fix = $phpcsFile->addFixableError($error, $stackPtr, $errorCode, $data);
+
+        if ($fix === false) {
+            return $end;
+        }
+
+        $phpcsFile->fixer->beginChangeset();
+        $phpcsFile->fixer->replaceToken($stackPtr, '');
+        $phpcsFile->fixer->addContentBefore($start, $tokens[$stackPtr]['content']);
+        $phpcsFile->fixer->endChangeset();
+
+        return $end;
+    }
+}

--- a/Universal/Tests/Operators/DisallowStandalonePostIncrementDecrementUnitTest.inc
+++ b/Universal/Tests/Operators/DisallowStandalonePostIncrementDecrementUnitTest.inc
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * These are ok.
+ */
+$i = 10;
+--$i;
+-- $i;
+-- /*comment*/ $i;
+    ++$i;
+    ++
+    $i;
+    ++/*comment*/$i;
+
+if (true) {
+    ++ClassName::$v;
+--\Fully\Qualified\ClassName::$v;
+    ++namespace\ClassName::$v;
+}
+
+++self::$v;--self::$v;
+
+--$a[0];
+
+++$obj->prop;
+--$obj->prop;
+
+/*
+ * These should throw errors.
+ */
+$i--;
+$i        --;
+$i /*comment*/ --;
+    $i++;
+    $i ++;
+    $i /*comment*/ ++;
+
+$a[0]--;
+
+if (true) {
+    ClassName::$v++;
+\Fully\Qualified\ClassName::$v--;
+    namespace\ClassName::$v++;
+}
+
+self::$v++;self::$v--;
+
+           $obj->prop ++;
+/*comment*/ $obj-> /*comment*/ prop --;
+
+$obj->prop[$value[2]]++;
+$var['key' . ($i + 10) . 'key']--;
+
+/*
+ * Report on, but don't auto-fix, statements with multiple in/decrementers.
+ */
+++$i--;
+++ -- $i ++ ++;
+
+/*
+ * Don't touch non-stand-alone statements.
+ */
+while ($i++ && $i < 10);
+
+for ($i = 0; $i < 10; $i++) {}
+
+function_call($i--, $j++);
+
+$a = 10 + $i++ - 5;
+
+return $a['key'][$i++];
+
+// Intentional parse error.
+++;

--- a/Universal/Tests/Operators/DisallowStandalonePostIncrementDecrementUnitTest.inc.fixed
+++ b/Universal/Tests/Operators/DisallowStandalonePostIncrementDecrementUnitTest.inc.fixed
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * These are ok.
+ */
+$i = 10;
+--$i;
+-- $i;
+-- /*comment*/ $i;
+    ++$i;
+    ++
+    $i;
+    ++/*comment*/$i;
+
+if (true) {
+    ++ClassName::$v;
+--\Fully\Qualified\ClassName::$v;
+    ++namespace\ClassName::$v;
+}
+
+++self::$v;--self::$v;
+
+--$a[0];
+
+++$obj->prop;
+--$obj->prop;
+
+/*
+ * These should throw errors.
+ */
+--$i;
+--$i        ;
+--$i /*comment*/ ;
+    ++$i;
+    ++$i ;
+    ++$i /*comment*/ ;
+
+--$a[0];
+
+if (true) {
+    ++ClassName::$v;
+--\Fully\Qualified\ClassName::$v;
+    ++namespace\ClassName::$v;
+}
+
+++self::$v;--self::$v;
+
+           ++$obj->prop ;
+/*comment*/ --$obj-> /*comment*/ prop ;
+
+++$obj->prop[$value[2]];
+--$var['key' . ($i + 10) . 'key'];
+
+/*
+ * Report on, but don't auto-fix, statements with multiple in/decrementers.
+ */
+++$i--;
+++ -- $i ++ ++;
+
+/*
+ * Don't touch non-stand-alone statements.
+ */
+while ($i++ && $i < 10);
+
+for ($i = 0; $i < 10; $i++) {}
+
+function_call($i--, $j++);
+
+$a = 10 + $i++ - 5;
+
+return $a['key'][$i++];
+
+// Intentional parse error.
+++;

--- a/Universal/Tests/Operators/DisallowStandalonePostIncrementDecrementUnitTest.php
+++ b/Universal/Tests/Operators/DisallowStandalonePostIncrementDecrementUnitTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\Operators;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the DisallowStandalonePostIncrementDecrement sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\Operators\DisallowStandalonePostIncrementDecrementSniff
+ *
+ * @since 1.0.0
+ */
+class DisallowStandalonePostIncrementDecrementUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [
+            31 => 1,
+            32 => 1,
+            33 => 1,
+            34 => 1,
+            35 => 1,
+            36 => 1,
+            38 => 1,
+            41 => 1,
+            42 => 1,
+            43 => 1,
+            46 => 2,
+            48 => 1,
+            49 => 1,
+            51 => 1,
+            52 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [
+            57 => 1,
+            58 => 1,
+        ];
+    }
+}


### PR DESCRIPTION
New sniff to disallow the use of post-in/decrements in stand-alone statements and discourage the use of multiple increment/decrement operators in a stand-alone statement.

> Post-in/decrement returns the value and in/decrements afterwards.
> Pre-in/decrement in/decrements the value and returns afterwards.
> Using pre-in/decrement is more in line with the principle of least astonishment
> and prevents bugs when code gets moved around at a later point in time.

Includes fixer.
Includes unit tests.
Includes documentation.
Includes metrics.