### PR TITLE
NoReservedKeywordParameterNames: also throw a warning for `parent` and `self`

### DIFF
--- a/Universal/Sniffs/NamingConventions/NoReservedKeywordParameterNamesSniff.php
+++ b/Universal/Sniffs/NamingConventions/NoReservedKeywordParameterNamesSniff.php
@@ -123,6 +123,13 @@ class NoReservedKeywordParameterNamesSniff implements Sniff
         'resource'      => true,
         'mixed'         => true,
         'numeric'       => true,
+
+        /*
+         * Not reserved keywords, but equally confusing when used in the context of function calls
+         * with named parameters.
+         */
+        'parent'        => true,
+        'self'          => true,
     ];
 
     /**

--- a/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.inc
+++ b/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.inc
@@ -7,5 +7,5 @@ $closure = function ( $foreach, $array, $require ) {}; // Bad x 3.
 $fn = fn($callable, $list) => $callable($list); // Bad x 2.
 
 abstract class Foo {
-	abstract public function bar($string, $exit); // Bad x 2.
+	abstract public function bar($string, $exit, $parent); // Bad x 3.
 }

--- a/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.php
+++ b/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.php
@@ -43,7 +43,7 @@ class NoReservedKeywordParameterNamesUnitTest extends AbstractSniffUnitTest
             5  => 2,
             6  => 3,
             7  => 2,
-            10 => 2,
+            10 => 3,
         ];
     }
 }


### PR DESCRIPTION
... as they will be equally confusing when used in the context of named parameters in function calls.

```php
foobar(self: new self());
```