### PR TITLE
GH Actions: version update for `ramsey/composer-install`

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -40,17 +40,17 @@ jobs:
       - name: 'Composer: adjust dependencies'
         run: |
           # The sniff stage doesn't run the unit tests, so no need for PHPUnit.
-          composer remove --no-update --dev phpunit/phpunit --no-scripts
+          composer remove --no-update --dev phpunit/phpunit --no-scripts --no-interaction
           # Using PHPCS `master` as an early detection system for bugs upstream.
-          composer require --no-update squizlabs/php_codesniffer:"dev-master"
+          composer require --no-update squizlabs/php_codesniffer:"dev-master" --no-interaction
           # Add PHPCSDevCS - this is the CS ruleset we use.
           # This is not in the composer.json as it has different minimum PHPCS reqs and would conflict.
-          composer require --no-update --dev phpcsstandards/phpcsdevcs:"^1.1.3"
+          composer require --no-update --dev phpcsstandards/phpcsdevcs:"^1.1.3" --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       - name: Install xmllint
         run: sudo apt-get install --no-install-recommends -y libxml2-utils

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -62,18 +62,18 @@ jobs:
           coverage: none
 
       - name: 'Composer: set PHPCS version for tests'
-        run: composer require --no-update --no-scripts squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}"
+        run: composer require --no-update --no-scripts squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies - normal
         if: matrix.php != 'latest'
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       # For the PHP "latest", we need to install with ignore platform reqs as not all dependencies allow it yet.
       - name: Install Composer dependencies - with ignore platform
         if: matrix.php == 'latest'
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
         with:
           composer-options: --ignore-platform-reqs
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 'Composer: set PHPCS version for tests'
-        run: composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}"
+        run: composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-interaction
 
       - name: 'Composer: conditionally prefer source for PHPCS'
         if: ${{ startsWith( matrix.phpcs_version, '4' ) }}
@@ -118,18 +118,18 @@ jobs:
       - name: 'Composer: conditionally remove PHPCSDevtools'
         if: ${{ startsWith( matrix.phpcs_version, '4' ) }}
         # Remove devtools as it will not (yet) install on PHPCS 4.x.
-        run: composer remove --no-update --dev phpcsstandards/phpcsdevtools
+        run: composer remove --no-update --dev phpcsstandards/phpcsdevtools --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies - normal
         if: ${{ startsWith( matrix.php, '8' ) == false }}
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       # For the PHP 8/"nightly", we need to install with ignore platform reqs as we're still using PHPUnit 7.
       - name: Install Composer dependencies - with ignore platform
         if: ${{ startsWith( matrix.php, '8' ) }}
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
         with:
           composer-options: --ignore-platform-reqs
 
@@ -197,15 +197,15 @@ jobs:
       - name: 'Composer: adjust dependencies'
         run: |
           # Set a specific PHPCS version.
-          composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-scripts
+          composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-scripts --no-interaction
 
       - name: Install Composer dependencies - normal
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       - name: Lint against parse errors
         if: matrix.phpcs_version == 'dev-master'

--- a/composer.json
+++ b/composer.json
@@ -44,10 +44,10 @@
             "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
         ],
         "install-devcs": [
-            "composer require --dev phpcsstandards/phpcsdevcs:\"^1.1.3\" --no-suggest"
+            "composer require --dev phpcsstandards/phpcsdevcs:\"^1.1.3\" --no-suggest --no-interaction"
         ],
         "remove-devcs": [
-            "composer remove --dev phpcsstandards/phpcsdevcs"
+            "composer remove --dev phpcsstandards/phpcsdevcs --no-interaction"
         ],
         "checkcs": [
             "@install-devcs",


### PR DESCRIPTION
The action used to install Composer packages and handle the caching has released a new major (and some follow-up patch releases), which means, the action reference needs to be updated to benefit from it.

Includes adding `--no-interaction` to "plain" Composer commands to potentially prevent CI hanging if, for whatever reason, interaction would be needed in the future.

Refs:
* https://github.com/ramsey/composer-install/releases/tag/2.0.0
* https://github.com/ramsey/composer-install/releases/tag/2.0.1
* https://github.com/ramsey/composer-install/releases/tag/2.0.2