### PR TITLE
GH Actions: show deprecations when linting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "prefer-stable": true,
     "scripts" : {
         "lint": [
-            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
+            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . --show-deprecated -e php --exclude vendor --exclude .git"
         ],
         "install-devcs": [
             "composer require --dev phpcsstandards/phpcsdevcs:\"^1.1.3\" --no-suggest --no-interaction"


### PR DESCRIPTION
While rare, there are some deprecations which PHP can show when a file is being linted.
By default these are ignored by PHP-Parallel-Lint.

Apparently though, there is an option to show them (wasn't documented until recently), so let's turn that option on.