### PR TITLE
Composer: up the minimum PHPCS version to 3.7.0 & remove work-arounds

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -29,13 +29,7 @@ jobs:
     strategy:
       matrix:
         php: ['5.4', 'latest']
-        phpcs_version: ['dev-master']
-
-        include:
-          - php: '7.3'
-            phpcs_version: '3.3.1'
-          - php: '5.4'
-            phpcs_version: '3.3.1'
+        phpcs_version: ['3.7.0', 'dev-master']
 
     name: "QTest${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
 
@@ -70,7 +64,7 @@ jobs:
         if: matrix.php != 'latest'
         uses: "ramsey/composer-install@v2"
 
-      # For the PHP "latest", we need to install with ignore platform reqs as not all dependencies allow it yet.
+      # For the PHP "latest", we need to install with ignore platform reqs as not all PHPUnit 7.x dependencies allow it.
       - name: Install Composer dependencies - with ignore platform
         if: matrix.php == 'latest'
         uses: "ramsey/composer-install@v2"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,35 +40,11 @@ jobs:
         # - PHP 8.1 needs PHPCS 3.6.1+ to run without errors.
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
-        php: ['5.5', '5.6', '7.0', '7.1', '7.2']
-        phpcs_version: ['3.3.1', 'dev-master']
+        php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '8.0', '8.1']
+        phpcs_version: ['3.7.0', 'dev-master']
         experimental: [false]
 
         include:
-          # Complement the builds run in code coverage to complete the matrix and prevent issues
-          # with PHPCS versions incompatible with certain PHP versions.
-          - php: '8.1'
-            phpcs_version: 'dev-master'
-            experimental: false
-          - php: '8.1'
-            phpcs_version: '3.6.1'
-            experimental: false
-
-          - php: '8.0'
-            phpcs_version: 'dev-master'
-            experimental: false
-          - php: '8.0'
-            phpcs_version: '3.5.7'
-            experimental: false
-
-          - php: '7.4'
-            phpcs_version: '3.5.0'
-            experimental: false
-
-          - php: '7.3'
-            phpcs_version: 'dev-master'
-            experimental: false
-
           # Experimental builds. These are allowed to fail.
           - php: '8.2'
             phpcs_version: 'dev-master'
@@ -161,13 +137,7 @@ jobs:
       matrix:
         # 7.4 should be updated to 8.0 when higher PHPUnit versions can be supported.
         php: ['5.4', '7.4']
-        phpcs_version: ['dev-master']
-
-        include:
-          - php: '7.3'
-            phpcs_version: '3.3.1'
-          - php: '5.4'
-            phpcs_version: '3.3.1'
+        phpcs_version: ['3.7.0', 'dev-master']
 
     name: "Coverage${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Minimum Requirements
 -------------------------------------------
 
 * PHP 5.4 or higher.
-* [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **3.3.1** or higher.
+* [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **3.7.0** or higher.
 * [PHPCSUtils](https://github.com/PHPCSStandards/PHPCSUtils) version **1.0.0** or higher.
 
 

--- a/Universal/Sniffs/Constants/LowercaseClassResolutionKeywordSniff.php
+++ b/Universal/Sniffs/Constants/LowercaseClassResolutionKeywordSniff.php
@@ -34,15 +34,8 @@ class LowercaseClassResolutionKeywordSniff implements Sniff
      */
     public function register()
     {
-        /*
-         * In PHPCS < 3.4.1, the class keyword after a double colon + comment may be tokenized as
-         * `T_CLASS` instead of as `T_STRING`, so registering both.
-         *
-         * @link https://github.com/squizlabs/php_codesniffer/issues/2431
-         */
         return [
-            \T_STRING,
-            \T_CLASS,
+            \T_STRING
         ];
     }
 

--- a/Universal/Sniffs/ControlStructures/DisallowAlternativeSyntaxSniff.php
+++ b/Universal/Sniffs/ControlStructures/DisallowAlternativeSyntaxSniff.php
@@ -87,22 +87,7 @@ class DisallowAlternativeSyntaxSniff implements Sniff
         }
 
         /*
-         * Deal with declare. Declare with alternative syntax does not get the scope opener/closer
-         * assigned in the tokens array prior to PHPCS 3.5.4, so let's set those ourselves.
-         *
-         * @link https://github.com/squizlabs/PHP_CodeSniffer/pull/2843
-         */
-        if ($tokens[$stackPtr]['code'] === \T_DECLARE && isset($tokens[$stackPtr]['scope_opener']) === false) {
-            $declareOpenClose = ControlStructures::getDeclareScopeOpenClose($phpcsFile, $stackPtr);
-            if ($declareOpenClose !== false) {
-                // Overrule the scope indexes in our local copy of the $tokens array.
-                $tokens[$stackPtr]['scope_opener'] = $declareOpenClose['opener'];
-                $tokens[$stackPtr]['scope_closer'] = $declareOpenClose['closer'];
-            }
-        }
-
-        /*
-         * Now check if the control structure uses alternative syntax.
+         * Check if the control structure uses alternative syntax.
          */
         if (isset($tokens[$stackPtr]['scope_opener'], $tokens[$stackPtr]['scope_closer']) === false) {
             // No scope opener found: inline control structure or parse error.

--- a/Universal/Tests/Constants/LowercaseClassResolutionKeywordUnitTest.inc
+++ b/Universal/Tests/Constants/LowercaseClassResolutionKeywordUnitTest.inc
@@ -4,7 +4,7 @@
  * Not our concern.
  */
 echo bar::classProp; // Not the keyword.
-$anon = new class {}; // Anonymous class, not the keyword.
+function class() {} // Function name, not the keyword.
 
 /*
  * OK.

--- a/Universal/Tests/Constants/LowercaseClassResolutionKeywordUnitTest.inc.fixed
+++ b/Universal/Tests/Constants/LowercaseClassResolutionKeywordUnitTest.inc.fixed
@@ -4,7 +4,7 @@
  * Not our concern.
  */
 echo bar::classProp; // Not the keyword.
-$anon = new class {}; // Anonymous class, not the keyword.
+function class() {} // Function name, not the keyword.
 
 /*
  * OK.

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require" : {
         "php" : ">=5.4",
-        "squizlabs/php_codesniffer" : "^3.3.1",
+        "squizlabs/php_codesniffer" : "^3.7.0",
         "dealerdirect/phpcodesniffer-composer-installer" : "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
         "phpcsstandards/phpcsutils" : "^1.0 || dev-develop"
     },


### PR DESCRIPTION
### Composer: up the minimum PHPCS version to 3.7.0

PHPCS 3.7.0 has just been released and contains significant improvements to - most notably - the tokenizer.

PHP 8.0 and 8.1 introduced a lot of new syntaxes and, while a lot of this can be supported for older PHPCS versions via PHPCSUtils, this will always impact performance and precision, so it is strongly advisable to use the latest PHPCS version as the new minimum to support the newly available PHP syntaxes.

Includes updating the GH Actions matrixes for this change.

Refs: https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.7.0

### QA: remove work-arounds for older PHPCS versions

As the minimum PHPCS version has been increased to PHPCS 3.7.0, a few work-arounds which were in place to work around tokenizer bugs in older PHPCS versions can now be removed.