### PR TITLE
Travis: add build against PHP 8.0 & fix Xdebug 3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,8 +107,13 @@ jobs:
     #### TEST STAGE ####
     # Additional builds to prevent issues with PHPCS versions incompatible with certain PHP versions.
     - stage: test
+      php: 8.0
+      env: PHPCS_VERSION="dev-master" LINT=1
+      # PHPCS is only compatible with PHP 8.0 as of version 3.5.7.
+    - php: 8.0
+      env: PHPCS_VERSION="3.5.7"
       # PHPCS is only compatible with PHP 7.4 as of version 3.5.0.
-      php: 7.4
+    - php: 7.4
       env: PHPCS_VERSION="3.5.0"
     - php: 7.3
       env: PHPCS_VERSION="dev-master" LINT=1
@@ -180,7 +185,7 @@ install:
       travis_retry composer remove --dev phpcsstandards/phpcsdevtools --no-update
       # --prefer-source ensures that the PHPCS native unit test framework will be available in PHPCS 4.x.
       travis_retry composer install --prefer-source --no-suggest
-    elif [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+    elif [[ $TRAVIS_PHP_VERSION == "nightly" || $TRAVIS_PHP_VERSION == "8.0" ]]; then
       # Ignore PHPUnit platform requirements for installing on nightly.
       travis_retry composer install --prefer-dist --no-suggest --ignore-platform-reqs
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -170,6 +170,12 @@ before_install:
       echo 'error_reporting = E_ALL & ~E_DEPRECATED' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
     fi
 
+  # Turn on Xdebug code coverage mode in case Xdebug 3 is being used.
+  - |
+    if [[ "${TRAVIS_BUILD_STAGE_NAME^}" == "Coverage" ]]; then
+      echo 'xdebug.mode = coverage' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+    fi
+
 
 install:
   # Set up test environment using Composer.

--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -23,6 +23,22 @@ if (\defined('PHP_CODESNIFFER_IN_TESTS') === false) {
     \define('PHP_CODESNIFFER_IN_TESTS', true);
 }
 
+/*
+ * PHPUnit 9.3 is the first version which supports Xdebug 3, but we're using PHPUnit 9.2
+ * for code coverage due to PHP_Parser interfering with our tests.
+ *
+ * For now, until a fix is pulled to allow us to use PHPUnit 9.3, this will allow
+ * PHPUnit 9.2 to run with Xdebug 3 for code coverage.
+ */
+if (\extension_loaded('xdebug') && \version_compare(\phpversion('xdebug'), '3', '>=')) {
+    if (defined('XDEBUG_CC_UNUSED') === false) {
+        define('XDEBUG_CC_UNUSED', null);
+    }
+    if (defined('XDEBUG_CC_DEAD_CODE') === false) {
+        define('XDEBUG_CC_DEAD_CODE', null);
+    }
+}
+
 $ds = \DIRECTORY_SEPARATOR;
 
 /*


### PR DESCRIPTION
PHP 8.0 has been branched off two months ago, so `nightly` is now PHP 8.1 and in the mean time PHP 8.0 was released last week.

As of today, there is a PHP 8.0 image available on Travis.

This PR adds two new builds against PHP 8.0 to the matrix and, as PHP 8.0 has been released, these builds are not allowed to fail.

### Tests: Xdebug 3 compatibility fix

As the tests are based on the PHPCS native test framework, they are limited to max PHPUnit 7.5.x.

However, Xdebug `3.0` was released last week and the Travis images for high PHP versions have been updated to include Xdebug `3.0`, but, of course, PHPUnit 7.5 is not compatible with Xdebug 3....

Declaring the "missing" constants which no longer exist in Xdebug 3, but which PHPUnit 7.5 is relying on to exist, will fix this, combined with enabling the Xdebug code coverage mode from within the Travis config.