### PR TITLE
NoReservedKeywordParameterNames: more specific error indicator

### DIFF
--- a/Universal/Sniffs/NamingConventions/NoReservedKeywordParameterNamesSniff.php
+++ b/Universal/Sniffs/NamingConventions/NoReservedKeywordParameterNamesSniff.php
@@ -181,7 +181,7 @@ class NoReservedKeywordParameterNamesSniff implements Sniff
             if (isset($this->reservedNames[$name]) === true) {
                 $phpcsFile->addWarning(
                     'It is recommended not to use reserved keywords as function parameter names. Found: %s',
-                    $stackPtr,
+                    $param['token'],
                     $name . 'Found',
                     [$param['name']]
                 );

--- a/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.inc
+++ b/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.inc
@@ -7,5 +7,9 @@ $closure = function ( $foreach, $array, $require ) {}; // Bad x 3.
 $fn = fn($callable, $list) => $callable($list); // Bad x 2.
 
 abstract class Foo {
-	abstract public function bar($string, $exit, $parent); // Bad x 3.
+    abstract public function bar(
+        string &$string,
+        Foo|false $exit,
+        ?int $parent
+    ); // Bad x 3.
 }

--- a/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.php
+++ b/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.php
@@ -43,7 +43,9 @@ class NoReservedKeywordParameterNamesUnitTest extends AbstractSniffUnitTest
             5  => 2,
             6  => 3,
             7  => 2,
-            10 => 3,
+            11 => 1,
+            12 => 1,
+            13 => 1,
         ];
     }
 }


### PR DESCRIPTION
The warning for reserved keywords used in parameter names would previously be thrown on the line (+ column) where the `function` keyword for the function declaration was found.

This commit changes that to pinpoint the exact location of the reserved keyword used as a parameter name.

Includes adjusting one existing test to safeguard this (and safeguard handling with references and type declarations).