### PR TITLE
GH Actions: various tweaks

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -7,8 +7,6 @@ on:
     paths-ignore:
       - '**.md'
   pull_request:
-    paths-ignore:
-      - '**.md'
 
 jobs:
   checkcs:

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -7,6 +7,8 @@ on:
     paths-ignore:
       - '**.md'
   pull_request:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
 
 jobs:
   checkcs:

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           php-version: '7.4'
           coverage: none
+          tools: cs2pr
 
       - name: 'Composer: adjust dependencies'
         run: |
@@ -65,7 +66,11 @@ jobs:
 
       # Check the code-style consistency of the PHP files.
       - name: Check PHP code style
-        run: vendor/bin/phpcs
+        continue-on-error: true
+        run: vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml
+
+      - name: Show PHPCS results in PR
+        run: cs2pr ./phpcs-report.xml
 
       # Check that the sniffs available are feature complete.
       # For now, just check that all sniffs have unit tests.

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -7,6 +7,8 @@ on:
       - stable
     paths-ignore:
       - '**.md'
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
 
 jobs:
   #### QUICK TEST STAGE ####

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,7 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
+          tools: cs2pr
 
       - name: 'Composer: set PHPCS version for tests'
         run: composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}"
@@ -119,7 +120,7 @@ jobs:
 
       - name: Lint against parse errors
         if: matrix.phpcs_version == 'dev-master'
-        run: composer lint
+        run: composer lint -- --checkstyle | cs2pr
 
       - name: Run the unit tests
         run: composer test
@@ -169,6 +170,7 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: xdebug
+          tools: cs2pr
 
       - name: 'Composer: adjust dependencies'
         run: |
@@ -185,7 +187,7 @@ jobs:
 
       - name: Lint against parse errors
         if: matrix.phpcs_version == 'dev-master'
-        run: composer lint
+        run: composer lint -- --checkstyle | cs2pr
 
       - name: Run the unit tests with code coverage
         run: composer coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
     paths-ignore:
       - '**.md'
   pull_request:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
 
 jobs:
   #### TEST STAGE ####

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,6 @@ on:
     paths-ignore:
       - '**.md'
   pull_request:
-    paths-ignore:
-      - '**.md'
 
 jobs:
   #### TEST STAGE ####


### PR DESCRIPTION
### GH Actions: don't ignore markdown-only changes

... on pull requests as it doesn't play nice with required statuses.

### GH Actions: allow for manually triggering a workflow

Triggering a workflow for a branch manually is not supported by default in GH Actions, but has to be explicitly allowed.

Ref: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/

### GH Actions: report CS violations in the PR

The cs2pr tool will allow to display the results from an action run in checkstyle format in-line in the PR code view, which should improve usability of the workflow results.

Ref: https://github.com/staabm/annotate-pull-request-from-checkstyle

### GH Actions: report linting violations in the PR

The cs2pr tool will allow to display the results from an action run in checkstyle format in-line in the PR code view, which should improve usability of the workflow results.

Ref: https://github.com/staabm/annotate-pull-request-from-checkstyle

