### PR TITLE
QA/CS: update PHPCSDevCS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
             "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
         ],
         "install-devcs": [
-            "composer global require --dev phpcsstandards/phpcsdevcs:\"^1.0\" --no-suggest"
+            "composer global require --dev phpcsstandards/phpcsdevcs:\"^1.1\" --no-suggest"
         ],
         "remove-devcs": [
             "composer global remove --dev phpcsstandards/phpcsdevcs"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -44,9 +44,6 @@
     <!-- Set minimum PHP version supported to PHP 5.4. -->
     <config name="testVersion" value="5.4-"/>
 
-    <!-- Enforce short arrays. -->
-    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
-
 
     <!--
     #############################################################################


### PR DESCRIPTION
The new `1.1.x` version already includes a check for short array syntax, so we can remove that from our own ruleset.