### PR TITLE
New `Universal.Operators.TypeSeparatorSpacing` sniff

### DIFF
--- a/Universal/Docs/Operators/TypeSeparatorSpacingStandard.xml
+++ b/Universal/Docs/Operators/TypeSeparatorSpacingStandard.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<documentation title="Type Separator Spacing">
+    <standard>
+    <![CDATA[
+    There should be no spacing around the union type separator or the intersection type separator.
+
+    This applies to all locations where type declarations can be used, i.e. property types, parameter types and return types.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: No space around the separators.">
+        <![CDATA[
+function foo(
+    int<em>|</em>string $paramA,
+    TypeA<em>&</em>TypeB $paramB
+): int<em>|</em>false {}
+        ]]>
+        </code>
+        <code title="Invalid: Space around the separators.">
+        <![CDATA[
+function foo(
+    int<em> | </em>string $paramA,
+    TypeA<em> & </em>TypeB $paramB
+): int<em>
+   |
+   </em>false {}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/Operators/TypeSeparatorSpacingSniff.php
+++ b/Universal/Sniffs/Operators/TypeSeparatorSpacingSniff.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\Operators;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Fixers\SpacesFixer;
+
+/**
+ * Enforce no space around union type and intersection type separators.
+ *
+ * @since 1.0.0
+ */
+final class TypeSeparatorSpacingSniff implements Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [
+            \T_TYPE_UNION,
+            \T_TYPE_INTERSECTION,
+        ];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $type = ($tokens[$stackPtr]['code'] === \T_TYPE_UNION) ? 'union' : 'intersection';
+        $code = \ucfirst($type) . 'Type';
+
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        SpacesFixer::checkAndFix(
+            $phpcsFile,
+            $stackPtr,
+            $prevNonEmpty,
+            0, // Expected spaces.
+            'Expected %s before the ' . $type . ' type separator. Found: %s',
+            $code . 'SpacesBefore',
+            'error',
+            0,
+            'Space before ' . $type . ' type separator'
+        );
+
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        SpacesFixer::checkAndFix(
+            $phpcsFile,
+            $stackPtr,
+            $nextNonEmpty,
+            0, // Expected spaces.
+            'Expected %s after the ' . $type . ' type separator. Found: %s',
+            $code . 'SpacesAfter',
+            'error',
+            0,
+            'Space after ' . $type . ' type separator'
+        );
+    }
+}

--- a/Universal/Tests/Operators/TypeSeparatorSpacingUnitTest.inc
+++ b/Universal/Tests/Operators/TypeSeparatorSpacingUnitTest.inc
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * Correct spacing (even though some of the code is invalid, but that's not the concern of this sniff).
+ */
+class CorrectSpacing {
+
+    public int|bool|null $property;
+
+    protected function foo(int|bool $paramA, Foo&Bar $paramB): InterFaceName|false&InvalidIntersection {}
+}
+
+function namedFunction(?string|null &...$p, TypeA&namespace\TypeB $q): string|int {};
+
+$closure = function (TypeA|TypeB $p, TypeA&namespace\TypeB $q): \Fully\Qualified&Partially\Qualified {};
+
+$arrow = fn (TypeA|TypeB $p, TypeA&namespace\TypeB $q): string|int => $p * $q;
+
+/*
+ * Incorrect spacing.
+ */
+class IncorrectSpacing {
+
+    public int | bool    |
+       null $property;
+
+    protected function foo(int | bool $paramA, Foo
+    &
+    Bar $paramB): InterFaceName /*comment*/ |  false /*comment */ &  InvalidIntersection {}
+}
+
+function namedFunction(?string  |  null &...$p, TypeA&  namespace\TypeB $q): string
+  |int {};
+
+$closure = function (TypeA      |       TypeB $p, TypeA  &namespace\TypeB $q): \Fully\Qualified & Partially\Qualified {};
+
+$arrow = fn (TypeA | TypeB $p, TypeA &  namespace\TypeB $q): string  |  int => $p * $q;
+
+// Live coding.
+// This test should be the last test in the file.
+function foo(int|

--- a/Universal/Tests/Operators/TypeSeparatorSpacingUnitTest.inc.fixed
+++ b/Universal/Tests/Operators/TypeSeparatorSpacingUnitTest.inc.fixed
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Correct spacing (even though some of the code is invalid, but that's not the concern of this sniff).
+ */
+class CorrectSpacing {
+
+    public int|bool|null $property;
+
+    protected function foo(int|bool $paramA, Foo&Bar $paramB): InterFaceName|false&InvalidIntersection {}
+}
+
+function namedFunction(?string|null &...$p, TypeA&namespace\TypeB $q): string|int {};
+
+$closure = function (TypeA|TypeB $p, TypeA&namespace\TypeB $q): \Fully\Qualified&Partially\Qualified {};
+
+$arrow = fn (TypeA|TypeB $p, TypeA&namespace\TypeB $q): string|int => $p * $q;
+
+/*
+ * Incorrect spacing.
+ */
+class IncorrectSpacing {
+
+    public int|bool|null $property;
+
+    protected function foo(int|bool $paramA, Foo&Bar $paramB): InterFaceName /*comment*/ |false /*comment */ &InvalidIntersection {}
+}
+
+function namedFunction(?string|null &...$p, TypeA&namespace\TypeB $q): string|int {};
+
+$closure = function (TypeA|TypeB $p, TypeA&namespace\TypeB $q): \Fully\Qualified&Partially\Qualified {};
+
+$arrow = fn (TypeA|TypeB $p, TypeA&namespace\TypeB $q): string|int => $p * $q;
+
+// Live coding.
+// This test should be the last test in the file.
+function foo(int|

--- a/Universal/Tests/Operators/TypeSeparatorSpacingUnitTest.php
+++ b/Universal/Tests/Operators/TypeSeparatorSpacingUnitTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\Operators;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the TypeSeparatorSpacing sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\Operators\TypeSeparatorSpacingSniff
+ *
+ * @since 1.0.0
+ */
+final class TypeSeparatorSpacingUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [
+            24 => 4,
+            27 => 2,
+            28 => 2,
+            29 => 4,
+            32 => 3,
+            33 => 1,
+            35 => 5,
+            37 => 6,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
New sniff to enforce no spaces around union type and intersection type separator operators.

Includes fixer.
Includes unit tests.
Includes documentation.
Includes metrics.