### PR TITLE
GH Actions: tweak coverage run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - stable
+      - develop
     paths-ignore:
       - '**.md'
   pull_request:
@@ -14,6 +15,7 @@ on:
 jobs:
   #### TEST STAGE ####
   test:
+    if: ${{ github.ref != 'refs/heads/develop' }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -139,6 +141,8 @@ jobs:
   coverage:
     # No use running the coverage builds if there are failing test builds.
     needs: test
+    # The default condition is success(), but this is false when one of the previous jobs is skipped
+    if: always() && (needs.test.result == 'success' || needs.test.result == 'skipped')
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
As things were, coverage would only be run on pull requests and on `master`.
Generally speaking, this is sufficient, but it does mean that the coverage over time is no longer properly tracked, which is a shame.

The tweaks I'm making now should:
* Still run the normal `test` and `coverage` jobs on pull requests and merges to `master`.
* For merges to `develop`, skip the `test` job, but do run the `coverage`, so it will be tracked again.