### PR TITLE
Add dependabot configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# Dependabot configuration.
+#
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5 # Set to 0 to (temporarily) disable.
+    versioning-strategy: widen
+    commit-message:
+      prefix: "Composer:"
+    labels:
+      - "Type: chores/QA"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "GH Actions:"
+    labels:
+      - "Type: chores/QA"


### PR DESCRIPTION
This automatically enabled Dependabot to:
* Submit pull requests for security updates and version updates for Composer dependencies.
* Submit pull requests for security updates and version updates for GH Action runner dependencies.

For Composer dependencies, a preference is given to _widen_ the version restrictions instead of updating them to a new minimum.
This is a deliberate choice as this package is a library, not an application.

The configuration has been set up to:
* Run once a week.
* Submit a maximum of 5 pull requests at a time.
    If additional pull requests are needed, these will subsequently be submitted the next time Dependabot runs after one or more of the open pull requests have been merged.
* The commit messages for PRs submitted by Dependabot will be prefixed according the conventions used in this repo up to now.
* The PRs will automatically be labelled with an appropriate label as already in use in this repo.