### PR TITLE
New `Universal.Files.SeparateFunctionsFromOO` sniff

### DIFF
--- a/Universal/Docs/Files/SeparateFunctionsFromOOStandard.xml
+++ b/Universal/Docs/Files/SeparateFunctionsFromOOStandard.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Separate Functions From OO"
+    >
+    <standard>
+    <![CDATA[
+    A file should either declare (global/namespaced) functions or declare OO structures, but not both.
+
+    Nested function declarations, i.e. functions declared within a function/method will be disregarded for the purposes of this sniff.
+    The same goes for anonymous classes, closures and arrow functions.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Files containing only functions or only OO.">
+        <![CDATA[
+// Valid1.php
+<?php
+class Bar {
+    public function foo() {}
+}
+
+// Valid2.php
+<?php
+function foo() {}
+function bar() {}
+function baz() {}
+        ]]>
+        </code>
+        <code title="Invalid: File containing both OO structure declarations as well as function declarations.">
+        <![CDATA[
+// Invalid.php
+<?php
+function foo() {}
+
+class Bar {
+    public function foo() {}
+}
+
+function bar() {}
+function baz() {}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/Files/SeparateFunctionsFromOOSniff.php
+++ b/Universal/Sniffs/Files/SeparateFunctionsFromOOSniff.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\Files;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
+
+/**
+ * A file should either declare (global/namespaced) functions or declare OO structures, but not both.
+ *
+ * Nested function declarations, i.e. functions declared within a function/method will be disregarded
+ * for the purposes of this sniff.
+ * The same goes for anonymous classes, closures and arrow functions.
+ *
+ * Notes:
+ * - This sniff has no opinion on side effects. If you want to sniff for those, use the PHPCS
+ *   native `PSR1.Files.SideEffects` sniff.
+ * - This sniff has no opinion on multiple OO structures being declared in one file.
+ *   If you want to sniff for that, use the PHPCS native `Generic.Files.OneObjectStructurePerFile` sniff.
+ *
+ * @since 1.0.0
+ */
+final class SeparateFunctionsFromOOSniff implements Sniff
+{
+
+    /**
+     * Tokens this sniff searches for.
+     *
+     * Enhanced from within the register() methods.
+     *
+     * @since 1.0.0
+     *
+     * @var array
+     */
+    private $search = [
+        // Some tokens to help skip over structures we're not interested in.
+        \T_START_HEREDOC => \T_START_HEREDOC,
+        \T_START_NOWDOC  => \T_START_NOWDOC,
+    ];
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        $this->search += Tokens::$ooScopeTokens;
+        $this->search += Collections::functionDeclarationTokens();
+
+        return Collections::phpOpenTags();
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $firstOO       = null;
+        $firstFunction = null;
+        $functionCount = 0;
+        $OOCount       = 0;
+
+        for ($i = 0; $i < $phpcsFile->numTokens; $i++) {
+            // Ignore anything within square brackets.
+            if ($tokens[$i]['code'] !== \T_OPEN_CURLY_BRACKET
+                && isset($tokens[$i]['bracket_opener'], $tokens[$i]['bracket_closer'])
+                && $i === $tokens[$i]['bracket_opener']
+            ) {
+                $i = $tokens[$i]['bracket_closer'];
+                continue;
+            }
+
+            // Skip past nested arrays, function calls and arbitrary groupings.
+            if ($tokens[$i]['code'] === \T_OPEN_PARENTHESIS
+                && isset($tokens[$i]['parenthesis_closer'])
+            ) {
+                $i = $tokens[$i]['parenthesis_closer'];
+                continue;
+            }
+
+            // Skip over potentially large docblocks.
+            if ($tokens[$i]['code'] === \T_DOC_COMMENT_OPEN_TAG
+                && isset($tokens[$i]['comment_closer'])
+            ) {
+                $i = $tokens[$i]['comment_closer'];
+                continue;
+            }
+
+            // Ignore everything else we're not interested in.
+            if (isset($this->search[$tokens[$i]['code']]) === false) {
+                continue;
+            }
+
+            // Skip over structures which won't contain anything we're interested in.
+            if (($tokens[$i]['code'] === \T_START_HEREDOC
+                || $tokens[$i]['code'] === \T_START_NOWDOC
+                || $tokens[$i]['code'] === \T_ANON_CLASS
+                || $tokens[$i]['code'] === \T_CLOSURE
+                || $tokens[$i]['code'] === \T_FN)
+                && isset($tokens[$i]['scope_condition'], $tokens[$i]['scope_closer'])
+                && $tokens[$i]['scope_condition'] === $i
+            ) {
+                $i = $tokens[$i]['scope_closer'];
+                continue;
+            }
+
+            // This will be either a function declaration or an OO declaration token.
+            if ($tokens[$i]['code'] === \T_FUNCTION) {
+                if (isset($firstFunction) === false) {
+                    $firstFunction = $i;
+                }
+
+                ++$functionCount;
+            } else {
+                if (isset($firstOO) === false) {
+                    $firstOO = $i;
+                }
+
+                ++$OOCount;
+            }
+
+            if (isset($tokens[$i]['scope_closer']) === true) {
+                $i = $tokens[$i]['scope_closer'];
+            }
+        }
+
+        if ($functionCount > 0 && $OOCount > 0) {
+            $phpcsFile->recordMetric($stackPtr, 'Functions or OO declarations ?', 'Both function and OO declarations');
+
+            $reportToken = \max($firstFunction, $firstOO);
+
+            $phpcsFile->addError(
+                'A file should either contain function declarations or OO structure declarations, but not both.'
+                    . ' Found %d function declaration(s) and %d OO structure declaration(s).'
+                    . ' The first function declaration was found on line %d;'
+                    . ' the first OO declaration was found on line %d',
+                $reportToken,
+                'Mixed',
+                [
+                    $functionCount,
+                    $OOCount,
+                    $tokens[$firstFunction]['line'],
+                    $tokens[$firstOO]['line'],
+                ]
+            );
+        } elseif ($functionCount > 0) {
+            $phpcsFile->recordMetric($stackPtr, 'Functions or OO declarations ?', 'Only function(s)');
+        } elseif ($OOCount > 0) {
+            $phpcsFile->recordMetric($stackPtr, 'Functions or OO declarations ?', 'Only OO structure(s)');
+        } else {
+            $phpcsFile->recordMetric($stackPtr, 'Functions or OO declarations ?', 'Neither');
+        }
+
+        // Ignore the rest of the file.
+        return ($phpcsFile->numTokens + 1);
+    }
+}

--- a/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.1.inc
+++ b/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.1.inc
@@ -1,0 +1,40 @@
+<?php
+
+// Valid: File which only declares functions, both global and namespaced.
+
+function fooA() {}
+
+function fooB() {}
+
+function fooC() {}
+
+namespace First;
+
+function firstFooA() {}
+
+function firstFooB() {}
+
+namespace Second;
+
+function secondFooA() {}
+
+if ($a === $b) {
+    function secondFooB() {}
+}
+
+// This sniff has no rules about side-effects.
+$globVar = new class() {
+    public function thisIsAnAnonymousClass() {}
+};
+
+$closure = function($a, $b) {
+    return $a + $b;
+};
+
+define('MY_CONSTANT', 'foo');
+
+const ANOTHER_CONSTANT = 'bar';
+
+while ( true ) {
+    // Do something.
+}

--- a/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.2.inc
+++ b/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.2.inc
@@ -1,0 +1,41 @@
+<?php
+
+// Valid: File which only declares functions, both global and namespaced.
+
+namespace {
+    function fooA() {}
+    function fooB() {}
+    function fooC() {}
+}
+
+namespace First {
+    function firstFooA() {}
+    function firstFooB() {}
+}
+
+namespace Second {
+    function secondFooA() {}
+
+    if ($a === $b) {
+        function secondFooB() {}
+    }
+}
+
+namespace {
+    // This sniff has no rules about side-effects.
+    $globVar = new class() {
+        public function thisIsAnAnonymousClass() {}
+    };
+
+    $closure = function($a, $b) {
+        return $a + $b;
+    };
+
+    define('MY_CONSTANT', 'foo');
+
+    const ANOTHER_CONSTANT = 'bar';
+
+    while ( true ) {
+        // Do something.
+    }
+}

--- a/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.3.inc
+++ b/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.3.inc
@@ -1,0 +1,48 @@
+<?php
+
+// Valid: File which only declares OO structures, both global and namespaced.
+
+abstract class fooA {
+    // Methods within OO structures should be ignored by the sniff.
+    function get() {}
+    abstract function set();
+}
+
+interface fooB() {}
+
+trait fooC() {}
+
+namespace First;
+
+class firstFooA() {}
+
+trait firstFooB() {}
+
+namespace Second;
+
+interface secondFooA() {
+    // Methods within OO structures should be ignored by the sniff.
+    function get();
+    function set();
+}
+
+if (!class_exists('secondFooB')) {
+    class secondFooB() {}
+}
+
+// This sniff has no rules about side-effects.
+$globVar = new class() {
+    public function thisIsAnAnonymousClass() {}
+};
+
+$closure = function($a, $b) {
+    return $a + $b;
+};
+
+define('MY_CONSTANT', 'foo');
+
+const ANOTHER_CONSTANT = 'bar';
+
+while ( true ) {
+    // Do something.
+}

--- a/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.4.inc
+++ b/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.4.inc
@@ -1,0 +1,50 @@
+<?php
+
+// Valid: File which only declares OO structures, both global and namespaced.
+
+namespace {
+    abstract class fooA {
+        // Methods within OO structures should be ignored by the sniff.
+        function get() {}
+        abstract function set();
+    }
+
+    interface fooB() {}
+    trait fooC() {}
+}
+
+namespace First {
+    class firstFooA() {}
+    trait firstFooB() {}
+}
+
+namespace Second {
+    interface secondFooA() {
+        // Methods within OO structures should be ignored by the sniff.
+        function get();
+        function set();
+    }
+
+    if (!class_exists('secondFooB')) {
+        class secondFooB() {}
+    }
+}
+
+namespace {
+    // This sniff has no rules about side-effects.
+    $globVar = new class() {
+        public function thisIsAnAnonymousClass() {}
+    };
+
+    $closure = function($a, $b) {
+        return $a + $b;
+    };
+
+    define('MY_CONSTANT', 'foo');
+
+    const ANOTHER_CONSTANT = 'bar';
+
+    while ( true ) {
+        // Do something.
+    }
+}

--- a/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.5.inc
+++ b/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.5.inc
@@ -1,0 +1,35 @@
+<?php
+
+// Valid: File which doesn't declare functions nor OO structures.
+
+$globVar = new class() {
+    public function thisIsAnAnonymousClass() {}
+};
+
+/**
+ * Docblock
+ */
+$closure = function($a, $b) {
+    return $a + $b;
+};
+
+define('MY_CONSTANT', 'foo');
+
+const ANOTHER_CONSTANT = 'bar';
+
+while ( true ) {
+    $array      = array( 1, 2, 3 );
+    $list       = list( 1, 2, 3 );
+    $shortArray = [ 1, 2, 3 ];
+    [ 1, 2, 3 ] = $shortList;
+
+    $array['access'] = 'key';
+}
+
+$heredoc = <<<EOD
+text
+EOD;
+
+$nowdoc = <<<'EOD'
+text
+EOD;

--- a/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.6.inc
+++ b/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.6.inc
@@ -1,0 +1,11 @@
+<?php
+
+// Invalid: File which declares both function(s) as well as OO structure(s).
+
+function foo() {}
+
+class Bar() {}
+
+if ($a === $b ) {
+    function secondFooB() {}
+}

--- a/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.7.inc
+++ b/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.7.inc
@@ -1,0 +1,11 @@
+<?php
+
+// Invalid: File which declares both function(s) as well as OO structure(s).
+
+interface IBar {
+    function bar();
+}
+
+trait TBar {}
+
+function foo() {}

--- a/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.php
+++ b/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\Files;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the SeparateFunctionsFromOO sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\Files\SeparateFunctionsFromOOSniff
+ *
+ * @since 1.0.0
+ */
+final class SeparateFunctionsFromOOUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @param string $testFile The name of the file being tested.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getErrorList($testFile = '')
+    {
+        switch ($testFile) {
+            case 'SeparateFunctionsFromOOUnitTest.6.inc':
+                return [
+                    7 => 1,
+                ];
+
+            case 'SeparateFunctionsFromOOUnitTest.7.inc':
+                return [
+                    11 => 1,
+                ];
+
+            default:
+                return [];
+        }
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array <int line number> => <int number of warnings>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
This sniff will enforce that a file should either declare (global/namespaced) functions or declare OO structures, but not both.

Nested function declarations, i.e. functions declared within a function/method will be disregarded for the purposes of this sniff.
The same goes for anonymous classes, closures and arrow functions.

Other notes:
- This sniff has no opinion on side effects. If you want to sniff for those, use the PHPCS native `PSR1.Files.SideEffects` sniff.
- This sniff has no opinion on multiple OO structures being declared in one file.
    If you want to sniff for that, use the PHPCS native `Generic.Files.OneObjectStructurePerFile` sniff.

Includes unit tests.
Includes documentation.
Includes metrics.