### PR TITLE
GH Actions: more tweaks

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches-ignore:
       - stable
+      - develop
     paths-ignore:
       - '**.md'
   # Allow manually triggering the workflow.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -225,6 +225,8 @@ jobs:
 
   coveralls-finish:
     needs: coverage
+    if: always() && needs.coverage.result == 'success'
+
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
* Skip the `quicktest` on `develop` as those are the same builds as for `coverage`, so no need to run those twice.
* Also make sure that the coveralls-finish will actually run. Should after a build running just coverage already, but didn't.