### PR TITLE
CI: various updates

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -10,6 +10,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   checkcs:
     name: 'Basic CS and QA checks'

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -39,7 +39,7 @@ jobs:
           composer require --no-update squizlabs/php_codesniffer:"dev-master"
           # Add PHPCSDevCS - this is the CS ruleset we use.
           # This is not in the composer.json as it has different minimum PHPCS reqs and would conflict.
-          composer require --no-update --dev phpcsstandards/phpcsdevcs:"^1.1.2"
+          composer require --no-update --dev phpcsstandards/phpcsdevcs:"^1.1.3"
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -11,6 +11,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   #### QUICK TEST STAGE ####
   # This is a much quicker test which only runs the unit tests and linting against the low/high

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -51,7 +51,7 @@ jobs:
           if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
             echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On'
           else
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL, display_errors=On'
+            echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On'
           fi
 
       - name: Install PHP

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -70,7 +70,7 @@ jobs:
         if: matrix.php != 'latest'
         uses: "ramsey/composer-install@v1"
 
-      # For the PHP "nightly", we need to install with ignore platform reqs as not all dependencies allow it yet.
+      # For the PHP "latest", we need to install with ignore platform reqs as not all dependencies allow it yet.
       - name: Install Composer dependencies - with ignore platform
         if: matrix.php == 'latest'
         uses: "ramsey/composer-install@v1"
@@ -81,5 +81,10 @@ jobs:
         if: matrix.phpcs_version == 'dev-master'
         run: composer lint
 
-      - name: Run the unit tests
+      - name: Run the unit tests - PHP 5.4 - 8.0
+        if: matrix.php != 'latest'
         run: composer test
+
+      - name: Run the unit tests - PHP > 8.1
+        if: matrix.php == 'latest'
+        run: composer test -- --no-configuration --bootstrap=phpunit-bootstrap.php --dont-report-useless-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,7 @@ jobs:
           if [[ "${{ matrix.phpcs_version }}" != "dev-master" && "${{ matrix.phpcs_version }}" != "4.0.x-dev" ]]; then
             echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On'
           else
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL, display_errors=On'
+            echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On'
           fi
 
       - name: Install PHP
@@ -178,7 +178,7 @@ jobs:
           if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
             echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On'
           else
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL, display_errors=On'
+            echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On'
           fi
 
       - name: Install PHP

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
         # - PHPCS will run without errors on PHP 5.4 - 7.2 on any supported version.
         # - PHP 7.4 needs PHPCS 3.5.0+ to run without errors.
         # - PHP 8.0 needs PHPCS 3.5.7+ to run without errors.
+        # - PHP 8.1 needs PHPCS 3.6.1+ to run without errors.
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
         php: ['5.5', '5.6', '7.0', '7.1', '7.2']
@@ -46,6 +47,13 @@ jobs:
         include:
           # Complement the builds run in code coverage to complete the matrix and prevent issues
           # with PHPCS versions incompatible with certain PHP versions.
+          - php: '8.1'
+            phpcs_version: 'dev-master'
+            experimental: false
+          - php: '8.1'
+            phpcs_version: '3.6.1'
+            experimental: false
+
           - php: '8.0'
             phpcs_version: 'dev-master'
             experimental: false
@@ -62,10 +70,7 @@ jobs:
             experimental: false
 
           # Experimental builds. These are allowed to fail.
-
-          # Current lowest PHPCS version which _may_ run on PHP 8 is 3.5.7, so don't even try
-          # to test against older versions.
-          - php: '8.1'
+          - php: '8.2'
             phpcs_version: 'dev-master'
             experimental: true
 
@@ -133,11 +138,11 @@ jobs:
         run: composer lint
 
       - name: Run the unit tests - PHP 5.4 - 8.0
-        if: ${{ matrix.php != '8.1' }}
+        if: ${{ matrix.php < '8.1' }}
         run: composer test
 
-      - name: Run the unit tests - PHP 8.1
-        if: ${{ matrix.php == '8.1' }}
+      - name: Run the unit tests - PHP > 8.1
+        if: ${{ matrix.php >= '8.1' }}
         run: composer test -- --no-configuration --bootstrap=phpunit-bootstrap.php --dont-report-useless-tests
 
   #### CODE COVERAGE STAGE ####

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   #### TEST STAGE ####
   test:

--- a/composer.json
+++ b/composer.json
@@ -71,5 +71,10 @@
         "coverage-local": [
             "@php ./vendor/phpunit/phpunit/phpunit --filter PHPCSExtra ./vendor/squizlabs/php_codesniffer/tests/AllTests.php --coverage-html ./build/coverage-html"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
             "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
         ],
         "install-devcs": [
-            "composer require --dev phpcsstandards/phpcsdevcs:\"^1.1\" --no-suggest"
+            "composer require --dev phpcsstandards/phpcsdevcs:\"^1.1.3\" --no-suggest"
         ],
         "remove-devcs": [
             "composer remove --dev phpcsstandards/phpcsdevcs"


### PR DESCRIPTION
### Composer: use PHPCSDevCS v 1.1.3

Ref: https://github.com/PHPCSStandards/PHPCSDevCS/releases/tag/1.1.3

### Composer: allow the PHPCS plugin

The `dealerdirect/phpcodesniffer-composer-installer` Composer plugin is used to register external PHPCS standards with PHPCS.

As of Composer 2.2.0, Composer plugins need to be explicitly allowed to run. This adds the necessary configuration for that.

Refs:
* https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution

### GH Actions: auto-cancel previous builds for same branch

Previously, in Travis, when the same branch was pushed again and the "Auto cancellation" option on the "Settings" page had been turned on (as it was for most repos), any still running builds for the same branch would be stopped in favour of starting the build for the newly pushed version of the branch.

To enable this behaviour in GH Actions, a `concurrency` configuration needs to be added to each workflow for which this should applied to.

More than anything, this is a way to be kind to GitHub by not wasting resources which they so kindly provide to us for free.

Refs:
* https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/
* https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency

### GH Actions: use error_reporting=-1

### GH Actions: update for the release of PHP 8.1
