### PR TITLE
New `Universal.CodeAnalysis.ForeachUniqueAssignment` sniff

### DIFF
--- a/Universal/Docs/CodeAnalysis/ForeachUniqueAssignmentStandard.xml
+++ b/Universal/Docs/CodeAnalysis/ForeachUniqueAssignmentStandard.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<documentation title="Foreach Unique Assignment">
+    <standard>
+    <![CDATA[
+    When a foreach control structure uses the same variable for both the $key as well as the $value assignment, the key will be disregarded and be inaccessible and the variable will contain the value.
+    Mix in reference assignments and the behaviour becomes even more unpredictable.
+
+    This is a coding error. Either use unique variables for the key and the value or don't assign the key.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: using unique variables.">
+        <![CDATA[
+foreach ($array as $k => $v ) {}
+        ]]>
+        </code>
+        <code title="Invalid: using the same variable for both the key as well as the value.">
+        <![CDATA[
+foreach ($array as $k => $k ) {}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/CodeAnalysis/ForeachUniqueAssignmentSniff.php
+++ b/Universal/Sniffs/CodeAnalysis/ForeachUniqueAssignmentSniff.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\CodeAnalysis;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\GetTokensAsString;
+
+/**
+ * Detects using the same variable for both the key as well as the value in a foreach assignment.
+ *
+ * @link https://twitter.com/exakat/status/1509103728934203397
+ * @link https://3v4l.org/DdddX
+ *
+ * @since 1.0.0
+ */
+class ForeachUniqueAssignmentSniff implements Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [\T_FOREACH];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['parenthesis_opener'], $tokens[$stackPtr]['parenthesis_closer']) === false) {
+            // Parse error or live coding, not our concern.
+            return;
+        }
+
+        $opener = $tokens[$stackPtr]['parenthesis_opener'];
+        $closer = $tokens[$stackPtr]['parenthesis_closer'];
+
+        $asPtr = $phpcsFile->findNext(\T_AS, ($opener + 1), $closer);
+        if ($asPtr === false) {
+            // Parse error or live coding, not our concern.
+            return;
+        }
+
+        $doubleArrowPtr = $phpcsFile->findNext(\T_DOUBLE_ARROW, ($asPtr + 1), $closer);
+        if ($doubleArrowPtr === false) {
+            // Key does not get assigned.
+            return;
+        }
+
+        $keyAsString   = GetTokensAsString::noEmpties($phpcsFile, ($asPtr + 1), ($doubleArrowPtr - 1));
+        $valueAsString = GetTokensAsString::noEmpties($phpcsFile, ($doubleArrowPtr + 1), ($closer - 1));
+
+        if (\ltrim($keyAsString, '&') !== \ltrim($valueAsString, '&')) {
+            // Key and value not the same.
+            return;
+        }
+
+        $error  = 'The variables used for the key and the value in a foreach assignment should be unique.';
+        $error .= 'Both the key and the value will be currently assigned to: "%s"';
+
+        $fix = $phpcsFile->addFixableError($error, $doubleArrowPtr, 'NotUnique', [$valueAsString]);
+        if ($fix === true) {
+            $phpcsFile->fixer->beginChangeset();
+
+            // Remove the key.
+            for ($i = ($asPtr + 1); $i < ($doubleArrowPtr + 1); $i++) {
+                if ($tokens[$i]['code'] === \T_WHITESPACE
+                    && isset(Tokens::$commentTokens[$tokens[($i + 1)]['code']])
+                ) {
+                    // Don't remove whitespace when followed directly by a comment.
+                    continue;
+                }
+
+                if (isset(Tokens::$commentTokens[$tokens[$i]['code']])) {
+                    // Don't remove comments.
+                    continue;
+                }
+
+                // Remove everything else.
+                $phpcsFile->fixer->replaceToken($i, '');
+            }
+
+            $phpcsFile->fixer->endChangeset();
+        }
+    }
+}

--- a/Universal/Tests/CodeAnalysis/ForeachUniqueAssignmentUnitTest.inc
+++ b/Universal/Tests/CodeAnalysis/ForeachUniqueAssignmentUnitTest.inc
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Not an issue.
+ */
+// No double arrow in assignment.
+foreach ($array as $v ) {}
+foreach (array( 1 => 'value') as $v ) {}
+
+// Unique variables.
+foreach ($array as $k => $v ) {}
+foreach ($array as $k => &$v ) {}
+foreach ($array as $k['key'] => $k['value'] ) {}
+foreach ($array as $k[$name] => $k[$value] ) {}
+foreach ($data as $key => [$id, [$name, $address]]) {}
+foreach ($data as list("id" => $id, "name" => $name)) {}
+foreach ($array as array($a) => list($a) ) {}
+
+/*
+ * The issue.
+ */
+foreach ($array as $k => $k ) {}
+foreach ($array as /*comment*/ $k [ 'key' ] => $k['key'] ) {}
+foreach ($array as $k[$name /*comment*/] => $k[/*comment*/ $name] ) {}
+foreach ($array as [$a] => [$a] ) {}
+foreach ($array as list($a) => list($a) ) {}
+foreach ( $data as $this->prop['key'] => $this->prop['key'] ) {}
+
+// Also detect the same variable being used in combination with a reference assignment.
+foreach ($a as $k => &$k) {}
+
+/*
+ * Parse errors, not our concern.
+ */
+foreach ($array) {} // Missing "as".
+foreach ($array as $k => $k

--- a/Universal/Tests/CodeAnalysis/ForeachUniqueAssignmentUnitTest.inc.fixed
+++ b/Universal/Tests/CodeAnalysis/ForeachUniqueAssignmentUnitTest.inc.fixed
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Not an issue.
+ */
+// No double arrow in assignment.
+foreach ($array as $v ) {}
+foreach (array( 1 => 'value') as $v ) {}
+
+// Unique variables.
+foreach ($array as $k => $v ) {}
+foreach ($array as $k => &$v ) {}
+foreach ($array as $k['key'] => $k['value'] ) {}
+foreach ($array as $k[$name] => $k[$value] ) {}
+foreach ($data as $key => [$id, [$name, $address]]) {}
+foreach ($data as list("id" => $id, "name" => $name)) {}
+foreach ($array as array($a) => list($a) ) {}
+
+/*
+ * The issue.
+ */
+foreach ($array as $k ) {}
+foreach ($array as /*comment*/ $k['key'] ) {}
+foreach ($array as /*comment*/ $k[/*comment*/ $name] ) {}
+foreach ($array as [$a] ) {}
+foreach ($array as list($a) ) {}
+foreach ( $data as $this->prop['key'] ) {}
+
+// Also detect the same variable being used in combination with a reference assignment.
+foreach ($a as &$k) {}
+
+/*
+ * Parse errors, not our concern.
+ */
+foreach ($array) {} // Missing "as".
+foreach ($array as $k => $k

--- a/Universal/Tests/CodeAnalysis/ForeachUniqueAssignmentUnitTest.php
+++ b/Universal/Tests/CodeAnalysis/ForeachUniqueAssignmentUnitTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\CodeAnalysis;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the ForeachUniqueAssignment sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\CodeAnalysis\ForeachUniqueAssignmentSniff
+ *
+ * @since 1.0.0
+ */
+class ForeachUniqueAssignmentUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getErrorList()
+    {
+        return [
+            22 => 1,
+            23 => 1,
+            24 => 1,
+            25 => 1,
+            26 => 1,
+            27 => 1,
+            30 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array <int line number> => <int number of warnings>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Inspired by a tweet from @dseguy, this new sniff will detect `foreach` control structures which use the same variable for both the _key_ as well as the _value_ assignment as this will lead to unexpected - and most likely unintended - behaviour.

The sniff includes a fixer which will remove the key assignment when the issue is detected as the value is required and the key optional.

The fixer maintains the existing behaviour for the code, though that behaviour may not be the desired behaviour, so any autogenerated fixes should be carefully reviewed (as always).

Refs:
* https://twitter.com/exakat/status/1509103728934203397
* https://3v4l.org/DdddX

Includes fixer.
Includes unit tests.
Includes documentation.