### PR TITLE
Travis: change from "trusty" to "xenial"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-dist: trusty
+os: linux
+dist: xenial
 
 language: php
 
@@ -12,7 +13,6 @@ cache:
     - $HOME/.cache/composer/files
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
@@ -89,8 +89,10 @@ jobs:
       env: PHPCS_VERSION="3.3.1"
 
     - php: 5.4
+      dist: trusty
       env: PHPCS_VERSION="dev-master" LINT=1
     - php: 5.4
+      dist: trusty
       env: PHPCS_VERSION="3.3.1"
 
     #### TEST STAGE ####
@@ -101,6 +103,13 @@ jobs:
       env: PHPCS_VERSION="3.5.0"
     - php: 7.3
       env: PHPCS_VERSION="dev-master" LINT=1
+
+    - php: 5.5
+      dist: trusty
+      env: PHPCS_VERSION="dev-master" LINT=1
+    - php: 5.5
+      dist: trusty
+      env: PHPCS_VERSION="3.3.1"
 
     - php: 7.4
       env: PHPCS_VERSION="4.0.x-dev@dev"
@@ -119,8 +128,10 @@ jobs:
       env: PHPCS_VERSION="3.3.1" COVERALLS_VERSION="^2.0"
 
     - php: 5.4
+      dist: trusty
       env: PHPCS_VERSION="dev-master" LINT=1 COVERALLS_VERSION="^1.0"
     - php: 5.4
+      dist: trusty
       env: PHPCS_VERSION="3.3.1" COVERALLS_VERSION="^1.0"
 
   allow_failures:


### PR DESCRIPTION
As the "trusty" environment is no longer officially supported by Travis, they decided in their wisdom to silently stop updating the PHP "nightly" image, which makes it next to useless as the last image apparently is from January....

This updates the Travis config to:
* Use the `xenial` distro, which at this time is the default.
* Sets the distro for low PHP versions explicitly to `trusty`.
* Makes the expected OS explicit (linux).