### PR TITLE
Travis/Composer: future-proof the CS setup a little more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,19 +47,27 @@ jobs:
     #### SNIFF STAGE ####
     - stage: sniff
       php: 7.4
-      install: skip
+      install:
+        # Set up CS check.
+        # - Using PHPCS `master` as an early detection system for bugs upstream.
+        # - COMPOSER_ROOT_VERSION is needed to get round the (upcoming) recursive dependency when using CI.
+        - export COMPOSER_ROOT_VERSION="1.99.99"
+        - travis_retry composer remove --dev phpunit/phpunit --no-update --no-scripts
+        - travis_retry composer require --no-update squizlabs/php_codesniffer:"dev-master"
+        - travis_retry composer install-devcs
       before_script: skip
       script:
         # Check the code style of the code base.
-        - composer travis-checkcs
+        - vendor/bin/phpcs
+      after_success: skip
 
     - stage: validate
       php: 7.4
-      env: PHPCS_VERSION="dev-master"
       addons:
         apt:
           packages:
             - libxml2-utils
+      before_script: skip
       script:
         # Validate the composer.json file.
         # @link https://getcomposer.org/doc/03-cli.md#validate
@@ -76,6 +84,7 @@ jobs:
 
         # Check that the sniffs available are feature complete.
         - composer check-complete
+      after_success: skip
 
     #### QUICK TEST STAGE ####
     # This is a much quicker test which only runs the unit tests and linting against the low/high

--- a/composer.json
+++ b/composer.json
@@ -31,34 +31,33 @@
         "phpcsstandards/phpcsdevtools": "^1.0",
         "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0"
     },
+    "extra": {
+        "branch-alias": {
+            "dev-stable": "1.x-dev",
+            "dev-develop": "1.x-dev"
+        }
+    },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts" : {
-        "install-standards": [
-            "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
-        ],
         "lint": [
             "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
         ],
         "install-devcs": [
-            "composer global require --dev phpcsstandards/phpcsdevcs:\"^1.1\" --no-suggest"
+            "composer require --dev phpcsstandards/phpcsdevcs:\"^1.1\" --no-suggest"
         ],
         "remove-devcs": [
-            "composer global remove --dev phpcsstandards/phpcsdevcs"
+            "composer remove --dev phpcsstandards/phpcsdevcs"
         ],
         "checkcs": [
             "@install-devcs",
-            "phpcs",
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
             "@remove-devcs"
         ],
         "fixcs": [
             "@install-devcs",
-            "phpcbf",
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf",
             "@remove-devcs"
-        ],
-        "travis-checkcs": [
-            "@install-devcs",
-            "/home/travis/.composer/vendor/bin/phpcs"
         ],
         "check-complete": [
             "@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./NormalizedArrays ./Universal"


### PR DESCRIPTION
* Composer: add branch aliases
* Travis: move CS install steps to the `Sniff` stage.

See PHPCompatibility/PHPCompatibility#1221 for more extensive background information about these changes.