### PR TITLE
New `Universal.Classes.RequireFinalClass` sniff

### DIFF
--- a/Universal/Docs/Classes/RequireFinalClassStandard.xml
+++ b/Universal/Docs/Classes/RequireFinalClassStandard.xml
@@ -1,0 +1,21 @@
+<documentation title="Require Final Class">
+    <standard>
+    <![CDATA[
+    Requires the use of the `final` keyword for non-abstract class declarations.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Final class.">
+        <![CDATA[
+<em>final class</em> Foo {}
+<em>final class</em> Bar extends MyAbstract {}
+        ]]>
+        </code>
+        <code title="Invalid: Non-final class.">
+        <![CDATA[
+<em>class</em> Foo {}
+<em>abstract class</em> Bar implements MyInterface {}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/Classes/RequireFinalClassSniff.php
+++ b/Universal/Sniffs/Classes/RequireFinalClassSniff.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHPCSUtils\Utils\GetTokensAsString;
+use PHPCSUtils\Utils\ObjectDeclarations;
+
+/**
+ * Require classes being declared as "final".
+ *
+ * @since 1.0.0
+ */
+class RequireFinalClassSniff implements Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [
+            \T_CLASS,
+        ];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $classProp = ObjectDeclarations::getClassProperties($phpcsFile, $stackPtr);
+        if ($classProp['is_final'] === true) {
+            $phpcsFile->recordMetric($stackPtr, 'Class declaration type', 'final');
+            return;
+        }
+
+        if ($classProp['is_abstract'] === true) {
+            // Abstract classes can't be final.
+            $phpcsFile->recordMetric($stackPtr, 'Class declaration type', 'abstract');
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        if (isset($tokens[$stackPtr]['scope_opener']) === false) {
+            // Live coding or parse error.
+            return;
+        }
+
+        $phpcsFile->recordMetric($stackPtr, 'Class declaration type', 'not abstract, not final');
+
+        $snippet = GetTokensAsString::compact($phpcsFile, $stackPtr, $tokens[$stackPtr]['scope_opener'], true);
+        $fix     = $phpcsFile->addFixableError(
+            'A non-abstract class should be declared as final. Found: %s}',
+            $stackPtr,
+            'NonFinalClassFound',
+            [$snippet]
+        );
+
+        if ($fix === true) {
+            $phpcsFile->fixer->addContentBefore($stackPtr, 'final ');
+        }
+    }
+}

--- a/Universal/Tests/Classes/RequireFinalClassUnitTest.inc
+++ b/Universal/Tests/Classes/RequireFinalClassUnitTest.inc
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * OK.
+ */
+final class FooA {}
+
+final /*comment*/ class FooB extends Something {}
+
+final
+    /*comment*/
+    class FooC {}
+
+abstract class AbstractBarC implements MyInterface {}
+
+$a = new MyClass() {}
+
+// Parse error. Not our concern.
+final abstract class BazD {}
+
+/*
+ * Bad.
+ */
+class BazA {}
+
+    class CheckHandlingOfIndentation extends Something {}
+
+class BazC implements MyInterface {}
+
+// Live coding. Ignore. This must be the last test in the file.
+class LiveCoding

--- a/Universal/Tests/Classes/RequireFinalClassUnitTest.inc.fixed
+++ b/Universal/Tests/Classes/RequireFinalClassUnitTest.inc.fixed
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * OK.
+ */
+final class FooA {}
+
+final /*comment*/ class FooB extends Something {}
+
+final
+    /*comment*/
+    class FooC {}
+
+abstract class AbstractBarC implements MyInterface {}
+
+$a = new MyClass() {}
+
+// Parse error. Not our concern.
+final abstract class BazD {}
+
+/*
+ * Bad.
+ */
+final class BazA {}
+
+    final class CheckHandlingOfIndentation extends Something {}
+
+final class BazC implements MyInterface {}
+
+// Live coding. Ignore. This must be the last test in the file.
+class LiveCoding

--- a/Universal/Tests/Classes/RequireFinalClassUnitTest.php
+++ b/Universal/Tests/Classes/RequireFinalClassUnitTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\Classes;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the RequireFinalClass sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\Classes\RequireFinalClassSniff
+ *
+ * @since 1.0.0
+ */
+class RequireFinalClassUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getErrorList()
+    {
+        return [
+            24 => 1,
+            26 => 1,
+            28 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array <int line number> => <int number of warnings>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
New sniff to require all non-abstract classes to be declared `final`.

:warning: The included fixer should be considered a risky fixer as it can break integrations!

Includes fixer.
Includes unit tests.
Includes documentation.
Includes metrics.