### PR TITLE
New `Universal.Classes.Disallow/RequireAnonClassParentheses` sniffs

### DIFF
--- a/Universal/Docs/Classes/DisallowAnonClassParenthesesStandard.xml
+++ b/Universal/Docs/Classes/DisallowAnonClassParenthesesStandard.xml
@@ -1,0 +1,20 @@
+<documentation title="Disallow Anonymous Class Parentheses">
+    <standard>
+    <![CDATA[
+    Disallows the use of parentheses when declaring an anonymous class without passing parameters.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Anonymous class without parentheses or with parameters.">
+        <![CDATA[
+$anon = new class<em></em> {};
+$anon = new class<em>($param)</em> {};
+        ]]>
+        </code>
+        <code title="Invalid: Anonymous class with parentheses.">
+        <![CDATA[
+$anon = new class<em>()</em> {};
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Docs/Classes/RequireAnonClassParenthesesStandard.xml
+++ b/Universal/Docs/Classes/RequireAnonClassParenthesesStandard.xml
@@ -1,0 +1,19 @@
+<documentation title="Require Anonymous Class Parentheses">
+    <standard>
+    <![CDATA[
+    Require the use of parentheses when declaring an anonymous class.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Anonymous class with parentheses.">
+        <![CDATA[
+$anon = new class<em>()</em> {};
+        ]]>
+        </code>
+        <code title="Invalid: Anonymous class without parentheses.">
+        <![CDATA[
+$anon = new class<em></em> {};
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/Classes/DisallowAnonClassParenthesesSniff.php
+++ b/Universal/Sniffs/Classes/DisallowAnonClassParenthesesSniff.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Forbid for an anonymous class declaration/instantiation to have parentheses, except when
+ * parameters are being passed.
+ *
+ * @since 1.0.0
+ */
+class DisallowAnonClassParenthesesSniff implements Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [
+            \T_ANON_CLASS,
+        ];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($nextNonEmpty === false
+            || $tokens[$nextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS
+        ) {
+            // No parentheses found.
+            $phpcsFile->recordMetric($stackPtr, 'Anon class declaration with parenthesis', 'no');
+            return;
+        }
+
+        if (isset($tokens[$nextNonEmpty]['parenthesis_closer']) === false) {
+            // Incomplete set of parentheses. Ignore.
+            $phpcsFile->recordMetric($stackPtr, 'Anon class declaration with parenthesis', 'yes');
+            return;
+        }
+
+        $closer    = $tokens[$nextNonEmpty]['parenthesis_closer'];
+        $hasParams = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonEmpty + 1), $closer, true);
+        if ($hasParams !== false) {
+            // There is something between the parentheses. Ignore.
+            $phpcsFile->recordMetric($stackPtr, 'Anon class declaration with parenthesis', 'yes, with parameter');
+            return;
+        }
+
+        $phpcsFile->recordMetric($stackPtr, 'Anon class declaration with parenthesis', 'yes');
+
+        $fix = $phpcsFile->addFixableError(
+            'Parenthesis not allowed when creating a new anonymous class without passing parameters',
+            $stackPtr,
+            'Found'
+        );
+
+        if ($fix === true) {
+            $phpcsFile->fixer->beginChangeset();
+            for ($i = $nextNonEmpty; $i <= $closer; $i++) {
+                if (isset(Tokens::$commentTokens[$tokens[$i]['code']]) === true) {
+                    continue;
+                }
+
+                $phpcsFile->fixer->replaceToken($i, '');
+            }
+            $phpcsFile->fixer->endChangeset();
+        }
+    }
+}

--- a/Universal/Sniffs/Classes/RequireAnonClassParenthesesSniff.php
+++ b/Universal/Sniffs/Classes/RequireAnonClassParenthesesSniff.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Require that an anonymous class declaration/instantiation has parentheses, i.e. `new class().
+ *
+ * @since 1.0.0
+ */
+class RequireAnonClassParenthesesSniff implements Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [
+            \T_ANON_CLASS,
+        ];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($nextNonEmpty !== false
+            && $tokens[$nextNonEmpty]['code'] === \T_OPEN_PARENTHESIS
+        ) {
+            // Parentheses found.
+            $phpcsFile->recordMetric($stackPtr, 'Anon class declaration with parenthesis', 'yes');
+            return;
+        }
+
+        $phpcsFile->recordMetric($stackPtr, 'Anon class declaration with parenthesis', 'no');
+
+        $fix = $phpcsFile->addFixableError(
+            'Parenthesis required when creating a new anonymous class.',
+            $stackPtr,
+            'Missing'
+        );
+
+        if ($fix === true) {
+            $phpcsFile->fixer->addContent($stackPtr, '()');
+        }
+    }
+}

--- a/Universal/Tests/Classes/DisallowAnonClassParenthesesUnitTest.inc
+++ b/Universal/Tests/Classes/DisallowAnonClassParenthesesUnitTest.inc
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * OK.
+ */
+$a = new MyClass();
+
+$anon = new class { // OK.
+    public static function get_instance() {
+        return new self(); // Even though within anon class, it's not the anon class instantiation we're looking for.
+    }
+}
+
+$util->doSomething( new class {} ); // OK.
+$b = new class( 10 ) extends SomeClass implements SomeInterface {}; // OK, has parameter.
+$anon = new class // Comment
+    ($param) {}; // OK, has parameter.
+
+/*
+ * Bad.
+ */
+$util->doSomething( new class() {} );
+$b = new class (  ) extends SomeClass implements SomeInterface {};
+$anon = new class // Comment
+    () {};
+
+$b = new class ( /*comment*/ ) {};
+
+// Live coding.
+// Intentional parse error. This has to be the last test in the file.
+$anon = new class()

--- a/Universal/Tests/Classes/DisallowAnonClassParenthesesUnitTest.inc.fixed
+++ b/Universal/Tests/Classes/DisallowAnonClassParenthesesUnitTest.inc.fixed
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * OK.
+ */
+$a = new MyClass();
+
+$anon = new class { // OK.
+    public static function get_instance() {
+        return new self(); // Even though within anon class, it's not the anon class instantiation we're looking for.
+    }
+}
+
+$util->doSomething( new class {} ); // OK.
+$b = new class( 10 ) extends SomeClass implements SomeInterface {}; // OK, has parameter.
+$anon = new class // Comment
+    ($param) {}; // OK, has parameter.
+
+/*
+ * Bad.
+ */
+$util->doSomething( new class {} );
+$b = new class  extends SomeClass implements SomeInterface {};
+$anon = new class // Comment
+     {};
+
+$b = new class /*comment*/ {};
+
+// Live coding.
+// Intentional parse error. This has to be the last test in the file.
+$anon = new class()

--- a/Universal/Tests/Classes/DisallowAnonClassParenthesesUnitTest.php
+++ b/Universal/Tests/Classes/DisallowAnonClassParenthesesUnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\Classes;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the DisallowAnonClassParentheses sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\Classes\DisallowAnonClassParenthesesSniff
+ *
+ * @since 1.0.0
+ */
+class DisallowAnonClassParenthesesUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getErrorList()
+    {
+        return [
+            22 => 1,
+            23 => 1,
+            24 => 1,
+            27 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array <int line number> => <int number of warnings>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}

--- a/Universal/Tests/Classes/RequireAnonClassParenthesesUnitTest.inc
+++ b/Universal/Tests/Classes/RequireAnonClassParenthesesUnitTest.inc
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * OK.
+ */
+$a = new MyClass();
+
+$anon = new class() { // OK.
+    public static function get_instance() {
+        return new self(); // Even though within anon class, it's not the anon class instantiation we're looking for.
+    }
+}
+
+$util->doSomething( new class() {} ); // OK.
+$b = new class( 10 ) extends SomeClass implements SomeInterface {}; // OK.
+$anon = new class // Comment
+    () {}; // OK.
+
+/*
+ * Bad.
+ */
+$util->doSomething( new class {} );
+$b = new class extends SomeClass implements SomeInterface {};
+
+// Live coding.
+// Intentional parse error. This has to be the last test in the file.
+$anon = new class

--- a/Universal/Tests/Classes/RequireAnonClassParenthesesUnitTest.inc.fixed
+++ b/Universal/Tests/Classes/RequireAnonClassParenthesesUnitTest.inc.fixed
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * OK.
+ */
+$a = new MyClass();
+
+$anon = new class() { // OK.
+    public static function get_instance() {
+        return new self(); // Even though within anon class, it's not the anon class instantiation we're looking for.
+    }
+}
+
+$util->doSomething( new class() {} ); // OK.
+$b = new class( 10 ) extends SomeClass implements SomeInterface {}; // OK.
+$anon = new class // Comment
+    () {}; // OK.
+
+/*
+ * Bad.
+ */
+$util->doSomething( new class() {} );
+$b = new class() extends SomeClass implements SomeInterface {};
+
+// Live coding.
+// Intentional parse error. This has to be the last test in the file.
+$anon = new class

--- a/Universal/Tests/Classes/RequireAnonClassParenthesesUnitTest.php
+++ b/Universal/Tests/Classes/RequireAnonClassParenthesesUnitTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\Classes;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the RequireAnonClassParentheses sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\Classes\RequireAnonClassParenthesesSniff
+ *
+ * @since 1.0.0
+ */
+class RequireAnonClassParenthesesUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getErrorList()
+    {
+        return [
+            22 => 1,
+            23 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array <int line number> => <int number of warnings>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
This adds two new sniffs:

* `Universal.Classes.DisallowAnonClassParentheses` to disallow the use of parentheses when declaring an anonymous class without passing parameters.
*  `Universal.Classes.RequireAnonClassParentheses` to require the use of parentheses when declaring an anonymous class whether parameters are passed or not.

PSR12 has no opinion on whether or not anonymous class declarations without parameters should have parentheses, so parentheses for an anonymous class are not enforced, nor forbidden by the `PSR12.Classes.ClassInstantiation` sniff.

These two sniffs allow for a consistent codebase regarding anonymous class parentheses, whether you choose to enforce them or forbid them.

Includes fixer.
Includes unit tests.
Includes documentation.
Includes metrics.
