### PR TITLE
GH Actions: get the tests running on PHP 8.1 (nightly) and more

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,8 +122,13 @@ jobs:
         if: matrix.phpcs_version == 'dev-master'
         run: composer lint -- --checkstyle | cs2pr
 
-      - name: Run the unit tests
+      - name: Run the unit tests - PHP 5.4 - 8.0
+        if: ${{ matrix.php != '8.1' }}
         run: composer test
+
+      - name: Run the unit tests - PHP 8.1
+        if: ${{ matrix.php == '8.1' }}
+        run: composer test -- --no-configuration --bootstrap=phpunit-bootstrap.php --dont-report-useless-tests
 
   #### CODE COVERAGE STAGE ####
   # N.B.: Coverage is only checked on the lowest and highest stable PHP versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,6 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
-          tools: cs2pr
         env:
           # Token is needed for the PHPCS 4.x run against source.
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -123,7 +122,7 @@ jobs:
 
       - name: Lint against parse errors
         if: matrix.phpcs_version == 'dev-master'
-        run: composer lint -- --checkstyle | cs2pr
+        run: composer lint
 
       - name: Run the unit tests - PHP 5.4 - 8.0
         if: ${{ matrix.php != '8.1' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,9 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
           tools: cs2pr
+        env:
+          # Token is needed for the PHPCS 4.x run against source.
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 'Composer: set PHPCS version for tests'
         run: composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}"


### PR DESCRIPTION
### GH Actions: get the tests running on PHP 8.1 (nightly)

Letting PHPUnit read the config file causes an error on PHP 8.1 in combination with PHPUnit 7.

For now, special case the test run on PHP 8.1 and pass the only necessary config from the configuration file on via CLI arguments.

**_Note: the tests will still fail for now due to an incompatibility in PHPCS itself. A fix for this has been pulled. Once that fix has been merged, the tests are expected to pass._**

See: https://github.com/squizlabs/PHP_CodeSniffer/pull/3250

### GH Actions: fix downloading package from source

The test run against PHPCS 4.x needs to download from `source` instead of Packagist to ensure the necessary test base classes are available.

A lot of the time, this fails with an error:
```
   [Composer\Downloader\TransportException]
   Could not authenticate against github.com
```

Composer then downloads from Packagist anyway which will cause the tests to fail as the test runners aren't available.

Passing the Composer Token to the `setup-php` action should fix this.

Refs:
* https://github.com/shivammathur/setup-php#composer-github-oauth
* composer/composer#9084

### GH Actions: only report linting violations on high/low PHP

No need to see the same errors 10 times. Twice is enough ;-)

