### PR TITLE
README: update for Composer 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Installing via Composer is highly recommended.
 
 Run the following from the root of your project:
 ```bash
+composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
 composer require --dev phpcsstandards/phpcsextra:"^1.0"
 ```
 
@@ -65,6 +66,7 @@ composer require --dev phpcsstandards/phpcsextra:"^1.0"
 
 Alternatively, you may want to install this standard globally:
 ```bash
+composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
 composer global require --dev phpcsstandards/phpcsextra:"^1.0"
 ```
 


### PR DESCRIPTION
The `dealerdirect/phpcodesniffer-composer-installer` Composer plugin is a non-dev requirement for VIPCS.

As of Composer 2.2.0, Composer plugins need to be explicitly allowed to run.

This commit adds the CLI command to set those permissions to the installation instructions.

Refs:
* https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution