### PR TITLE
New `Universal.PHP.OneStatementInShortEchoTag` sniff

### DIFF
--- a/Universal/Docs/PHP/OneStatementInShortEchoTagStandard.xml
+++ b/Universal/Docs/PHP/OneStatementInShortEchoTagStandard.xml
@@ -1,0 +1,37 @@
+<documentation title="One Statement In Short Echo Tag">
+    <standard>
+    <![CDATA[
+    Best practice: Short open echo tags should only ever contain *one* statement.
+    Use normal "<?php" tags for multi-statement PHP.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Using short open echo tag with one statement.">
+        <![CDATA[
+div><?= $text ?></div>
+        ]]>
+        </code>
+        <code title="Invalid: Using short open echo tag with multiple statements.">
+        <![CDATA[
+<div><em><?=</em> $text; <em>echo $moreText;</em> ?></div>
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: Using normal PHP tag with multiple statements.">
+        <![CDATA[
+<div><em><?php</em>
+echo $text;
+echo $moreText;
+?></div>
+        ]]>
+        </code>
+        <code title="Invalid: Using short open echo tag with multiple statements.">
+        <![CDATA[
+<div><em><?=</em> $text;
+<em>echo $moreText;</em>
+?></div>
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/PHP/OneStatementInShortEchoTagSniff.php
+++ b/Universal/Sniffs/PHP/OneStatementInShortEchoTagSniff.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\PHP;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Disallows multiple statements when PHP is opened with a short open echo tag.
+ *
+ * When using short open echo tags, PHP will echo out the result of the first statement.
+ * Subsequent statements will not be echo-ed out, but will be treated as "normal" PHP.
+ *
+ * As a best practice, short open echo tags should contain only one statement.
+ *
+ * @since 1.0.0
+ */
+class OneStatementInShortEchoTagSniff implements Sniff
+{
+
+    /**
+     * Registers the tokens that this sniff wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return int[]
+     */
+    public function register()
+    {
+        return [
+            \T_OPEN_TAG_WITH_ECHO,
+        ];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return int Integer stack pointer to skip the rest of the file.
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($stackPtr + 1));
+        if ($endOfStatement === false
+            || $tokens[$endOfStatement]['code'] === \T_CLOSE_TAG
+        ) {
+            return;
+        }
+
+        // Semi-colon, so check for any code between it and the close tag.
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($endOfStatement + 1), null, true);
+        if ($nextNonEmpty === false
+            || $tokens[$nextNonEmpty]['code'] === \T_CLOSE_TAG
+        ) {
+            return;
+        }
+
+        $fix = $phpcsFile->addFixableError(
+            'Only one statement is allowed when using short open echo PHP tags.'
+                . ' Use the "<?php" open tag for multi-statement PHP.',
+            $nextNonEmpty,
+            'Found'
+        );
+
+        if ($fix === true) {
+            if ($tokens[($stackPtr + 1)]['code'] === \T_WHITESPACE) {
+                $phpcsFile->fixer->replaceToken($stackPtr, '<?php echo');
+            } else {
+                $phpcsFile->fixer->replaceToken($stackPtr, '<?php echo ');
+            }
+        }
+    }
+}

--- a/Universal/Tests/PHP/OneStatementInShortEchoTagUnitTest.1.inc
+++ b/Universal/Tests/PHP/OneStatementInShortEchoTagUnitTest.1.inc
@@ -1,0 +1,33 @@
+<?php
+
+// Multiple statements when in using normal open tags is fine.
+$someText = 'something';
+echo 'b';
+
+// Single statement in short open echo tags is fine.
+?>
+<div><?= $someText ?></div>
+<div><?= $someText /* comment */ ?></div>
+<div><?= $someText; ?></div>
+<div><?= $someText, $anotherText, $moreText; //comment
+?></div>
+<div><?= $someText . $anotherText . ($x + 10); ?></div>
+<div><?= ($cond) ? $someText : $anotherText ?></div>
+
+// Multiple statements in short open echo tags should be flagged.
+<div><?=$someText;
+echo $anotherText;
+?></div>
+<div><?= $someText;
+if ($cond) {
+    echo $someText;
+} else {
+    echo $anotherText;
+}
+?></div>
+<div><?= $someText;
+trigger_error('test', E_USER_NOTICE);
+?></div>
+
+// Unclosed tag. This must be the last test in the file.
+<div><?= $someText

--- a/Universal/Tests/PHP/OneStatementInShortEchoTagUnitTest.1.inc.fixed
+++ b/Universal/Tests/PHP/OneStatementInShortEchoTagUnitTest.1.inc.fixed
@@ -1,0 +1,33 @@
+<?php
+
+// Multiple statements when in using normal open tags is fine.
+$someText = 'something';
+echo 'b';
+
+// Single statement in short open echo tags is fine.
+?>
+<div><?= $someText ?></div>
+<div><?= $someText /* comment */ ?></div>
+<div><?= $someText; ?></div>
+<div><?= $someText, $anotherText, $moreText; //comment
+?></div>
+<div><?= $someText . $anotherText . ($x + 10); ?></div>
+<div><?= ($cond) ? $someText : $anotherText ?></div>
+
+// Multiple statements in short open echo tags should be flagged.
+<div><?php echo $someText;
+echo $anotherText;
+?></div>
+<div><?php echo $someText;
+if ($cond) {
+    echo $someText;
+} else {
+    echo $anotherText;
+}
+?></div>
+<div><?php echo $someText;
+trigger_error('test', E_USER_NOTICE);
+?></div>
+
+// Unclosed tag. This must be the last test in the file.
+<div><?= $someText

--- a/Universal/Tests/PHP/OneStatementInShortEchoTagUnitTest.2.inc
+++ b/Universal/Tests/PHP/OneStatementInShortEchoTagUnitTest.2.inc
@@ -1,0 +1,2 @@
+// Parse error.
+<div><?= if ($cond) { $someText; } else { $anotherText; } ?></div>

--- a/Universal/Tests/PHP/OneStatementInShortEchoTagUnitTest.2.inc.fixed
+++ b/Universal/Tests/PHP/OneStatementInShortEchoTagUnitTest.2.inc.fixed
@@ -1,0 +1,2 @@
+// Parse error.
+<div><?php echo if ($cond) { $someText; } else { $anotherText; } ?></div>

--- a/Universal/Tests/PHP/OneStatementInShortEchoTagUnitTest.php
+++ b/Universal/Tests/PHP/OneStatementInShortEchoTagUnitTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\PHP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the OneStatementInShortEchoTag sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\PHP\OneStatementInShortEchoTagSniff
+ *
+ * @since 1.0.0
+ */
+class OneStatementInShortEchoTagUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @param string $testFile The name of the file being tested.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getErrorList($testFile = '')
+    {
+        switch ($testFile) {
+            case 'OneStatementInShortEchoTagUnitTest.1.inc':
+                return [
+                    19 => 1,
+                    22 => 1,
+                    29 => 1,
+                ];
+
+            case 'OneStatementInShortEchoTagUnitTest.2.inc':
+                return [
+                    2 => 1,
+                ];
+
+            default:
+                return [];
+        }
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Sniff to disallow short open echo tags `<?=` containing more than one PHP statement.

When using short open echo tags, PHP will echo out the result of the first statement. Subsequent statements will not be echo-ed out, but will be treated as "normal" PHP.
As a best practice, short open echo tags should contain only one statement.

Includes fixer.
Includes unit tests.
Includes documentation.