### PR TITLE
New `Universal.NamingConventions.NoReservedKeywordParameterNames` sniff

### DIFF
--- a/Universal/Docs/NamingConventions/NoReservedKeywordParameterNamesStandard.xml
+++ b/Universal/Docs/NamingConventions/NoReservedKeywordParameterNamesStandard.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<documentation title="No Reserved Keyword Parameter Names">
+    <standard>
+    <![CDATA[
+    It is recommended not to use reserved keywords as parameter names as this can become confusing when people use them in function calls using named parameters.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: parameter names do not use reserved keywords.">
+        <![CDATA[
+function foo( $input, $description ) {}
+        ]]>
+        </code>
+        <code title="Invalid: parameter names use reserved keywords.">
+        <![CDATA[
+function foo( $string, $echo = true ) {}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/NamingConventions/NoReservedKeywordParameterNamesSniff.php
+++ b/Universal/Sniffs/NamingConventions/NoReservedKeywordParameterNamesSniff.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\NamingConventions;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\FunctionDeclarations;
+
+/**
+ * Verifies that parameters in function declarations do not use PHP reserved keywords.
+ *
+ * @link https://www.php.net/manual/en/reserved.keywords.php
+ *
+ * @since 1.0.0
+ */
+class NoReservedKeywordParameterNamesSniff implements Sniff
+{
+
+    /**
+     * A list of PHP reserved keywords.
+     *
+     * @since 1.0.0
+     *
+     * @var array(string => string)
+     */
+    protected $reservedNames = [
+        'abstract'      => true,
+        'and'           => true,
+        'array'         => true,
+        'as'            => true,
+        'break'         => true,
+        'callable'      => true,
+        'case'          => true,
+        'catch'         => true,
+        'class'         => true,
+        'clone'         => true,
+        'const'         => true,
+        'continue'      => true,
+        'declare'       => true,
+        'default'       => true,
+        'die'           => true,
+        'do'            => true,
+        'echo'          => true,
+        'else'          => true,
+        'elseif'        => true,
+        'empty'         => true,
+        'enddeclare'    => true,
+        'endfor'        => true,
+        'endforeach'    => true,
+        'endif'         => true,
+        'endswitch'     => true,
+        'endwhile'      => true,
+        'eval'          => true,
+        'exit'          => true,
+        'extends'       => true,
+        'final'         => true,
+        'finally'       => true,
+        'fn'            => true,
+        'for'           => true,
+        'foreach'       => true,
+        'function'      => true,
+        'global'        => true,
+        'goto'          => true,
+        'if'            => true,
+        'implements'    => true,
+        'include'       => true,
+        'include_once'  => true,
+        'instanceof'    => true,
+        'insteadof'     => true,
+        'interface'     => true,
+        'isset'         => true,
+        'list'          => true,
+        'match'         => true,
+        'namespace'     => true,
+        'new'           => true,
+        'or'            => true,
+        'print'         => true,
+        'private'       => true,
+        'protected'     => true,
+        'public'        => true,
+        'require'       => true,
+        'require_once'  => true,
+        'return'        => true,
+        'static'        => true,
+        'switch'        => true,
+        'throw'         => true,
+        'trait'         => true,
+        'try'           => true,
+        'unset'         => true,
+        'use'           => true,
+        'var'           => true,
+        'while'         => true,
+        'xor'           => true,
+        'yield'         => true,
+        '__CLASS__'     => true,
+        '__DIR__'       => true,
+        '__FILE__'      => true,
+        '__FUNCTION__'  => true,
+        '__LINE__'      => true,
+        '__METHOD__'    => true,
+        '__NAMESPACE__' => true,
+        '__TRAIT__'     => true,
+        'int'           => true,
+        'float'         => true,
+        'bool'          => true,
+        'string'        => true,
+        'true'          => true,
+        'false'         => true,
+        'null'          => true,
+        'void'          => true,
+        'iterable'      => true,
+        'object'        => true,
+        'resource'      => true,
+        'mixed'         => true,
+        'numeric'       => true,
+    ];
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return Collections::functionDeclarationTokensBC();
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens    = $phpcsFile->getTokens();
+        $content   = $tokens[$stackPtr]['content'];
+        $contentLC = \strtolower($content);
+
+        // Get all parameters from method signature.
+        try {
+            $parameters = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
+            if (empty($parameters)) {
+                return;
+            }
+        } catch (RuntimeException $e) {
+            // Most likely a T_STRING which wasn't an arrow function.
+            return;
+        }
+
+        $paramNames = [];
+        foreach ($parameters as $param) {
+            $name = \ltrim($param['name'], '$');
+            if (isset($this->reservedNames[$name]) === true) {
+                $phpcsFile->addWarning(
+                    'It is recommended not to use reserved keywords as function parameter names. Found: %s',
+                    $stackPtr,
+                    $name . 'Found',
+                    [$param['name']]
+                );
+            }
+        }
+    }
+}

--- a/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.inc
+++ b/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.inc
@@ -1,0 +1,11 @@
+<?php
+
+function foo( $parameter, $descriptive_name ) {} // OK.
+
+function foo( $string, $echo = true ) {} // Bad x 2.
+$closure = function ( $foreach, $array, $require ) {}; // Bad x 3.
+$fn = fn($callable, $list) => $callable($list); // Bad x 2.
+
+abstract class Foo {
+	abstract public function bar($string, $exit); // Bad x 2.
+}

--- a/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.php
+++ b/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\NamingConventions;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the NoReservedKeywordParameterNames sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\NamingConventions\NoReservedKeywordParameterNamesSniff
+ *
+ * @since 1.0.0
+ */
+class NoReservedKeywordParameterNamesUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getErrorList()
+    {
+        return [];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array <int line number> => <int number of warnings>
+     */
+    public function getWarningList()
+    {
+        return [
+            5  => 2,
+            6  => 3,
+            7  => 2,
+            10 => 2,
+        ];
+    }
+}


### PR DESCRIPTION
Sniff to verify that function parameters do not use reserved keywords as names, as this can become confusing when people use them in function calls using named parameters.

Includes unit tests.
Includes documentation.