### PR TITLE
New `Universal.CodeAnalysis.StaticInFinalClass` sniff

### DIFF
--- a/Universal/Docs/CodeAnalysis/StaticInFinalClassStandard.xml
+++ b/Universal/Docs/CodeAnalysis/StaticInFinalClassStandard.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<documentation title="Static in Final Class">
+    <standard>
+    <![CDATA[
+    When a class is declared as final, using the `static` keyword for late static binding is unnecessary and redundant.
+    This rule also covers using `static` in a comparison with `instanceof`, using `static` for class instantiations or as a return type.
+
+    `self` should be used instead.
+
+    This applies to final classes, anonymous classes (final by nature) and enums (final by design).
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Using 'self' in a final OO constuct.">
+        <![CDATA[
+final class Foo
+{
+    public function myMethod($param) : <em>self</em>
+    {
+        $var = <em>self</em>::functionCall();
+        $var = $obj instanceof <em>self</em>;
+        $var = new <em>self</em>;
+    }
+}
+        ]]>
+        </code>
+        <code title="Invalid: Using 'static' in a final OO constuct.">
+        <![CDATA[
+$anon = new class {
+    public function myMethod(
+    ): int|<em>static</em>|false {
+        $var = <em>static</em>::$prop;
+        $var = $obj instanceof <em>static</em>;
+        $var = new <em>static</em>();
+    }
+};
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/CodeAnalysis/StaticInFinalClassSniff.php
+++ b/Universal/Sniffs/CodeAnalysis/StaticInFinalClassSniff.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\CodeAnalysis;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\Conditions;
+use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\GetTokensAsString;
+use PHPCSUtils\Utils\ObjectDeclarations;
+use PHPCSUtils\Utils\Scopes;
+
+/**
+ * Forbid the use of the `static` keyword for late static binding in OO constructs which are final.
+ *
+ * @since 1.0.0
+ */
+final class StaticInFinalClassSniff implements Sniff
+{
+
+    /**
+     * OO Scopes in which late static binding is useless.
+     *
+     * @var int|string[]
+     */
+    private $validOOScopes = [
+        \T_CLASS,      // Only if final.
+        \T_ANON_CLASS, // Final by nature.
+        \T_ENUM,       // Final by design.
+    ];
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [
+            // This token is used to retrieve return types reliably.
+            \T_FUNCTION,
+            // While this is our "real" target.
+            \T_STATIC,
+            // But we also need this as after "instanceof", `static` is tokenized as `T_STRING in PHPCS < 4.0.0.
+            // See: https://github.com/squizlabs/PHP_CodeSniffer/pull/3121
+            \T_STRING,
+        ];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[$stackPtr]['code'] === \T_STRING
+            && \strtolower($tokens[$stackPtr]['content']) !== 'static'
+        ) {
+            return;
+        }
+
+        if ($tokens[$stackPtr]['code'] === \T_FUNCTION) {
+            /*
+             * Check return types for methods in final classes, anon classes and enums.
+             *
+             * Will return the scope opener of the function to prevent potential duplicate notifications.
+             */
+            $scopeOpener = $stackPtr;
+            if (isset($tokens[$stackPtr]['scope_opener']) === true) {
+                $scopeOpener = $tokens[$stackPtr]['scope_opener'];
+            }
+
+            $ooPtr = Scopes::validDirectScope($phpcsFile, $stackPtr, $this->validOOScopes);
+            if ($ooPtr === false) {
+                // Method in a trait (not known where it is used), interface (never final) or not in an OO scope.
+                return $scopeOpener;
+            }
+
+            if ($tokens[$ooPtr]['code'] === \T_CLASS) {
+                $classProps = ObjectDeclarations::getClassProperties($phpcsFile, $ooPtr);
+                if ($classProps['is_final'] === false) {
+                    // Method in a non-final class.
+                    return $scopeOpener;
+                }
+            }
+
+            $functionProps = FunctionDeclarations::getProperties($phpcsFile, $stackPtr);
+            if ($functionProps['return_type'] === '') {
+                return $scopeOpener;
+            }
+
+            $staticPtr = $phpcsFile->findNext(
+                \T_STATIC,
+                $functionProps['return_type_token'],
+                ($functionProps['return_type_end_token'] + 1)
+            );
+
+            if ($staticPtr === false) {
+                return $scopeOpener;
+            }
+
+            // Found a return type containing the `static` type.
+            $this->handleError($phpcsFile, $staticPtr, 'ReturnType', '"static" return type');
+
+            return $scopeOpener;
+        }
+
+        /*
+         * Check other uses of static.
+         */
+        $functionPtr = Conditions::getLastCondition($phpcsFile, $stackPtr, [\T_FUNCTION, \T_CLOSURE]);
+        if ($functionPtr === false || $tokens[$functionPtr]['code'] === \T_CLOSURE) {
+            /*
+             * When `false`, this code is absolutely invalid, but not something to be addressed via this sniff.
+             * When a closure, we're not interested in it. The closure class is final, but closures
+             * can be bound to other classes. This needs further research and should maybe get its own sniff.
+             */
+            return;
+        }
+
+        $ooPtr = Scopes::validDirectScope($phpcsFile, $functionPtr, $this->validOOScopes);
+        if ($ooPtr === false) {
+            // Not in an OO context.
+            return;
+        }
+
+        if ($tokens[$ooPtr]['code'] === \T_CLASS) {
+            $classProps = ObjectDeclarations::getClassProperties($phpcsFile, $ooPtr);
+            if ($classProps['is_final'] === false) {
+                // Token in a non-final class.
+                return;
+            }
+        }
+
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        if ($prevNonEmpty !== false) {
+            if ($tokens[$prevNonEmpty]['code'] === \T_INSTANCEOF) {
+                $prevPrevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
+                $extraMsg         = GetTokensAsString::compact($phpcsFile, $prevPrevNonEmpty, $stackPtr, true);
+                $this->handleError($phpcsFile, $stackPtr, 'InstanceOf', '"' . $extraMsg . '"');
+                return;
+            }
+
+            if ($tokens[$prevNonEmpty]['code'] === \T_NEW) {
+                $this->handleError($phpcsFile, $stackPtr, 'NewInstance', '"new static"');
+                return;
+            }
+        }
+
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['code'] === \T_DOUBLE_COLON) {
+            $nextNextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true);
+            $extraMsg         = GetTokensAsString::compact($phpcsFile, $stackPtr, $nextNextNonEmpty, true);
+            $this->handleError($phpcsFile, $stackPtr, 'ScopeResolution', '"' . $extraMsg . '"');
+            return;
+        }
+    }
+
+    /**
+     * Throw and potentially fix the error.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of erroneous `T_STATIC` token.
+     * @param string                      $errorCode The error code for the message.
+     * @param string                      $extraMsg  Addition to the error message.
+     *
+     * @return void
+     */
+    private function handleError($phpcsFile, $stackPtr, $errorCode, $extraMsg)
+    {
+        $fix = $phpcsFile->addFixableError(
+            'Use "self" instead of "static" when using late static binding in a final OO construct. Found: %s',
+            $stackPtr,
+            $errorCode,
+            [$extraMsg]
+        );
+
+        if ($fix === true) {
+            $phpcsFile->fixer->replaceToken($stackPtr, 'self');
+        }
+    }
+}

--- a/Universal/Tests/CodeAnalysis/StaticInFinalClassUnitTest.inc
+++ b/Universal/Tests/CodeAnalysis/StaticInFinalClassUnitTest.inc
@@ -1,0 +1,171 @@
+<?php
+
+/*
+ * Not our target: prevent false positives.
+ */
+class NotTargetStatic {
+
+    static $php4StyleStaticProp;
+
+    public static string|int $phpModernStaticProp;
+
+    protected static function staticMethod()
+    {
+        static $a, $b;
+
+        $var = namedParams(static: $foo);
+        $var = namedParams($bar, static: $foo);
+    }
+}
+
+trait UseContextUnknown {
+    public function unionType(): int|static|false
+    {
+        $var = static::$prop;
+        $var = static::CONSTANT;
+    }
+}
+
+final class ClosuresAreNotTargettedByThisSniff {
+    public static $className = 'Bar';
+    public function foobar() {
+        $closure = function() {
+            // Returns new instance of Closure, not of ClosuresAreNotTargettedByThisSniff.
+            // Still unnecessary, but not the target of this sniff.
+            // Should possibly get its own sniff.
+            return new static();
+        };
+    }
+}
+
+
+/*
+ * Not valid in any PHP version.
+ */
+final class InvalidUseOfStatic
+{
+    const INVALID_IN_CONSTANT_DECLARATION = static::class;
+
+    protected int|static $notAllowedAsPropertyType;
+
+    public function NotAllowedAsParamType(static $param) {}
+
+    public function NotAllowedInDefaultValue($paramA = new static(), $paramB = static::MY_CONST) {}
+}
+
+$closure = function() {
+    static::outsideClassContext();
+};
+
+function foobar() {
+    static::outsideClassContext();
+};
+
+static::$outsideClassContext;
+
+
+/*
+ * OK, not used in a final class.
+ */
+abstract class ValidUseOfStaticInAbstract
+{
+    public function usingStatic($param) : static
+    {
+        $var = static::functionCall();
+        $var = static::class;
+
+        $var = $obj instanceof static;
+
+        $var = new static;
+        $var = new static::$className;
+    }
+}
+
+class ValidUseOfStaticInConcrete extends Foo
+{
+    public function unionType(): int|static|false
+    {
+        $var = static::$prop;
+        $var = static::CONSTANT;
+
+        $var = new static();
+    }
+}
+
+interface NeverFinal {
+    public function typedMethod(): static|ArrrayAccess;
+}
+
+
+/*
+ * Unnecessary use of static for late static binding.
+ */
+final class FinalClass
+{
+    public function usingStatic($param) : static
+    {
+        $var = static::functionCall();
+        $var = static::class;
+
+        $var = $obj instanceof static;
+
+        $var = new static;
+    }
+}
+
+function foo() {
+    // Nested in global function to ensure nested code is not skipped over.
+    $anon = new class extends AnonClassIsAlwaysFinal {
+        public function unionType(): int|static|false
+        {
+            $var = static::$prop;
+            $var = static::CONSTANT;
+
+            $var = $obj
+                instanceof
+                // Comment.
+                static;
+
+            $var = new static();
+        }
+    };
+}
+
+class NonFinalClassWithNesting {
+    function foo() {
+        // Nested in non-final class to ensure nested code is not skipped over.
+        $anon = new class extends AnonClassIsAlwaysFinal {
+            public function unionType(): int|static|false
+            {
+                $var = static::$prop;
+                $var = static::CONSTANT;
+
+                $var = $obj
+                    instanceof
+                    // Comment.
+                    STATIC;
+
+                $var = new static::$className;
+            }
+        };
+    }
+}
+
+enum FinalByDesign {
+    public function typedMethod(): static|ArrrayAccess {
+        $var = static::functionCall();
+        $var = static::class;
+
+        $var = $obj instanceof static;
+
+        $var = new static;
+    }
+}
+
+
+// Live coding. This has to be the last test in the file.
+class LiveCoding extends Foo {
+    public static function bar(): static {}
+
+    function baz() {
+        $var = $obj instanceof static;

--- a/Universal/Tests/CodeAnalysis/StaticInFinalClassUnitTest.inc.fixed
+++ b/Universal/Tests/CodeAnalysis/StaticInFinalClassUnitTest.inc.fixed
@@ -1,0 +1,171 @@
+<?php
+
+/*
+ * Not our target: prevent false positives.
+ */
+class NotTargetStatic {
+
+    static $php4StyleStaticProp;
+
+    public static string|int $phpModernStaticProp;
+
+    protected static function staticMethod()
+    {
+        static $a, $b;
+
+        $var = namedParams(static: $foo);
+        $var = namedParams($bar, static: $foo);
+    }
+}
+
+trait UseContextUnknown {
+    public function unionType(): int|static|false
+    {
+        $var = static::$prop;
+        $var = static::CONSTANT;
+    }
+}
+
+final class ClosuresAreNotTargettedByThisSniff {
+    public static $className = 'Bar';
+    public function foobar() {
+        $closure = function() {
+            // Returns new instance of Closure, not of ClosuresAreNotTargettedByThisSniff.
+            // Still unnecessary, but not the target of this sniff.
+            // Should possibly get its own sniff.
+            return new static();
+        };
+    }
+}
+
+
+/*
+ * Not valid in any PHP version.
+ */
+final class InvalidUseOfStatic
+{
+    const INVALID_IN_CONSTANT_DECLARATION = static::class;
+
+    protected int|static $notAllowedAsPropertyType;
+
+    public function NotAllowedAsParamType(static $param) {}
+
+    public function NotAllowedInDefaultValue($paramA = new static(), $paramB = static::MY_CONST) {}
+}
+
+$closure = function() {
+    static::outsideClassContext();
+};
+
+function foobar() {
+    static::outsideClassContext();
+};
+
+static::$outsideClassContext;
+
+
+/*
+ * OK, not used in a final class.
+ */
+abstract class ValidUseOfStaticInAbstract
+{
+    public function usingStatic($param) : static
+    {
+        $var = static::functionCall();
+        $var = static::class;
+
+        $var = $obj instanceof static;
+
+        $var = new static;
+        $var = new static::$className;
+    }
+}
+
+class ValidUseOfStaticInConcrete extends Foo
+{
+    public function unionType(): int|static|false
+    {
+        $var = static::$prop;
+        $var = static::CONSTANT;
+
+        $var = new static();
+    }
+}
+
+interface NeverFinal {
+    public function typedMethod(): static|ArrrayAccess;
+}
+
+
+/*
+ * Unnecessary use of static for late static binding.
+ */
+final class FinalClass
+{
+    public function usingStatic($param) : self
+    {
+        $var = self::functionCall();
+        $var = self::class;
+
+        $var = $obj instanceof self;
+
+        $var = new self;
+    }
+}
+
+function foo() {
+    // Nested in global function to ensure nested code is not skipped over.
+    $anon = new class extends AnonClassIsAlwaysFinal {
+        public function unionType(): int|self|false
+        {
+            $var = self::$prop;
+            $var = self::CONSTANT;
+
+            $var = $obj
+                instanceof
+                // Comment.
+                self;
+
+            $var = new self();
+        }
+    };
+}
+
+class NonFinalClassWithNesting {
+    function foo() {
+        // Nested in non-final class to ensure nested code is not skipped over.
+        $anon = new class extends AnonClassIsAlwaysFinal {
+            public function unionType(): int|self|false
+            {
+                $var = self::$prop;
+                $var = self::CONSTANT;
+
+                $var = $obj
+                    instanceof
+                    // Comment.
+                    self;
+
+                $var = new self::$className;
+            }
+        };
+    }
+}
+
+enum FinalByDesign {
+    public function typedMethod(): self|ArrrayAccess {
+        $var = self::functionCall();
+        $var = self::class;
+
+        $var = $obj instanceof self;
+
+        $var = new self;
+    }
+}
+
+
+// Live coding. This has to be the last test in the file.
+class LiveCoding extends Foo {
+    public static function bar(): static {}
+
+    function baz() {
+        $var = $obj instanceof static;

--- a/Universal/Tests/CodeAnalysis/StaticInFinalClassUnitTest.php
+++ b/Universal/Tests/CodeAnalysis/StaticInFinalClassUnitTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\CodeAnalysis;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the UnnecessaryStaticInFinalClass sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\CodeAnalysis\StaticInFinalClassSniff
+ *
+ * @since 1.0.0
+ */
+final class StaticInFinalClassUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getErrorList()
+    {
+        return [
+            105 => 1,
+            107 => 1,
+            108 => 1,
+            110 => 1,
+            112 => 1,
+            119 => 1,
+            121 => 1,
+            122 => 1,
+            127 => 1,
+            129 => 1,
+            138 => 1,
+            140 => 1,
+            141 => 1,
+            146 => 1,
+            148 => 1,
+            155 => 1,
+            156 => 1,
+            157 => 1,
+            159 => 1,
+            161 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array <int line number> => <int number of warnings>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
New sniff to detect using `static` instead of `self` in OO constructs which are `final`.

Includes fixer.
Includes unit tests.
Includes documentation.