### PR TITLE
Universal/DisallowAlternativeSyntax: bug fix

### DIFF
--- a/Universal/Sniffs/ControlStructures/DisallowAlternativeSyntaxSniff.php
+++ b/Universal/Sniffs/ControlStructures/DisallowAlternativeSyntaxSniff.php
@@ -131,7 +131,7 @@ class DisallowAlternativeSyntaxSniff implements Sniff
             $phpcsFile->recordMetric($stackPtr, 'Control structure style', 'alternative syntax');
         }
 
-        if ($this->allowWithInlineHTML === true) {
+        if ($hasInlineHTML !== false && $this->allowWithInlineHTML === true) {
             return;
         }
 

--- a/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.inc
+++ b/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.inc
@@ -141,6 +141,40 @@ A is something else
 
 <?php
 // phpcs:set Universal.ControlStructures.DisallowAlternativeSyntax allowWithInlineHTML true
+if (true):
+    // Code.
+elseif (false):
+    // Code.
+else:
+    // Code.
+endif;
+
+for ($i = 1; $i <= 10; $i++)
+    :
+    echo $i;
+endfor;
+
+foreach ($a as $k => $v):
+    echo "Key: $k; Current value of \$a: $v.\n";
+endforeach;
+
+while (++$i <= 10):
+    echo $i;
+endwhile /*comment*/ ;
+
+switch ($foo) :
+    case 1:
+        echo '<div>something</div>';
+        break;
+    default;
+        echo '<div>something</div>';
+        break;
+endswitch;
+
+declare (ticks = 1):
+    echo 'ticking';
+enddeclare;
+
 ?>
 <?php if ($a == 5): ?>
 A is equal to 5

--- a/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.inc.fixed
+++ b/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.inc.fixed
@@ -141,6 +141,40 @@ A is something else
 
 <?php
 // phpcs:set Universal.ControlStructures.DisallowAlternativeSyntax allowWithInlineHTML true
+if (true){
+    // Code.
+} elseif (false){
+    // Code.
+} else{
+    // Code.
+}
+
+for ($i = 1; $i <= 10; $i++)
+    {
+    echo $i;
+}
+
+foreach ($a as $k => $v){
+    echo "Key: $k; Current value of \$a: $v.\n";
+}
+
+while (++$i <= 10){
+    echo $i;
+} /*comment*/ 
+
+switch ($foo) {
+    case 1:
+        echo '<div>something</div>';
+        break;
+    default;
+        echo '<div>something</div>';
+        break;
+}
+
+declare (ticks = 1){
+    echo 'ticking';
+}
+
 ?>
 <?php if ($a == 5): ?>
 A is equal to 5

--- a/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.php
+++ b/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.php
@@ -46,6 +46,14 @@ class DisallowAlternativeSyntaxUnitTest extends AbstractSniffUnitTest
             127 => 1,
             131 => 1,
             138 => 1,
+            144 => 1,
+            146 => 1,
+            148 => 1,
+            153 => 1,
+            157 => 1,
+            161 => 1,
+            165 => 1,
+            174 => 1,
         ];
     }
 


### PR DESCRIPTION
When the `allowWithInlineHTML` property was set to `true`, the sniff would always bow out, independently of whether inline HTML was found or not.

Fixed now.

Includes additional unit tests.