### PR TITLE
New `Universal.Classes.DisallowFinalClass` sniff

### DIFF
--- a/Universal/Docs/Classes/DisallowFinalClassStandard.xml
+++ b/Universal/Docs/Classes/DisallowFinalClassStandard.xml
@@ -1,0 +1,21 @@
+<documentation title="Disallow Final Class">
+    <standard>
+    <![CDATA[
+    Disallows the use of the `final` keyword for class declarations.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Non-final class.">
+        <![CDATA[
+<em>class</em> Foo {}
+<em>abstract class</em> Bar implements MyInterface {}
+        ]]>
+        </code>
+        <code title="Invalid: Final class.">
+        <![CDATA[
+<em>final class</em> Foo {}
+<em>final class</em> Bar extends MyAbstract {}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/Classes/DisallowFinalClassSniff.php
+++ b/Universal/Sniffs/Classes/DisallowFinalClassSniff.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHPCSUtils\BackCompat\BCFile;
+use PHPCSUtils\Utils\GetTokensAsString;
+
+/**
+ * Forbids classes from being declared as "final".
+ *
+ * @since 1.0.0
+ */
+class DisallowFinalClassSniff implements Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [
+            \T_CLASS,
+        ];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        /*
+         * Deliberately using the BCFile version of getClassProperties to allow
+         * for handling the parse error of classes declared as both final + abstract.
+         */
+        $classProp = BCFile::getClassProperties($phpcsFile, $stackPtr);
+        if ($classProp['is_final'] === false) {
+            if ($classProp['is_abstract'] === false) {
+                $phpcsFile->recordMetric($stackPtr, 'Class declaration type', 'abstract');
+            }
+
+            $phpcsFile->recordMetric($stackPtr, 'Class declaration type', 'final');
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        if (isset($tokens[$stackPtr]['scope_opener']) === false) {
+            // Live coding or parse error.
+            return;
+        }
+
+        $phpcsFile->recordMetric($stackPtr, 'Class declaration type', 'not abstract, not final');
+
+        // No extra safeguards needed, we know the keyword will exist based on the check above.
+        $finalKeyword = $phpcsFile->findPrevious(\T_FINAL, ($stackPtr - 1));
+
+        $snippet = GetTokensAsString::compact($phpcsFile, $finalKeyword, $tokens[$stackPtr]['scope_opener'], true);
+        $fix     = $phpcsFile->addFixableError(
+            'Declaring a class as final is not allowed. Found: %s}',
+            $finalKeyword,
+            'FinalClassFound',
+            [$snippet]
+        );
+
+        if ($fix === true) {
+            $phpcsFile->fixer->beginChangeset();
+            $phpcsFile->fixer->replaceToken($finalKeyword, '');
+
+            // Remove redundant whitespace.
+            for ($i = ($finalKeyword + 1); $i < $stackPtr; $i++) {
+                if ($tokens[$i]['code'] === \T_WHITESPACE) {
+                    $phpcsFile->fixer->replaceToken($i, '');
+                    continue;
+                }
+
+                break;
+            }
+
+            $phpcsFile->fixer->endChangeset();
+        }
+    }
+}

--- a/Universal/Tests/Classes/DisallowFinalClassUnitTest.inc
+++ b/Universal/Tests/Classes/DisallowFinalClassUnitTest.inc
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * OK.
+ */
+class FooA {}
+
+class FooB extends Something {}
+
+abstract class AbstractBarC implements MyInterface {}
+
+$a = new MyClass() {}
+
+class FooC {
+    // Constant, not class (PHP 8.1).
+    final const BAZ = 10;
+
+    // Method, not class.
+    final function bar() {}
+}
+
+/*
+ * Bad.
+ */
+final class BazA {}
+
+final
+
+      class CheckHandlingOfSuperfluousWhitespace extends Something {}
+
+    final class CheckHandlingOfIndentation {}
+
+final /*comment*/ class BazC implements MyInterface {}
+
+// Parse error. Remove the final keyword.
+final abstract class BazD {}
+
+// Live coding. Ignore. This must be the last test in the file.
+final class

--- a/Universal/Tests/Classes/DisallowFinalClassUnitTest.inc.fixed
+++ b/Universal/Tests/Classes/DisallowFinalClassUnitTest.inc.fixed
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * OK.
+ */
+class FooA {}
+
+class FooB extends Something {}
+
+abstract class AbstractBarC implements MyInterface {}
+
+$a = new MyClass() {}
+
+class FooC {
+    // Constant, not class (PHP 8.1).
+    final const BAZ = 10;
+
+    // Method, not class.
+    final function bar() {}
+}
+
+/*
+ * Bad.
+ */
+class BazA {}
+
+class CheckHandlingOfSuperfluousWhitespace extends Something {}
+
+    class CheckHandlingOfIndentation {}
+
+/*comment*/ class BazC implements MyInterface {}
+
+// Parse error. Remove the final keyword.
+abstract class BazD {}
+
+// Live coding. Ignore. This must be the last test in the file.
+final class

--- a/Universal/Tests/Classes/DisallowFinalClassUnitTest.php
+++ b/Universal/Tests/Classes/DisallowFinalClassUnitTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\Classes;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the DisallowFinalClass sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\Classes\DisallowFinalClassSniff
+ *
+ * @since 1.0.0
+ */
+class DisallowFinalClassUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getErrorList()
+    {
+        return [
+            25 => 1,
+            27 => 1,
+            31 => 1,
+            33 => 1,
+            36 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array <int line number> => <int number of warnings>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
New sniff to disallow classes being declared `final`.

Includes fixer.
Includes unit tests.
Includes documentation.
Includes metrics.