### PR TITLE
GH Actions: turn display_errors on

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -43,9 +43,9 @@ jobs:
         id: set_ini
         run: |
           if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED'
+            echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On'
           else
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL'
+            echo '::set-output name=PHP_INI::error_reporting=E_ALL, display_errors=On'
           fi
 
       - name: Install PHP

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,9 +81,9 @@ jobs:
         id: set_ini
         run: |
           if [[ "${{ matrix.phpcs_version }}" != "dev-master" && "${{ matrix.phpcs_version }}" != "4.0.x-dev" ]]; then
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED'
+            echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On'
           else
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL'
+            echo '::set-output name=PHP_INI::error_reporting=E_ALL, display_errors=On'
           fi
 
       - name: Install PHP
@@ -170,9 +170,9 @@ jobs:
         id: set_ini
         run: |
           if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED'
+            echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On'
           else
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL'
+            echo '::set-output name=PHP_INI::error_reporting=E_ALL, display_errors=On'
           fi
 
       - name: Install PHP


### PR DESCRIPTION
Turns out the default setting for `error_reporting` used by the SetupPHP action is `error_reporting=E_ALL & ~E_DEPRECATED & ~E_STRICT` and `display_errors` is set to `Off`.

For the purposes of CI, I'd recommend running with `E_ALL` and `display_errors=On` to ensure **all** PHP notices are shown.

In this script, error_reporting was already enabled, but the error display was not yet fixed. Sorted now.