### PR TITLE
New `Universal.WhiteSpace.PrecisionAlignment` sniff

### DIFF
--- a/Universal/Docs/WhiteSpace/PrecisionAlignmentStandard.xml
+++ b/Universal/Docs/WhiteSpace/PrecisionAlignmentStandard.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<documentation title="Precision Alignment">
+    <standard>
+    <![CDATA[
+    Detects when the indentation is not a multiple of a tab-width, i.e. when precision alignment is used.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: indentation equals (a multiple of) the tab width.">
+        <![CDATA[
+// Code samples presume tab width = 4.
+<em>[space][space][space][space]</em>$foo = 'bar';
+
+<em>[tab]</em>$foo = 'bar';
+        ]]>
+        </code>
+        <code title="Invalid: precision alignment used, indentation does not equal (a multiple of) the tab width.">
+        <![CDATA[
+// Code samples presume tab width = 4.
+<em>[space][space]</em>$foo = 'bar';
+
+<em>[tab][space]</em>$foo = 'bar';
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
+++ b/Universal/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
@@ -1,0 +1,381 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\BackCompat\Helper;
+
+/**
+ * Detects when the indentation is not a multiple of a tab-width, i.e. when precision alignment is used.
+ *
+ * In rare cases, spaces for precision alignment can be intentional and acceptable,
+ * but more often than not, precision alignment is a typo.
+ *
+ * Notes:
+ * - When using this sniff with tab-based standards, please ensure that the `tab-width` is set
+ *   and either don't set the `$indent` property or set it to the tab-width.
+ * - Precision alignment *within* text strings (multi-line text strings, heredocs, nowdocs)
+ *   will NOT be flagged by this sniff.
+ * - The fixer works based on "best guess" and may not always result in the desired indentation.
+ * - This sniff does not concern itself with tabs versus spaces.
+ *   Use the PHPCS native `Generic.WhiteSpace.DisallowTabIndent` or the
+ *   `Generic.WhiteSpace.DisallowSpaceIndent` sniffs for that.
+ *
+ * @since 1.0.0
+ */
+final class PrecisionAlignmentSniff implements Sniff
+{
+
+    /**
+     * A list of tokenizers this sniff supports.
+     *
+     * @since 1.0.0
+     *
+     * @var array
+     */
+    public $supportedTokenizers = [
+        'PHP',
+        'JS',
+        'CSS',
+    ];
+
+    /**
+     * The indent used for the codebase.
+     *
+     * This property is used to determine whether something is indentation or precision alignment.
+     * If this property is not set, the sniff will look to the `--tab-width` CLI value.
+     * If that also isn't set, the default tab-width of 4 will be used.
+     *
+     * @since 1.0.0
+     *
+     * @var int|null
+     */
+    public $indent = null;
+
+    /**
+     * Allow for providing a list of tokens for which (preceding) precision alignment should be ignored.
+     *
+     * By default, precision alignment will always be flagged.
+     *
+     * Example usage:
+     * ```xml
+     * <rule ref="PHPCSExtra.WhiteSpace.PrecisionAlignment">
+     *    <properties>
+     *        <property name="ignoreAlignmentBefore" type="array">
+     *            <!-- Ignore precision alignment in inline HTML -->
+     *            <element value="T_INLINE_HTML"/>
+     *            <!-- Ignore precision alignment in multiline chained method calls. -->
+     *            <element value="T_OBJECT_OPERATOR"/>
+     *        </property>
+     *    </properties>
+     * </rule>
+     * ```
+     *
+     * @since 1.0.0
+     *
+     * @var array
+     */
+    public $ignoreAlignmentBefore = [];
+
+    /**
+     * Whether or not potential trailing whitespace on otherwise blank lines should be examined or ignored.
+     *
+     * Defaults to `true`, i.e. ignore blank lines.
+     *
+     * It is recommended to only set this to `false` if the standard including this sniff does not
+     * include the `Squiz.WhiteSpace.SuperfluousWhitespace` sniff (which is included in most standards).
+     *
+     * @since 1.0.0
+     *
+     * @var bool
+     */
+    public $ignoreBlankLines = true;
+
+    /**
+     * The --tab-width CLI value that is being used.
+     *
+     * @since 1.0.0
+     *
+     * @var int
+     */
+    private $tabWidth;
+
+    /**
+     * Whitespace tokens and tokens which can contain leading whitespace.
+     *
+     * A few additional tokens will be added to this list in the register() method.
+     *
+     * @since 1.0.0
+     *
+     * @var array<int|string, int|string>
+     */
+    private $tokensToCheck = [
+        \T_WHITESPACE             => \T_WHITESPACE,
+        \T_INLINE_HTML            => \T_INLINE_HTML,
+        \T_DOC_COMMENT_WHITESPACE => \T_DOC_COMMENT_WHITESPACE,
+        \T_COMMENT                => \T_COMMENT,
+        \T_END_HEREDOC            => \T_END_HEREDOC,
+        \T_END_NOWDOC             => \T_END_NOWDOC,
+    ];
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        // Add the ignore annotation tokens to the list of tokens to check.
+        $this->tokensToCheck += Tokens::$phpcsCommentTokens;
+
+        return [
+            \T_OPEN_TAG,
+            \T_OPEN_TAG_WITH_ECHO,
+        ];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return int Integer stack pointer to skip the rest of the file.
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        /*
+         * Handle the properties.
+         */
+        if (isset($this->tabWidth) === false || \defined('PHP_CODESNIFFER_IN_TESTS') === true) {
+            $this->tabWidth = Helper::getTabWidth($phpcsFile);
+        }
+
+        if (isset($this->indent) === true) {
+            $indent = (int) $this->indent;
+        } else {
+            $indent = $this->tabWidth;
+        }
+
+        $ignoreTokens = (array) $this->ignoreAlignmentBefore;
+        if (empty($ignoreTokens) === false) {
+            $ignoreTokens = \array_flip($ignoreTokens);
+        }
+
+        /*
+         * Check the whole file in one go.
+         */
+        $tokens = $phpcsFile->getTokens();
+
+        for ($i = 0; $i < $phpcsFile->numTokens; $i++) {
+            if ($tokens[$i]['column'] !== 1) {
+                // Only interested in the first token on each line.
+                continue;
+            }
+
+            if (isset($this->tokensToCheck[$tokens[$i]['code']]) === false) {
+                // Not one of the target tokens.
+                continue;
+            }
+
+            if ($tokens[$i]['content'] === $phpcsFile->eolChar) {
+                // Skip completely blank lines.
+                continue;
+            }
+
+            if (isset($ignoreTokens[$tokens[$i]['type']]) === true
+                || (isset($tokens[($i + 1)]) && isset($ignoreTokens[$tokens[($i + 1)]['type']]))
+            ) {
+                // This is one of the tokens being ignored.
+                continue;
+            }
+
+            $spaces = 0;
+            switch ($tokens[$i]['code']) {
+                case \T_WHITESPACE:
+                    if ($this->ignoreBlankLines === true
+                        && isset($tokens[($i + 1)])
+                        && $tokens[$i]['line'] !== $tokens[($i + 1)]['line']
+                    ) {
+                        // Skip blank lines which only contain trailing whitespace.
+                        continue 2;
+                    }
+
+                    $spaces = ($tokens[$i]['length'] % $indent);
+                    break;
+
+                case \T_DOC_COMMENT_WHITESPACE:
+                    /*
+                     * Blank lines with trailing whitespace in docblocks are tokenized as
+                     * two T_DOC_COMMENT_WHITESPACE tokens: one for the trailing whitespace,
+                     * one for the new line character.
+                     */
+                    if ($this->ignoreBlankLines === true
+                        && isset($tokens[($i + 1)])
+                        && $tokens[($i + 1)]['content'] === $phpcsFile->eolChar
+                        && isset($tokens[($i + 2)])
+                        && $tokens[$i]['line'] !== $tokens[($i + 2)]['line']
+                    ) {
+                        // Skip blank lines which only contain trailing whitespace.
+                        continue 2;
+                    }
+
+                    $spaces = ($tokens[$i]['length'] % $indent);
+
+                    if (isset($tokens[($i + 1)]) === true
+                        && ($tokens[($i + 1)]['code'] === \T_DOC_COMMENT_STAR
+                            || $tokens[($i + 1)]['code'] === \T_DOC_COMMENT_CLOSE_TAG)
+                        && $spaces !== 0
+                    ) {
+                        // One alignment space expected before the *.
+                        --$spaces;
+                    }
+                    break;
+
+                case \T_COMMENT:
+                case \T_INLINE_HTML:
+                    if ($this->ignoreBlankLines === true
+                        && \trim($tokens[$i]['content']) === ''
+                        && isset($tokens[($i + 1)])
+                        && $tokens[$i]['line'] !== $tokens[($i + 1)]['line']
+                    ) {
+                        // Skip blank lines which only contain trailing whitespace.
+                        continue 2;
+                    }
+
+                    // Deliberate fall-through.
+
+                case \T_PHPCS_ENABLE:
+                case \T_PHPCS_DISABLE:
+                case \T_PHPCS_SET:
+                case \T_PHPCS_IGNORE:
+                case \T_PHPCS_IGNORE_FILE:
+                case \T_END_HEREDOC:
+                case \T_END_NOWDOC:
+                    /*
+                     * Indentation is included in the contents of the token for:
+                     * - inline HTML
+                     * - PHP 7.3+ flexible heredoc/nowdoc closer identifiers;
+                     * - subsequent lines of multi-line comments;
+                     * - PHPCS native annotations when part of a multi-line comment.
+                     */
+                    $content    = \ltrim($tokens[$i]['content']);
+                    $whitespace = \str_replace($content, '', $tokens[$i]['content']);
+
+                    /*
+                     * If there is no content, this is a blank line in a comment or in inline HTML.
+                     * In that case, use the predetermined length as otherwise the new line character
+                     * at the end of the whitespace will throw the count off.
+                     */
+                    $length = ($content === '') ? $tokens[$i]['length'] : \strlen($whitespace);
+                    $spaces = ($length % $indent);
+
+                    /*
+                     * For multi-line star-comments, which use (aligned) stars on subsequent
+                     * lines, we don't want to trigger on the one extra space before the star.
+                     *
+                     * While not 100% correct, don't exclude inline HTML from this check as
+                     * otherwise the sniff would trigger on multi-line /*-style inline javascript comments.
+                     * This may cause false negatives as there is no check for being in a
+                     * <script> tag, but that will be rare.
+                     */
+                    if (isset($content[0]) === true && $content[0] === '*' && $spaces !== 0) {
+                        --$spaces;
+                    }
+                    break;
+            }
+
+            if ($spaces === 0) {
+                continue;
+            }
+
+            $fix = $phpcsFile->addFixableWarning(
+                'Found precision alignment of %s spaces.',
+                $i,
+                'Found',
+                [$spaces]
+            );
+
+            if ($fix === true) {
+                $round = (int) \round($spaces / $indent, 0);
+
+                switch ($tokens[$i]['code']) {
+                    case \T_WHITESPACE:
+                        /*
+                         * More complex than you'd think as "length" doesn't include new lines,
+                         * but we don't want to remove new lines either.
+                         */
+                        $replaceLength = (((int) ($tokens[$i]['length'] / $indent) + $round) * $indent);
+                        $replace       = \str_repeat(' ', $replaceLength);
+                        $newContent    = \substr_replace($tokens[$i]['content'], $replace, 0, $tokens[$i]['length']);
+
+                        $phpcsFile->fixer->replaceToken($i, $newContent);
+                        break;
+
+                    case \T_DOC_COMMENT_WHITESPACE:
+                        $replaceLength = (((int) ($tokens[$i]['length'] / $indent) + $round) * $indent);
+                        $replace       = \str_repeat(' ', $replaceLength);
+
+                        if (isset($tokens[($i + 1)]) === true
+                            && ($tokens[($i + 1)]['code'] === \T_DOC_COMMENT_STAR
+                                || $tokens[($i + 1)]['code'] === \T_DOC_COMMENT_CLOSE_TAG)
+                            && $round === 0
+                        ) {
+                            // Maintain the extra space before the star.
+                            $replace .= ' ';
+                        }
+
+                        $newContent = \substr_replace($tokens[$i]['content'], $replace, 0, $tokens[$i]['length']);
+
+                        $phpcsFile->fixer->replaceToken($i, $newContent);
+                        break;
+
+                    case \T_COMMENT:
+                    case \T_INLINE_HTML:
+                    case \T_PHPCS_ENABLE:
+                    case \T_PHPCS_DISABLE:
+                    case \T_PHPCS_SET:
+                    case \T_PHPCS_IGNORE:
+                    case \T_PHPCS_IGNORE_FILE:
+                    case \T_END_HEREDOC:
+                    case \T_END_NOWDOC:
+                        $replaceLength = (((int) ($length / $indent) + $round) * $indent);
+                        $replace       = \str_repeat(' ', $replaceLength);
+
+                        if (isset($content[0]) === true && $content[0] === '*' && $round === 0) {
+                            // Maintain the extra space before the star.
+                            $replace .= ' ';
+                        }
+
+                        if ($content === '') {
+                            // Preserve new lines in blank line comment tokens.
+                            $newContent = \substr_replace($tokens[$i]['content'], $replace, 0, $length);
+                        } else {
+                            $newContent = $replace . $content;
+                        }
+
+                        $phpcsFile->fixer->replaceToken($i, $newContent);
+                        break;
+                }
+            }
+        }
+
+        // No need to look at this file again.
+        return $phpcsFile->numTokens;
+    }
+}

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.css
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.css
@@ -1,0 +1,6 @@
+/* Space-based file. */
+#login-container {
+    margin-left: -225px;
+    width: 450px;
+     height: 450px; /* Bad. */
+}

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.css.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.css.fixed
@@ -1,0 +1,6 @@
+/* Space-based file. */
+#login-container {
+    margin-left: -225px;
+    width: 450px;
+    height: 450px; /* Bad. */
+}

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.inc
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.inc
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * File with space based indentation.
+ * Using the default indent value of 4 spaces.
+ */
+
+    function exampleFunctionA() {} // OK: [4 spaces].
+
+/*
+ * OK: sets of four spaces.
+ */
+        function exampleFunctionB() {}
+
+/*
+ * OK: sets of four spaces.
+ */
+            function exampleFunctionC() {}
+
+    /**
+     * OK: Doc comment is indented with 4 spaces + one space for the star alignment.
+     *
+      * @var string  <= Warning.
+     * @access private
+     */
+
+    /*
+        OK: Multi-line comment is indented with 4 spaces + 4 spaces for the text alignment.
+     <= Warning, no star, but also not indented by multiples of 4 spaces.
+        OK: Another line of text.
+     */
+
+    /*
+     * OK: Multi-line comment is indented with 4 spaces + one space for the star alignment.
+     *
+       * <= Warning.
+     */
+
+     function exampleFunctionD() {}   // Warning: [4 spaces][extra space].
+      function exampleFunctionE() {}  // Warning: [4 spaces][extra space][extra space].
+       function exampleFunctionF() {} // Warning: [4 spaces][extra space][extra space][extra space].
+
+    $object->functioncall()
+        -> chained()
+        -> anothermethod();
+
+    $object->functioncall()
+           -> chained()        // Warning: [4 spaces][4 spaces][extra space][extra space][extra space].
+           -> anothermethod(); // Warning: [4 spaces][4 spaces][extra space][extra space][extra space].
+
+   ?> <!-- Warning: three spaces. -->
+
+    <p>
+      Warning: Some inline HTML with precision alignment.
+    </p>
+
+ <?php // Warning: one space.
+
+// Testing empty line within a comment.
+/*
+
+*/
+
+// Testing that incorrectly aligned docblocks and multi-line inline comments do not trigger errors.
+// The incorrectly star alignment is not the concern of this sniff.
+    /**
+    * Provision some options
+    */
+
+    /*
+    * Provision some options
+    */
+
+?>
+
+<script type="text/javascript">
+    /*
+     * Multi-line javascript comment should not trigger this sniff.
+     */
+    alert('OK');
+      alert('bad'); <!-- Warning. -->
+</script>
+
+<?php

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.inc.fixed
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * File with space based indentation.
+ * Using the default indent value of 4 spaces.
+ */
+
+    function exampleFunctionA() {} // OK: [4 spaces].
+
+/*
+ * OK: sets of four spaces.
+ */
+        function exampleFunctionB() {}
+
+/*
+ * OK: sets of four spaces.
+ */
+            function exampleFunctionC() {}
+
+    /**
+     * OK: Doc comment is indented with 4 spaces + one space for the star alignment.
+     *
+     * @var string  <= Warning.
+     * @access private
+     */
+
+    /*
+        OK: Multi-line comment is indented with 4 spaces + 4 spaces for the text alignment.
+    <= Warning, no star, but also not indented by multiples of 4 spaces.
+        OK: Another line of text.
+     */
+
+    /*
+     * OK: Multi-line comment is indented with 4 spaces + one space for the star alignment.
+     *
+        * <= Warning.
+     */
+
+    function exampleFunctionD() {}   // Warning: [4 spaces][extra space].
+        function exampleFunctionE() {}  // Warning: [4 spaces][extra space][extra space].
+        function exampleFunctionF() {} // Warning: [4 spaces][extra space][extra space][extra space].
+
+    $object->functioncall()
+        -> chained()
+        -> anothermethod();
+
+    $object->functioncall()
+            -> chained()        // Warning: [4 spaces][4 spaces][extra space][extra space][extra space].
+            -> anothermethod(); // Warning: [4 spaces][4 spaces][extra space][extra space][extra space].
+
+    ?> <!-- Warning: three spaces. -->
+
+    <p>
+        Warning: Some inline HTML with precision alignment.
+    </p>
+
+<?php // Warning: one space.
+
+// Testing empty line within a comment.
+/*
+
+*/
+
+// Testing that incorrectly aligned docblocks and multi-line inline comments do not trigger errors.
+// The incorrectly star alignment is not the concern of this sniff.
+    /**
+    * Provision some options
+    */
+
+    /*
+    * Provision some options
+    */
+
+?>
+
+<script type="text/javascript">
+    /*
+     * Multi-line javascript comment should not trigger this sniff.
+     */
+    alert('OK');
+        alert('bad'); <!-- Warning. -->
+</script>
+
+<?php

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.js
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.js
@@ -1,0 +1,8 @@
+/* Space-based file. */
+var x = {
+    abc: 1,
+    zyz: 2,
+     mno: {
+       abc: 4
+     },
+}

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.js.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.js.fixed
@@ -1,0 +1,8 @@
+/* Space-based file. */
+var x = {
+    abc: 1,
+    zyz: 2,
+    mno: {
+        abc: 4
+    },
+}

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.10.inc
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.10.inc
@@ -1,0 +1,6 @@
+<!-- Test file only using short open echo tags, tab-based. -->
+  <div><!-- Bad.-->
+	  <p><a href="http://url/"><!-- Bad.-->
+		  <?= 'print this string' ?><!-- Bad.-->
+	  </a/></p><!-- Bad.-->
+  </div><!-- Bad.-->

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.10.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.10.inc.fixed
@@ -1,0 +1,6 @@
+<!-- Test file only using short open echo tags, tab-based. -->
+    <div><!-- Bad.-->
+        <p><a href="http://url/"><!-- Bad.-->
+            <?= 'print this string' ?><!-- Bad.-->
+        </a/></p><!-- Bad.-->
+    </div><!-- Bad.-->

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.11.inc
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.11.inc
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * Test handling of leading whitespace in combination with heredoc/nowdoc closing identifiers.
+ *
+ * IMPORTANT: this needs to be a separate test case file as the PHP 7.3 style heredocs/nowdocs will
+ * cause problems for the tokenized when run on PHP < 7.3, causing all code after it to be garbage tokens.
+ *
+ * This also means that the functionality for PHP 7.3 style heredocs/nowdocs will only work when
+ * PHPCS is run on PHP 7.3+ (and same applies to the tests, this can only be tested on PHP 7.3+).
+ */
+
+/*
+ * Cross-version compatible heredoc/nowdocs.
+ *
+ * These will always be okay.
+ * The text lines are not checked and the closer MUST be at the start of the line,
+ * as otherwise the code will result in a parse error.
+ */
+$heredoc = <<<EOD
+some text
+      some text
+  some text
+EOD;
+
+$nowdoc = <<<'EOD'
+some text
+      some text
+  some text
+EOD;
+
+/*
+ * PHP >= 7.3: flexible heredoc/nowdocs.
+ *
+ * In this case, the indentation before the closing identifier will be checked.
+ * As before, the text lines will not be checked.
+ */
+$heredoc = <<<END
+      a
+     b
+    c
+    END; // OK.
+
+$nowdoc = <<<'END'
+      a
+     b
+    c
+    END; // OK.
+
+$heredoc = <<<"END"
+          a
+        b
+      c
+     END; // Warning.
+
+$nowdoc = <<<'END'
+          a
+        b
+      c
+     END; // Warning.

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.11.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.11.inc.fixed
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * Test handling of leading whitespace in combination with heredoc/nowdoc closing identifiers.
+ *
+ * IMPORTANT: this needs to be a separate test case file as the PHP 7.3 style heredocs/nowdocs will
+ * cause problems for the tokenized when run on PHP < 7.3, causing all code after it to be garbage tokens.
+ *
+ * This also means that the functionality for PHP 7.3 style heredocs/nowdocs will only work when
+ * PHPCS is run on PHP 7.3+ (and same applies to the tests, this can only be tested on PHP 7.3+).
+ */
+
+/*
+ * Cross-version compatible heredoc/nowdocs.
+ *
+ * These will always be okay.
+ * The text lines are not checked and the closer MUST be at the start of the line,
+ * as otherwise the code will result in a parse error.
+ */
+$heredoc = <<<EOD
+some text
+      some text
+  some text
+EOD;
+
+$nowdoc = <<<'EOD'
+some text
+      some text
+  some text
+EOD;
+
+/*
+ * PHP >= 7.3: flexible heredoc/nowdocs.
+ *
+ * In this case, the indentation before the closing identifier will be checked.
+ * As before, the text lines will not be checked.
+ */
+$heredoc = <<<END
+      a
+     b
+    c
+    END; // OK.
+
+$nowdoc = <<<'END'
+      a
+     b
+    c
+    END; // OK.
+
+$heredoc = <<<"END"
+          a
+        b
+      c
+    END; // Warning.
+
+$nowdoc = <<<'END'
+          a
+        b
+      c
+    END; // Warning.

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.12.inc
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.12.inc
@@ -1,0 +1,83 @@
+phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreBlankLines true
+
+<?php
+/*
+ * This file tests the handling (ignoring) of trailing whitespace on lines which only contain whitespace.
+ *
+ * BE CAREFUL WHEN SAVING THIS FILE!
+ * For the test to be accurate, the trailing whitespace on various blank lines needs to be preserved!
+ */
+
+// New line only.
+echo 'the line below only contains a new line char';
+
+// Blank line contains trailing whitespace, ignore.
+echo 'the line below has 4 spaces trailing whitespace!';
+    
+// Blank line contains trailing whitespace, ignore, even though it doesn't match the length of a tabstop.
+echo 'the line below has 5 spaces trailing whitespace!';
+     
+/*
+ * The line below only contains a new line char. OK.
+
+ * The line below has 4 spaces trailing whitespace! Ignore.
+    
+ * The line below has 5 spaces trailing whitespace! Ignore, even though not matching tab width.
+     
+ */
+
+/**
+ * The line below only contains a new line char. OK.
+
+ * The line below has 4 spaces trailing whitespace! Ignore.
+    
+ * The line below has 5 spaces trailing whitespace! Ignore, even though not matching tab width.
+     
+ */
+
+?>
+The line below only contains a new line char. OK.
+
+The line below has 4 spaces trailing whitespace! Ignore.
+    
+The line below has 5 spaces trailing whitespace! Ignore, even though not matching tab width.
+     
+<?php
+
+// Same tests, but now with indentation.
+
+    // New line only.
+    echo 'the line below only contains a new line char';
+
+    // Blank line contains trailing whitespace, ignore.
+    echo 'the line below has 4 spaces trailing whitespace!';
+    
+    // Blank line contains trailing whitespace, ignore, even though it doesn't match the length of a tabstop.
+    echo 'the line between these statement has 5 spaces trailing whitespace!';
+     
+    /*
+     * The line below only contains a new line char. OK.
+
+     * The line below has 4 spaces trailing whitespace! Ignore.
+    
+     * The line below has 5 spaces trailing whitespace! Ignore, even though not matching tab width.
+     
+     */
+
+    /**
+     * The line below only contains a new line char. OK.
+    
+     * The line below has 4 spaces trailing whitespace! Ignore.
+    
+     * The line below has 5 spaces trailing whitespace! Ignore, even though not matching tab width.
+     
+     */
+
+    ?>
+    The line below only contains a new line char. OK.
+
+    The line below has 4 spaces trailing whitespace! Ignore.
+    
+    The line below has 5 spaces trailing whitespace! Ignore, even though not matching tab width.
+     
+    <?php

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.12.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.12.inc.fixed
@@ -1,0 +1,83 @@
+phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreBlankLines true
+
+<?php
+/*
+ * This file tests the handling (ignoring) of trailing whitespace on lines which only contain whitespace.
+ *
+ * BE CAREFUL WHEN SAVING THIS FILE!
+ * For the test to be accurate, the trailing whitespace on various blank lines needs to be preserved!
+ */
+
+// New line only.
+echo 'the line below only contains a new line char';
+
+// Blank line contains trailing whitespace, ignore.
+echo 'the line below has 4 spaces trailing whitespace!';
+    
+// Blank line contains trailing whitespace, ignore, even though it doesn't match the length of a tabstop.
+echo 'the line below has 5 spaces trailing whitespace!';
+    
+/*
+ * The line below only contains a new line char. OK.
+
+ * The line below has 4 spaces trailing whitespace! Ignore.
+    
+ * The line below has 5 spaces trailing whitespace! Ignore, even though not matching tab width.
+    
+ */
+
+/**
+ * The line below only contains a new line char. OK.
+
+ * The line below has 4 spaces trailing whitespace! Ignore.
+    
+ * The line below has 5 spaces trailing whitespace! Ignore, even though not matching tab width.
+    
+ */
+
+?>
+The line below only contains a new line char. OK.
+
+The line below has 4 spaces trailing whitespace! Ignore.
+    
+The line below has 5 spaces trailing whitespace! Ignore, even though not matching tab width.
+    
+<?php
+
+// Same tests, but now with indentation.
+
+    // New line only.
+    echo 'the line below only contains a new line char';
+
+    // Blank line contains trailing whitespace, ignore.
+    echo 'the line below has 4 spaces trailing whitespace!';
+    
+    // Blank line contains trailing whitespace, ignore, even though it doesn't match the length of a tabstop.
+    echo 'the line between these statement has 5 spaces trailing whitespace!';
+    
+    /*
+     * The line below only contains a new line char. OK.
+
+     * The line below has 4 spaces trailing whitespace! Ignore.
+    
+     * The line below has 5 spaces trailing whitespace! Ignore, even though not matching tab width.
+    
+     */
+
+    /**
+     * The line below only contains a new line char. OK.
+    
+     * The line below has 4 spaces trailing whitespace! Ignore.
+    
+     * The line below has 5 spaces trailing whitespace! Ignore, even though not matching tab width.
+    
+     */
+
+    ?>
+    The line below only contains a new line char. OK.
+
+    The line below has 4 spaces trailing whitespace! Ignore.
+    
+    The line below has 5 spaces trailing whitespace! Ignore, even though not matching tab width.
+    
+    <?php

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.13.inc
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.13.inc
@@ -1,0 +1,84 @@
+phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreBlankLines false
+
+<?php
+/*
+ * This file tests the handling of trailing whitespace on lines which only contain whitespace.
+ *
+ * BE CAREFUL WHEN SAVING THIS FILE!
+ * For the test to be accurate, the trailing whitespace on various blank lines needs to be preserved!
+ */
+
+// New line only.
+echo 'the line below only contains a new line char';
+
+// Blank line contains trailing whitespace, ignore.
+echo 'the line below has 4 spaces trailing whitespace!';
+    
+// Blank line contains trailing whitespace, ignore, even though it doesn't match the length of a tabstop.
+echo 'the line below has 5 spaces trailing whitespace!';
+     
+/*
+ * The line below only contains a new line char. OK.
+
+ * The line below has 4 spaces trailing whitespace! Ignore.
+    
+ * The line below has 5 spaces trailing whitespace! Ignore, even though not matching tab width.
+     
+ */
+
+/**
+ * The line below only contains a new line char. OK.
+
+ * The line below has 4 spaces trailing whitespace! Ignore.
+    
+ * The line below has 5 spaces trailing whitespace! Ignore, even though not matching tab width.
+     
+ */
+
+?>
+The line below only contains a new line char. OK.
+
+The line below has 4 spaces trailing whitespace! Ignore.
+    
+The line below has 5 spaces trailing whitespace! Ignore, even though not matching tab width.
+     
+<?php
+
+// Same tests, but now with indentation.
+
+    // New line only.
+    echo 'the line below only contains a new line char';
+
+    // Blank line contains trailing whitespace, ignore.
+    echo 'the line below has 4 spaces trailing whitespace!';
+    
+    // Blank line contains trailing whitespace, ignore, even though it doesn't match the length of a tabstop.
+    echo 'the line between these statement has 5 spaces trailing whitespace!';
+     
+    /*
+     * The line below only contains a new line char. OK.
+
+     * The line below has 4 spaces trailing whitespace! Ignore.
+    
+     * The line below has 5 spaces trailing whitespace! Ignore, even though not matching tab width.
+     
+     */
+
+    /**
+     * The line below only contains a new line char. OK.
+    
+     * The line below has 4 spaces trailing whitespace! Ignore.
+    
+     * The line below has 5 spaces trailing whitespace! Ignore, even though not matching tab width.
+     
+     */
+
+    ?>
+    The line below only contains a new line char. OK.
+
+    The line below has 4 spaces trailing whitespace! Ignore.
+    
+    The line below has 5 spaces trailing whitespace! Ignore, even though not matching tab width.
+     
+    <?php
+// phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreBlankLines true

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.13.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.13.inc.fixed
@@ -1,0 +1,84 @@
+phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreBlankLines false
+
+<?php
+/*
+ * This file tests the handling of trailing whitespace on lines which only contain whitespace.
+ *
+ * BE CAREFUL WHEN SAVING THIS FILE!
+ * For the test to be accurate, the trailing whitespace on various blank lines needs to be preserved!
+ */
+
+// New line only.
+echo 'the line below only contains a new line char';
+
+// Blank line contains trailing whitespace, ignore.
+echo 'the line below has 4 spaces trailing whitespace!';
+    
+// Blank line contains trailing whitespace, ignore, even though it doesn't match the length of a tabstop.
+echo 'the line below has 5 spaces trailing whitespace!';
+    
+/*
+ * The line below only contains a new line char. OK.
+
+ * The line below has 4 spaces trailing whitespace! Ignore.
+    
+ * The line below has 5 spaces trailing whitespace! Ignore, even though not matching tab width.
+    
+ */
+
+/**
+ * The line below only contains a new line char. OK.
+
+ * The line below has 4 spaces trailing whitespace! Ignore.
+    
+ * The line below has 5 spaces trailing whitespace! Ignore, even though not matching tab width.
+    
+ */
+
+?>
+The line below only contains a new line char. OK.
+
+The line below has 4 spaces trailing whitespace! Ignore.
+    
+The line below has 5 spaces trailing whitespace! Ignore, even though not matching tab width.
+    
+<?php
+
+// Same tests, but now with indentation.
+
+    // New line only.
+    echo 'the line below only contains a new line char';
+
+    // Blank line contains trailing whitespace, ignore.
+    echo 'the line below has 4 spaces trailing whitespace!';
+    
+    // Blank line contains trailing whitespace, ignore, even though it doesn't match the length of a tabstop.
+    echo 'the line between these statement has 5 spaces trailing whitespace!';
+    
+    /*
+     * The line below only contains a new line char. OK.
+
+     * The line below has 4 spaces trailing whitespace! Ignore.
+    
+     * The line below has 5 spaces trailing whitespace! Ignore, even though not matching tab width.
+    
+     */
+
+    /**
+     * The line below only contains a new line char. OK.
+    
+     * The line below has 4 spaces trailing whitespace! Ignore.
+    
+     * The line below has 5 spaces trailing whitespace! Ignore, even though not matching tab width.
+    
+     */
+
+    ?>
+    The line below only contains a new line char. OK.
+
+    The line below has 4 spaces trailing whitespace! Ignore.
+    
+    The line below has 5 spaces trailing whitespace! Ignore, even though not matching tab width.
+    
+    <?php
+// phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreBlankLines true

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.14.inc
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.14.inc
@@ -1,0 +1,86 @@
+phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreAlignmentBefore[] T_FUNCTION,T_OBJECT_OPERATOR,T_OPEN_TAG
+
+<?php
+/*
+ * File with space based indentation, testing the ignoreAlignmentBefore property.
+ */
+
+    function exampleFunctionA() {} // OK: [4 spaces].
+
+/*
+ * OK: sets of four spaces.
+ */
+        function exampleFunctionB() {}
+
+/*
+ * OK: sets of four spaces.
+ */
+            function exampleFunctionC() {}
+
+    /**
+     * OK: Doc comment is indented with 4 spaces + one space for the star alignment.
+     *
+      * @var string  <= Warning.
+     * @access private
+     */
+
+    /*
+        OK: Multi-line comment is indented with 4 spaces + 4 spaces for the text alignment.
+     <= Warning, no star, but also not indented by multiples of 4 spaces.
+        OK: Another line of text.
+     */
+
+    /*
+     * OK: Multi-line comment is indented with 4 spaces + one space for the star alignment.
+     *
+       * <= Warning.
+     */
+
+     function exampleFunctionD() {}   // Ignored.
+      function exampleFunctionE() {}  // Ignored.
+       function exampleFunctionF() {} // Ignored.
+
+    $object->functioncall()
+        -> chained()
+        -> anothermethod();
+
+    $object->functioncall()
+           -> chained()        // Ignored.
+           -> anothermethod(); // Ignored.
+
+   ?> <!-- Warning: three spaces. -->
+
+    <p>
+      Warning: Some inline HTML with precision alignment.
+    </p>
+
+ <?php // Ignored.
+
+// Testing empty line within a comment.
+/*
+
+*/
+
+// Testing that incorrectly aligned docblocks and multi-line inline comments do not trigger errors.
+// The incorrectly star alignment is not the concern of this sniff.
+    /**
+    * Provision some options
+    */
+
+    /*
+    * Provision some options
+    */
+
+?>
+
+<script type="text/javascript">
+    /*
+     * Multi-line javascript comment should not trigger this sniff.
+     */
+    alert('OK');
+      alert('bad'); <!-- Warning. -->
+</script>
+
+<?php
+
+// phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreAlignmentBefore[]

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.14.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.14.inc.fixed
@@ -1,0 +1,86 @@
+phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreAlignmentBefore[] T_FUNCTION,T_OBJECT_OPERATOR,T_OPEN_TAG
+
+<?php
+/*
+ * File with space based indentation, testing the ignoreAlignmentBefore property.
+ */
+
+    function exampleFunctionA() {} // OK: [4 spaces].
+
+/*
+ * OK: sets of four spaces.
+ */
+        function exampleFunctionB() {}
+
+/*
+ * OK: sets of four spaces.
+ */
+            function exampleFunctionC() {}
+
+    /**
+     * OK: Doc comment is indented with 4 spaces + one space for the star alignment.
+     *
+     * @var string  <= Warning.
+     * @access private
+     */
+
+    /*
+        OK: Multi-line comment is indented with 4 spaces + 4 spaces for the text alignment.
+    <= Warning, no star, but also not indented by multiples of 4 spaces.
+        OK: Another line of text.
+     */
+
+    /*
+     * OK: Multi-line comment is indented with 4 spaces + one space for the star alignment.
+     *
+        * <= Warning.
+     */
+
+     function exampleFunctionD() {}   // Ignored.
+      function exampleFunctionE() {}  // Ignored.
+       function exampleFunctionF() {} // Ignored.
+
+    $object->functioncall()
+        -> chained()
+        -> anothermethod();
+
+    $object->functioncall()
+           -> chained()        // Ignored.
+           -> anothermethod(); // Ignored.
+
+    ?> <!-- Warning: three spaces. -->
+
+    <p>
+        Warning: Some inline HTML with precision alignment.
+    </p>
+
+ <?php // Ignored.
+
+// Testing empty line within a comment.
+/*
+
+*/
+
+// Testing that incorrectly aligned docblocks and multi-line inline comments do not trigger errors.
+// The incorrectly star alignment is not the concern of this sniff.
+    /**
+    * Provision some options
+    */
+
+    /*
+    * Provision some options
+    */
+
+?>
+
+<script type="text/javascript">
+    /*
+     * Multi-line javascript comment should not trigger this sniff.
+     */
+    alert('OK');
+        alert('bad'); <!-- Warning. -->
+</script>
+
+<?php
+
+// phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreAlignmentBefore[]

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.15.inc
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.15.inc
@@ -1,0 +1,86 @@
+phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreAlignmentBefore[] T_FUNCTION,T_OBJECT_OPERATOR,T_OPEN_TAG
+
+<?php
+/*
+ * File with mostly tab based indentation, testing the ignoreAlignmentBefore property.
+ */
+
+	function exampleFunctionA() {} // OK: [tab].
+
+/*
+ * OK: [tab][space][space][space][space]. This sniff is not concerned with tabs vs spaces.
+ */
+	    function exampleFunctionB() {}
+
+/*
+ * OK: [tab][space][space][tab][space][tab]. Comes down to three tabs. This sniff is not concerned with tabs vs spaces.
+ */
+	  	 	function exampleFunctionC() {}
+
+	/**
+	 * OK: Doc comment is indented with tabs and one space for the star alignment.
+	 *
+	  * @var string  <= Warning.
+	 * @access private
+	 */
+
+	/*
+		OK: Multi-line comment is indented with 2 tabs for the text alignment.
+	 <= Warning, no star, but also not indented by multiples of 4 spaces.
+	    OK: Another line of text [tab][space][space][space][space].
+	 */
+
+	/*
+	 * OK: Multi-line comment is indented with tabs and one space for the star alignment.
+	 *
+	   * <= Warning.
+	 */
+
+	 function exampleFunctionD() {} // Ignored.
+	  function exampleFunctionE() {} // Ignored.
+	   function exampleFunctionF() {} // Ignored.
+
+	$object->functioncall()
+		-> chained()
+		-> anothermethod();
+
+	$object->functioncall()
+		   -> chained()        // Ignored.
+		   -> anothermethod(); // Ignored.
+
+   ?> <!-- Warning: three spaces. -->
+
+	<p>
+	  Warning: Some inline HTML with precision alignment.
+	</p>
+
+ <?php // Ignored.
+
+// Testing empty line within a comment.
+/*
+
+*/
+
+// Testing that incorrectly aligned docblocks and multi-line inline comments do not trigger errors.
+// The incorrectly star alignment is not the concern of this sniff.
+	/**
+	* Provision some options
+	*/
+
+	/*
+	* Provision some options
+	*/
+
+?>
+
+<script type="text/javascript">
+	/*
+	 * Multi-line javascript comment should not trigger this sniff.
+	 */
+	alert('OK');
+	  alert('bad'); <!-- Warning. -->
+</script>
+
+<?php
+
+// phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreAlignmentBefore[]

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.15.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.15.inc.fixed
@@ -1,0 +1,86 @@
+phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreAlignmentBefore[] T_FUNCTION,T_OBJECT_OPERATOR,T_OPEN_TAG
+
+<?php
+/*
+ * File with mostly tab based indentation, testing the ignoreAlignmentBefore property.
+ */
+
+	function exampleFunctionA() {} // OK: [tab].
+
+/*
+ * OK: [tab][space][space][space][space]. This sniff is not concerned with tabs vs spaces.
+ */
+	    function exampleFunctionB() {}
+
+/*
+ * OK: [tab][space][space][tab][space][tab]. Comes down to three tabs. This sniff is not concerned with tabs vs spaces.
+ */
+	  	 	function exampleFunctionC() {}
+
+	/**
+	 * OK: Doc comment is indented with tabs and one space for the star alignment.
+	 *
+     * @var string  <= Warning.
+	 * @access private
+	 */
+
+	/*
+		OK: Multi-line comment is indented with 2 tabs for the text alignment.
+    <= Warning, no star, but also not indented by multiples of 4 spaces.
+	    OK: Another line of text [tab][space][space][space][space].
+	 */
+
+	/*
+	 * OK: Multi-line comment is indented with tabs and one space for the star alignment.
+	 *
+        * <= Warning.
+	 */
+
+	 function exampleFunctionD() {} // Ignored.
+	  function exampleFunctionE() {} // Ignored.
+	   function exampleFunctionF() {} // Ignored.
+
+	$object->functioncall()
+		-> chained()
+		-> anothermethod();
+
+	$object->functioncall()
+		   -> chained()        // Ignored.
+		   -> anothermethod(); // Ignored.
+
+    ?> <!-- Warning: three spaces. -->
+
+	<p>
+        Warning: Some inline HTML with precision alignment.
+	</p>
+
+ <?php // Ignored.
+
+// Testing empty line within a comment.
+/*
+
+*/
+
+// Testing that incorrectly aligned docblocks and multi-line inline comments do not trigger errors.
+// The incorrectly star alignment is not the concern of this sniff.
+	/**
+	* Provision some options
+	*/
+
+	/*
+	* Provision some options
+	*/
+
+?>
+
+<script type="text/javascript">
+	/*
+	 * Multi-line javascript comment should not trigger this sniff.
+	 */
+	alert('OK');
+        alert('bad'); <!-- Warning. -->
+</script>
+
+<?php
+
+// phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreAlignmentBefore[]

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.16.inc
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.16.inc
@@ -1,0 +1,86 @@
+phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreAlignmentBefore[] T_DOC_COMMENT_WHITESPACE,T_COMMENT,T_INLINE_HTML
+
+<?php
+/*
+ * File with space based indentation, testing the ignoreAlignmentBefore property.
+ */
+
+    function exampleFunctionA() {} // OK: [4 spaces].
+
+/*
+ * OK: sets of four spaces.
+ */
+        function exampleFunctionB() {}
+
+/*
+ * OK: sets of four spaces.
+ */
+            function exampleFunctionC() {}
+
+    /**
+     * OK: Doc comment is indented with 4 spaces + one space for the star alignment.
+     *
+      * @var string  <= Ignored.
+     * @access private
+     */
+
+    /*
+        OK: Multi-line comment is indented with 4 spaces + 4 spaces for the text alignment.
+     <= Ignored.
+        OK: Another line of text.
+     */
+
+    /*
+     * OK: Multi-line comment is indented with 4 spaces + one space for the star alignment.
+     *
+       * <= Ignored.
+     */
+
+     function exampleFunctionD() {}   // Warning: [4 spaces][extra space].
+      function exampleFunctionE() {}  // Warning: [4 spaces][extra space][extra space].
+       function exampleFunctionF() {} // Warning: [4 spaces][extra space][extra space][extra space].
+
+    $object->functioncall()
+        -> chained()
+        -> anothermethod();
+
+    $object->functioncall()
+           -> chained()        // Warning: [4 spaces][4 spaces][extra space][extra space][extra space].
+           -> anothermethod(); // Warning: [4 spaces][4 spaces][extra space][extra space][extra space].
+
+   ?> <!-- Warning: three spaces. -->
+
+    <p>
+      Ignored: Some inline HTML with precision alignment.
+    </p>
+
+ <?php // Ignored.
+
+// Testing empty line within a comment.
+/*
+
+*/
+
+// Testing that incorrectly aligned docblocks and multi-line inline comments do not trigger errors.
+// The incorrectly star alignment is not the concern of this sniff.
+    /**
+    * Provision some options
+    */
+
+    /*
+    * Provision some options
+    */
+
+?>
+
+<script type="text/javascript">
+    /*
+     * Multi-line javascript comment should not trigger this sniff.
+     */
+    alert('OK');
+      alert('bad'); <!-- Ignored. -->
+</script>
+
+<?php
+
+// phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreAlignmentBefore[]

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.16.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.16.inc.fixed
@@ -1,0 +1,86 @@
+phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreAlignmentBefore[] T_DOC_COMMENT_WHITESPACE,T_COMMENT,T_INLINE_HTML
+
+<?php
+/*
+ * File with space based indentation, testing the ignoreAlignmentBefore property.
+ */
+
+    function exampleFunctionA() {} // OK: [4 spaces].
+
+/*
+ * OK: sets of four spaces.
+ */
+        function exampleFunctionB() {}
+
+/*
+ * OK: sets of four spaces.
+ */
+            function exampleFunctionC() {}
+
+    /**
+     * OK: Doc comment is indented with 4 spaces + one space for the star alignment.
+     *
+      * @var string  <= Ignored.
+     * @access private
+     */
+
+    /*
+        OK: Multi-line comment is indented with 4 spaces + 4 spaces for the text alignment.
+     <= Ignored.
+        OK: Another line of text.
+     */
+
+    /*
+     * OK: Multi-line comment is indented with 4 spaces + one space for the star alignment.
+     *
+       * <= Ignored.
+     */
+
+    function exampleFunctionD() {}   // Warning: [4 spaces][extra space].
+        function exampleFunctionE() {}  // Warning: [4 spaces][extra space][extra space].
+        function exampleFunctionF() {} // Warning: [4 spaces][extra space][extra space][extra space].
+
+    $object->functioncall()
+        -> chained()
+        -> anothermethod();
+
+    $object->functioncall()
+            -> chained()        // Warning: [4 spaces][4 spaces][extra space][extra space][extra space].
+            -> anothermethod(); // Warning: [4 spaces][4 spaces][extra space][extra space][extra space].
+
+    ?> <!-- Warning: three spaces. -->
+
+    <p>
+      Ignored: Some inline HTML with precision alignment.
+    </p>
+
+ <?php // Ignored.
+
+// Testing empty line within a comment.
+/*
+
+*/
+
+// Testing that incorrectly aligned docblocks and multi-line inline comments do not trigger errors.
+// The incorrectly star alignment is not the concern of this sniff.
+    /**
+    * Provision some options
+    */
+
+    /*
+    * Provision some options
+    */
+
+?>
+
+<script type="text/javascript">
+    /*
+     * Multi-line javascript comment should not trigger this sniff.
+     */
+    alert('OK');
+      alert('bad'); <!-- Ignored. -->
+</script>
+
+<?php
+
+// phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreAlignmentBefore[]

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.17.inc
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.17.inc
@@ -1,0 +1,86 @@
+phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreAlignmentBefore[] T_DOC_COMMENT_WHITESPACE,T_COMMENT,T_INLINE_HTML
+
+<?php
+/*
+ * File with mostly tab based indentation, testing the ignoreAlignmentBefore property.
+ */
+
+	function exampleFunctionA() {} // OK: [tab].
+
+/*
+ * OK: [tab][space][space][space][space]. This sniff is not concerned with tabs vs spaces.
+ */
+	    function exampleFunctionB() {}
+
+/*
+ * OK: [tab][space][space][tab][space][tab]. Comes down to three tabs. This sniff is not concerned with tabs vs spaces.
+ */
+	  	 	function exampleFunctionC() {}
+
+	/**
+	 * OK: Doc comment is indented with tabs and one space for the star alignment.
+	 *
+	  * @var string  <= Ignored.
+	 * @access private
+	 */
+
+	/*
+		OK: Multi-line comment is indented with 2 tabs for the text alignment.
+	 <= Ignored.
+	    OK: Another line of text [tab][space][space][space][space].
+	 */
+
+	/*
+	 * OK: Multi-line comment is indented with tabs and one space for the star alignment.
+	 *
+	   * <= Ignored.
+	 */
+
+	 function exampleFunctionD() {} // Warning: [tab][space].
+	  function exampleFunctionE() {} // Warning: [tab][space][space].
+	   function exampleFunctionF() {} // Warning: [tab][space][space][space].
+
+	$object->functioncall()
+		-> chained()
+		-> anothermethod();
+
+	$object->functioncall()
+		   -> chained()        // Warning: [tab][tab][space][space][space].
+		   -> anothermethod(); // Warning: [tab][tab][space][space][space].
+
+   ?> <!-- Warning: three spaces. -->
+
+	<p>
+	  Ignored: Some inline HTML with precision alignment.
+	</p>
+
+ <?php // Ignored: one space.
+
+// Testing empty line within a comment.
+/*
+
+*/
+
+// Testing that incorrectly aligned docblocks and multi-line inline comments do not trigger errors.
+// The incorrectly star alignment is not the concern of this sniff.
+	/**
+	* Provision some options
+	*/
+
+	/*
+	* Provision some options
+	*/
+
+?>
+
+<script type="text/javascript">
+	/*
+	 * Multi-line javascript comment should not trigger this sniff.
+	 */
+	alert('OK');
+	  alert('bad'); <!-- Ignored. -->
+</script>
+
+<?php
+
+// phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreAlignmentBefore[]

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.17.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.17.inc.fixed
@@ -1,0 +1,86 @@
+phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreAlignmentBefore[] T_DOC_COMMENT_WHITESPACE,T_COMMENT,T_INLINE_HTML
+
+<?php
+/*
+ * File with mostly tab based indentation, testing the ignoreAlignmentBefore property.
+ */
+
+	function exampleFunctionA() {} // OK: [tab].
+
+/*
+ * OK: [tab][space][space][space][space]. This sniff is not concerned with tabs vs spaces.
+ */
+	    function exampleFunctionB() {}
+
+/*
+ * OK: [tab][space][space][tab][space][tab]. Comes down to three tabs. This sniff is not concerned with tabs vs spaces.
+ */
+	  	 	function exampleFunctionC() {}
+
+	/**
+	 * OK: Doc comment is indented with tabs and one space for the star alignment.
+	 *
+	  * @var string  <= Ignored.
+	 * @access private
+	 */
+
+	/*
+		OK: Multi-line comment is indented with 2 tabs for the text alignment.
+	 <= Ignored.
+	    OK: Another line of text [tab][space][space][space][space].
+	 */
+
+	/*
+	 * OK: Multi-line comment is indented with tabs and one space for the star alignment.
+	 *
+	   * <= Ignored.
+	 */
+
+    function exampleFunctionD() {} // Warning: [tab][space].
+        function exampleFunctionE() {} // Warning: [tab][space][space].
+        function exampleFunctionF() {} // Warning: [tab][space][space][space].
+
+	$object->functioncall()
+		-> chained()
+		-> anothermethod();
+
+	$object->functioncall()
+            -> chained()        // Warning: [tab][tab][space][space][space].
+            -> anothermethod(); // Warning: [tab][tab][space][space][space].
+
+    ?> <!-- Warning: three spaces. -->
+
+	<p>
+	  Ignored: Some inline HTML with precision alignment.
+	</p>
+
+ <?php // Ignored: one space.
+
+// Testing empty line within a comment.
+/*
+
+*/
+
+// Testing that incorrectly aligned docblocks and multi-line inline comments do not trigger errors.
+// The incorrectly star alignment is not the concern of this sniff.
+	/**
+	* Provision some options
+	*/
+
+	/*
+	* Provision some options
+	*/
+
+?>
+
+<script type="text/javascript">
+	/*
+	 * Multi-line javascript comment should not trigger this sniff.
+	 */
+	alert('OK');
+	  alert('bad'); <!-- Ignored. -->
+</script>
+
+<?php
+
+// phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreAlignmentBefore[]

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.18.inc
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.18.inc
@@ -1,0 +1,5 @@
+<?php
+
+    /*
+       * phpcs:disable Standard.Category.Sniff -- Bad, but will only be reported when PHPCS is run with --ignore-annotations.
+     */

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.18.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.18.inc.fixed
@@ -1,0 +1,5 @@
+<?php
+
+    /*
+        * phpcs:disable Standard.Category.Sniff -- Bad, but will only be reported when PHPCS is run with --ignore-annotations.
+     */

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.19a.inc
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.19a.inc
@@ -1,0 +1,15 @@
+phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreAlignmentBefore[] T_COMMENT,T_FUNCTION
+
+<?php
+/**
+ * Testing issue as reported upstream in
+ * https://github.com/squizlabs/PHP_CodeSniffer/issues/2179#issuecomment-437634372.
+ *
+ * This is an issue concerning property handling across multiple files, so the
+ * 19a, 19b and 19c test files together test (against) the issue.
+ */
+
+  // Bad, but not reported as token type is being ignored.
+     function exampleFunctionD() {} // Bad, but not reported as token type is being ignored.
+      function exampleFunctionE() {} // Bad, but not reported as token type is being ignored.
+       function exampleFunctionF() {} // Bad, but not reported as token type is being ignored.

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.19b.inc
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.19b.inc
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Testing issue as reported upstream in
+ * https://github.com/squizlabs/PHP_CodeSniffer/issues/2179#issuecomment-437634372.
+ *
+ * This is an issue concerning property handling across multiple files, so the
+ * 19a, 19b and 19c test files together test (against) the issue.
+ *
+ * This file should inherit the property settings from the 19a test case file.
+ */
+
+  // Bad, but not reported as token type is being ignored.
+     function exampleFunctionD() {} // Bad, but not reported as token type is (still) being ignored.
+      function exampleFunctionE() {} // Bad, but not reported as token type is (still) being ignored.
+       function exampleFunctionF() {} // Bad, but not reported as token type is (still) being ignored.

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.19c.inc
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.19c.inc
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Testing issue as reported upstream in
+ * https://github.com/squizlabs/PHP_CodeSniffer/issues/2179#issuecomment-437634372.
+ *
+ * This is an issue concerning property handling across multiple files, so the
+ * 19a, 19b and 19c test files together test (against) the issue.
+ *
+ * This file should inherit the property settings from the 19a test case file.
+ */
+
+  // Bad, but not reported as token type is being ignored.
+     function exampleFunctionD() {} // Bad, but not reported as token type is (still) being ignored.
+      function exampleFunctionE() {} // Bad, but not reported as token type is (still) being ignored.
+       function exampleFunctionF() {} // Bad, but not reported as token type is (still) being ignored.
+
+// phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreAlignmentBefore[]

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.css
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.css
@@ -1,0 +1,6 @@
+/* Tab-based file. */
+#login-container {
+	margin-left: -225px;
+	width: 450px;
+	 height: 450px; /* Bad. */
+}

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.css.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.css.fixed
@@ -1,0 +1,6 @@
+/* Tab-based file. */
+#login-container {
+	margin-left: -225px;
+	width: 450px;
+    height: 450px; /* Bad. */
+}

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.inc
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.inc
@@ -1,0 +1,86 @@
+phpcs:set Universal.WhiteSpace.PrecisionAlignment indent 4
+
+<?php
+/*
+ * File with space based indentation.
+ * Using an explicit custom indent value of 4 spaces.
+ */
+    function exampleFunctionA() {} // OK: [4 spaces].
+
+/*
+ * OK: sets of four spaces.
+ */
+        function exampleFunctionB() {}
+
+/*
+ * OK: sets of four spaces.
+ */
+            function exampleFunctionC() {}
+
+    /**
+     * OK: Doc comment is indented with 4 spaces + one space for the star alignment.
+     *
+      * @var string  <= Warning.
+     * @access private
+     */
+
+    /*
+        OK: Multi-line comment is indented with 4 spaces + 4 spaces for the text alignment.
+     <= Warning, no star, but also not indented by multiples of 4 spaces.
+        OK: Another line of text.
+     */
+
+    /*
+     * OK: Multi-line comment is indented with 4 spaces + one space for the star alignment.
+     *
+       * <= Warning.
+     */
+
+     function exampleFunctionD() {}   // Warning: [4 spaces][extra space].
+      function exampleFunctionE() {}  // Warning: [4 spaces][extra space][extra space].
+       function exampleFunctionF() {} // Warning: [4 spaces][extra space][extra space][extra space].
+
+    $object->functioncall()
+        -> chained()
+        -> anothermethod();
+
+    $object->functioncall()
+           -> chained()        // Warning: [4 spaces][4 spaces][extra space][extra space][extra space].
+           -> anothermethod(); // Warning: [4 spaces][4 spaces][extra space][extra space][extra space].
+
+   ?> <!-- Warning: three spaces. -->
+
+    <p>
+      Warning: Some inline HTML with precision alignment.
+    </p>
+
+ <?php // Warning: one space.
+
+// Testing empty line within a comment.
+/*
+
+*/
+
+// Testing that incorrectly aligned docblocks and multi-line inline comments do not trigger errors.
+// The incorrectly star alignment is not the concern of this sniff.
+    /**
+    * Provision some options
+    */
+
+    /*
+    * Provision some options
+    */
+
+?>
+
+<script type="text/javascript">
+    /*
+     * Multi-line javascript comment should not trigger this sniff.
+     */
+    alert('OK');
+      alert('bad'); <!-- Warning. -->
+</script>
+
+<?php
+
+// phpcs:set Universal.WhiteSpace.PrecisionAlignment indent

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.inc.fixed
@@ -1,0 +1,86 @@
+phpcs:set Universal.WhiteSpace.PrecisionAlignment indent 4
+
+<?php
+/*
+ * File with space based indentation.
+ * Using an explicit custom indent value of 4 spaces.
+ */
+    function exampleFunctionA() {} // OK: [4 spaces].
+
+/*
+ * OK: sets of four spaces.
+ */
+        function exampleFunctionB() {}
+
+/*
+ * OK: sets of four spaces.
+ */
+            function exampleFunctionC() {}
+
+    /**
+     * OK: Doc comment is indented with 4 spaces + one space for the star alignment.
+     *
+     * @var string  <= Warning.
+     * @access private
+     */
+
+    /*
+        OK: Multi-line comment is indented with 4 spaces + 4 spaces for the text alignment.
+    <= Warning, no star, but also not indented by multiples of 4 spaces.
+        OK: Another line of text.
+     */
+
+    /*
+     * OK: Multi-line comment is indented with 4 spaces + one space for the star alignment.
+     *
+        * <= Warning.
+     */
+
+    function exampleFunctionD() {}   // Warning: [4 spaces][extra space].
+        function exampleFunctionE() {}  // Warning: [4 spaces][extra space][extra space].
+        function exampleFunctionF() {} // Warning: [4 spaces][extra space][extra space][extra space].
+
+    $object->functioncall()
+        -> chained()
+        -> anothermethod();
+
+    $object->functioncall()
+            -> chained()        // Warning: [4 spaces][4 spaces][extra space][extra space][extra space].
+            -> anothermethod(); // Warning: [4 spaces][4 spaces][extra space][extra space][extra space].
+
+    ?> <!-- Warning: three spaces. -->
+
+    <p>
+        Warning: Some inline HTML with precision alignment.
+    </p>
+
+<?php // Warning: one space.
+
+// Testing empty line within a comment.
+/*
+
+*/
+
+// Testing that incorrectly aligned docblocks and multi-line inline comments do not trigger errors.
+// The incorrectly star alignment is not the concern of this sniff.
+    /**
+    * Provision some options
+    */
+
+    /*
+    * Provision some options
+    */
+
+?>
+
+<script type="text/javascript">
+    /*
+     * Multi-line javascript comment should not trigger this sniff.
+     */
+    alert('OK');
+        alert('bad'); <!-- Warning. -->
+</script>
+
+<?php
+
+// phpcs:set Universal.WhiteSpace.PrecisionAlignment indent

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.js
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.js
@@ -1,0 +1,8 @@
+/* Tab-based file. */
+var x = {
+	abc: 1,
+	zyz: 2,
+	 mno: {
+	   abc: 4
+	 },
+}

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.js.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.js.fixed
@@ -1,0 +1,8 @@
+/* Tab-based file. */
+var x = {
+	abc: 1,
+	zyz: 2,
+    mno: {
+        abc: 4
+    },
+}

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.3.inc
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.3.inc
@@ -1,0 +1,86 @@
+phpcs:set Universal.WhiteSpace.PrecisionAlignment indent 3
+
+<?php
+/*
+ * File with space based indentation.
+ * Using an explicit custom indent value of 3 spaces.
+ */
+   function exampleFunctionA() {} // OK: [3 spaces].
+
+/*
+ * OK: sets of three spaces.
+ */
+      function exampleFunctionB() {}
+
+/*
+ * OK: sets of three spaces.
+ */
+         function exampleFunctionC() {}
+
+   /**
+    * OK: Doc comment is indented with 3 spaces + one space for the star alignment.
+    *
+     * @var string  <= Warning.
+    * @access private
+    */
+
+   /*
+      OK: Multi-line comment is indented with 3 spaces + 3 spaces for the text alignment.
+    <= Warning, no star, but also not indented by multiples of 3 spaces.
+      OK: Another line of text.
+    */
+
+   /*
+    * OK: Multi-line comment is indented with 3 spaces + one space for the star alignment.
+    *
+     * <= Warning.
+    */
+
+    function exampleFunctionD() {}   // Warning: [3 spaces][extra space].
+     function exampleFunctionE() {}  // Warning: [3 spaces][extra space][extra space].
+       function exampleFunctionF() {} // Warning: [3 spaces][3 spaces][extra space].
+
+   $object->functioncall()
+      -> chained()
+      -> anothermethod();
+
+   $object->functioncall()
+          -> chained()        // Warning: [3 spaces][3 spaces][extra space].
+          -> anothermethod(); // Warning: [3 spaces][3 spaces][extra space].
+
+  ?> <!-- Warning: two spaces. -->
+
+   <p>
+     Warning: Some inline HTML with precision alignment.
+   </p>
+
+ <?php // Warning: one space.
+
+// Testing empty line within a comment.
+/*
+
+*/
+
+// Testing that incorrectly aligned docblocks and multi-line inline comments do not trigger errors.
+// The incorrectly star alignment is not the concern of this sniff.
+   /**
+   * Provision some options
+   */
+
+   /*
+   * Provision some options
+   */
+
+?>
+
+<script type="text/javascript">
+   /*
+    * Multi-line javascript comment should not trigger this sniff.
+    */
+   alert('OK');
+     alert('bad'); <!-- Warning. -->
+</script>
+
+<?php
+
+// phpcs:set Universal.WhiteSpace.PrecisionAlignment indent

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.3.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.3.inc.fixed
@@ -1,0 +1,86 @@
+phpcs:set Universal.WhiteSpace.PrecisionAlignment indent 3
+
+<?php
+/*
+ * File with space based indentation.
+ * Using an explicit custom indent value of 3 spaces.
+ */
+   function exampleFunctionA() {} // OK: [3 spaces].
+
+/*
+ * OK: sets of three spaces.
+ */
+      function exampleFunctionB() {}
+
+/*
+ * OK: sets of three spaces.
+ */
+         function exampleFunctionC() {}
+
+   /**
+    * OK: Doc comment is indented with 3 spaces + one space for the star alignment.
+    *
+    * @var string  <= Warning.
+    * @access private
+    */
+
+   /*
+      OK: Multi-line comment is indented with 3 spaces + 3 spaces for the text alignment.
+   <= Warning, no star, but also not indented by multiples of 3 spaces.
+      OK: Another line of text.
+    */
+
+   /*
+    * OK: Multi-line comment is indented with 3 spaces + one space for the star alignment.
+    *
+    * <= Warning.
+    */
+
+   function exampleFunctionD() {}   // Warning: [3 spaces][extra space].
+      function exampleFunctionE() {}  // Warning: [3 spaces][extra space][extra space].
+      function exampleFunctionF() {} // Warning: [3 spaces][3 spaces][extra space].
+
+   $object->functioncall()
+      -> chained()
+      -> anothermethod();
+
+   $object->functioncall()
+         -> chained()        // Warning: [3 spaces][3 spaces][extra space].
+         -> anothermethod(); // Warning: [3 spaces][3 spaces][extra space].
+
+   ?> <!-- Warning: two spaces. -->
+
+   <p>
+      Warning: Some inline HTML with precision alignment.
+   </p>
+
+<?php // Warning: one space.
+
+// Testing empty line within a comment.
+/*
+
+*/
+
+// Testing that incorrectly aligned docblocks and multi-line inline comments do not trigger errors.
+// The incorrectly star alignment is not the concern of this sniff.
+   /**
+   * Provision some options
+   */
+
+   /*
+   * Provision some options
+   */
+
+?>
+
+<script type="text/javascript">
+   /*
+    * Multi-line javascript comment should not trigger this sniff.
+    */
+   alert('OK');
+      alert('bad'); <!-- Warning. -->
+</script>
+
+<?php
+
+// phpcs:set Universal.WhiteSpace.PrecisionAlignment indent

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.4.inc
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.4.inc
@@ -1,0 +1,86 @@
+phpcs:set Universal.WhiteSpace.PrecisionAlignment indent 2
+
+<?php
+/*
+ * File with space based indentation.
+ * Using an explicit custom indent value of 2 spaces.
+ */
+    function exampleFunctionA() {} // OK: [2 spaces][2 spaces].
+
+/*
+ * OK: sets of two spaces.
+ */
+        function exampleFunctionB() {}
+
+/*
+ * OK: sets of two spaces.
+ */
+            function exampleFunctionC() {}
+
+    /**
+     * OK: Doc comment is indented with 4 spaces + one space for the star alignment.
+     *
+      * @var string  <= NO Warning as this is still a multiple of 2.
+     * @access private
+     */
+
+    /*
+        OK: Multi-line comment is indented with 4 spaces + 4 spaces for the text alignment.
+     <= Warning, no star, but also not indented by multiples of 2 spaces.
+        OK: Another line of text.
+     */
+
+    /*
+     * OK: Multi-line comment is indented with 4 spaces + one space for the star alignment.
+     *
+       * <= NO Warning as this is still a multiple of 2 (plus 1 space for the star).
+     */
+
+     function exampleFunctionD() {}   // Warning: [2 spaces][2 spaces][extra space].
+       function exampleFunctionE() {}  // Warning: [2 spaces][2 spaces][2 spaces][extra space].
+         function exampleFunctionF() {} // Warning: [2 spaces][2 spaces][2 spaces][2 spaces][extra space].
+
+  $object->functioncall()
+    -> chained()
+    -> anothermethod();
+
+  $object->functioncall()
+         -> chained()        // Warning: [2 spaces][2 spaces][2 spaces][2 spaces][extra space].
+         -> anothermethod(); // Warning: [2 spaces][2 spaces][2 spaces][2 spaces][extra space].
+
+   ?> <!-- Warning: three spaces. -->
+
+    <p>
+     Warning: Some inline HTML with precision alignment.
+    </p>
+
+ <?php // Warning: one space.
+
+// Testing empty line within a comment.
+/*
+
+*/
+
+// Testing that incorrectly aligned docblocks and multi-line inline comments do not trigger errors.
+// The incorrectly star alignment is not the concern of this sniff.
+    /**
+    * Provision some options
+    */
+
+    /*
+    * Provision some options
+    */
+
+?>
+
+<script type="text/javascript">
+    /*
+     * Multi-line javascript comment should not trigger this sniff.
+     */
+    alert('OK');
+     alert('bad'); <!-- Warning. -->
+</script>
+
+<?php
+
+// phpcs:set Universal.WhiteSpace.PrecisionAlignment indent

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.4.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.4.inc.fixed
@@ -1,0 +1,86 @@
+phpcs:set Universal.WhiteSpace.PrecisionAlignment indent 2
+
+<?php
+/*
+ * File with space based indentation.
+ * Using an explicit custom indent value of 2 spaces.
+ */
+    function exampleFunctionA() {} // OK: [2 spaces][2 spaces].
+
+/*
+ * OK: sets of two spaces.
+ */
+        function exampleFunctionB() {}
+
+/*
+ * OK: sets of two spaces.
+ */
+            function exampleFunctionC() {}
+
+    /**
+     * OK: Doc comment is indented with 4 spaces + one space for the star alignment.
+     *
+      * @var string  <= NO Warning as this is still a multiple of 2.
+     * @access private
+     */
+
+    /*
+        OK: Multi-line comment is indented with 4 spaces + 4 spaces for the text alignment.
+      <= Warning, no star, but also not indented by multiples of 2 spaces.
+        OK: Another line of text.
+     */
+
+    /*
+     * OK: Multi-line comment is indented with 4 spaces + one space for the star alignment.
+     *
+       * <= NO Warning as this is still a multiple of 2 (plus 1 space for the star).
+     */
+
+      function exampleFunctionD() {}   // Warning: [2 spaces][2 spaces][extra space].
+        function exampleFunctionE() {}  // Warning: [2 spaces][2 spaces][2 spaces][extra space].
+          function exampleFunctionF() {} // Warning: [2 spaces][2 spaces][2 spaces][2 spaces][extra space].
+
+  $object->functioncall()
+    -> chained()
+    -> anothermethod();
+
+  $object->functioncall()
+          -> chained()        // Warning: [2 spaces][2 spaces][2 spaces][2 spaces][extra space].
+          -> anothermethod(); // Warning: [2 spaces][2 spaces][2 spaces][2 spaces][extra space].
+
+    ?> <!-- Warning: three spaces. -->
+
+    <p>
+      Warning: Some inline HTML with precision alignment.
+    </p>
+
+  <?php // Warning: one space.
+
+// Testing empty line within a comment.
+/*
+
+*/
+
+// Testing that incorrectly aligned docblocks and multi-line inline comments do not trigger errors.
+// The incorrectly star alignment is not the concern of this sniff.
+    /**
+    * Provision some options
+    */
+
+    /*
+    * Provision some options
+    */
+
+?>
+
+<script type="text/javascript">
+    /*
+     * Multi-line javascript comment should not trigger this sniff.
+     */
+    alert('OK');
+      alert('bad'); <!-- Warning. -->
+</script>
+
+<?php
+
+// phpcs:set Universal.WhiteSpace.PrecisionAlignment indent

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.5.inc
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.5.inc
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * File with mostly tab based indentation.
+ * Using the default indent value of 1 tab = 4 spaces.
+ */
+
+	function exampleFunctionA() {} // OK: [tab].
+
+/*
+ * OK: [tab][space][space][space][space]. This sniff is not concerned with tabs vs spaces.
+ */
+	    function exampleFunctionB() {}
+
+/*
+ * OK: [tab][space][space][tab][space][tab]. Comes down to three tabs. This sniff is not concerned with tabs vs spaces.
+ */
+	  	 	function exampleFunctionC() {}
+
+	/**
+	 * OK: Doc comment is indented with tabs and one space for the star alignment.
+	 *
+	  * @var string  <= Warning.
+	 * @access private
+	 */
+
+	/*
+		OK: Multi-line comment is indented with 2 tabs for the text alignment.
+	 <= Warning, no star, but also not indented by multiples of 4 spaces.
+	    OK: Another line of text [tab][space][space][space][space].
+	 */
+
+	/*
+	 * OK: Multi-line comment is indented with tabs and one space for the star alignment.
+	 *
+	   * <= Warning.
+	 */
+
+	 function exampleFunctionD() {} // Warning: [tab][space].
+	  function exampleFunctionE() {} // Warning: [tab][space][space].
+	   function exampleFunctionF() {} // Warning: [tab][space][space][space].
+
+	$object->functioncall()
+		-> chained()
+		-> anothermethod();
+
+	$object->functioncall()
+		   -> chained()        // Warning: [tab][tab][space][space][space].
+		   -> anothermethod(); // Warning: [tab][tab][space][space][space].
+
+   ?> <!-- Warning: three spaces. -->
+
+	<p>
+	  Warning: Some inline HTML with precision alignment.
+	</p>
+
+ <?php // Warning: one space.
+
+// Testing empty line within a comment.
+/*
+
+*/
+
+// Testing that incorrectly aligned docblocks and multi-line inline comments do not trigger errors.
+// The incorrectly star alignment is not the concern of this sniff.
+	/**
+	* Provision some options
+	*/
+
+	/*
+	* Provision some options
+	*/
+
+?>
+
+<script type="text/javascript">
+	/*
+	 * Multi-line javascript comment should not trigger this sniff.
+	 */
+	alert('OK');
+	  alert('bad'); <!-- Warning. -->
+</script>
+
+<?php

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.5.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.5.inc.fixed
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * File with mostly tab based indentation.
+ * Using the default indent value of 1 tab = 4 spaces.
+ */
+
+	function exampleFunctionA() {} // OK: [tab].
+
+/*
+ * OK: [tab][space][space][space][space]. This sniff is not concerned with tabs vs spaces.
+ */
+	    function exampleFunctionB() {}
+
+/*
+ * OK: [tab][space][space][tab][space][tab]. Comes down to three tabs. This sniff is not concerned with tabs vs spaces.
+ */
+	  	 	function exampleFunctionC() {}
+
+	/**
+	 * OK: Doc comment is indented with tabs and one space for the star alignment.
+	 *
+     * @var string  <= Warning.
+	 * @access private
+	 */
+
+	/*
+		OK: Multi-line comment is indented with 2 tabs for the text alignment.
+    <= Warning, no star, but also not indented by multiples of 4 spaces.
+	    OK: Another line of text [tab][space][space][space][space].
+	 */
+
+	/*
+	 * OK: Multi-line comment is indented with tabs and one space for the star alignment.
+	 *
+        * <= Warning.
+	 */
+
+    function exampleFunctionD() {} // Warning: [tab][space].
+        function exampleFunctionE() {} // Warning: [tab][space][space].
+        function exampleFunctionF() {} // Warning: [tab][space][space][space].
+
+	$object->functioncall()
+		-> chained()
+		-> anothermethod();
+
+	$object->functioncall()
+            -> chained()        // Warning: [tab][tab][space][space][space].
+            -> anothermethod(); // Warning: [tab][tab][space][space][space].
+
+    ?> <!-- Warning: three spaces. -->
+
+	<p>
+        Warning: Some inline HTML with precision alignment.
+	</p>
+
+<?php // Warning: one space.
+
+// Testing empty line within a comment.
+/*
+
+*/
+
+// Testing that incorrectly aligned docblocks and multi-line inline comments do not trigger errors.
+// The incorrectly star alignment is not the concern of this sniff.
+	/**
+	* Provision some options
+	*/
+
+	/*
+	* Provision some options
+	*/
+
+?>
+
+<script type="text/javascript">
+	/*
+	 * Multi-line javascript comment should not trigger this sniff.
+	 */
+	alert('OK');
+        alert('bad'); <!-- Warning. -->
+</script>
+
+<?php

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.6.inc
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.6.inc
@@ -1,0 +1,86 @@
+phpcs:set Universal.WhiteSpace.PrecisionAlignment indent 4
+
+<?php
+/*
+ * File with mostly tab based indentation.
+ * Using an explicit custom indent value of 4 with tab-width 4.
+ */
+	function exampleFunctionA() {} // OK: [tab].
+
+/*
+ * OK: [tab][space][space][space][space]. This sniff is not concerned with tabs vs spaces.
+ */
+	    function exampleFunctionB() {}
+
+/*
+ * OK: [tab][space][space][tab][space][tab]. Comes down to three tabs. This sniff is not concerned with tabs vs spaces.
+ */
+	  	 	function exampleFunctionC() {}
+
+	/**
+	 * OK: Doc comment is indented with tabs and one space for the star alignment.
+	 *
+	  * @var string  <= Warning.
+	 * @access private
+	 */
+
+	/*
+		OK: Multi-line comment is indented with 2 tabs for the text alignment.
+	 <= Warning, no star, but also not indented by multiples of 4 spaces.
+	    OK: Another line of text [tab][space][space][space][space].
+	 */
+
+	/*
+	 * OK: Multi-line comment is indented with tabs and one space for the star alignment.
+	 *
+	   * <= Warning.
+	 */
+
+	 function exampleFunctionD() {} // Warning: [tab][space].
+	  function exampleFunctionE() {} // Warning: [tab][space][space].
+	   function exampleFunctionF() {} // Warning: [tab][space][space][space].
+
+	$object->functioncall()
+		-> chained()
+		-> anothermethod();
+
+	$object->functioncall()
+		   -> chained()        // Warning: [tab][tab][space][space][space].
+		   -> anothermethod(); // Warning: [tab][tab][space][space][space].
+
+   ?> <!-- Warning: three spaces. -->
+
+	<p>
+	  Warning: Some inline HTML with precision alignment.
+	</p>
+
+ <?php // Warning: one space.
+
+// Testing empty line within a comment.
+/*
+
+*/
+
+// Testing that incorrectly aligned docblocks and multi-line inline comments do not trigger errors.
+// The incorrectly star alignment is not the concern of this sniff.
+	/**
+	* Provision some options
+	*/
+
+	/*
+	* Provision some options
+	*/
+
+?>
+
+<script type="text/javascript">
+	/*
+	 * Multi-line javascript comment should not trigger this sniff.
+	 */
+	alert('OK');
+	  alert('bad'); <!-- Warning. -->
+</script>
+
+<?php
+
+// phpcs:set Universal.WhiteSpace.PrecisionAlignment indent

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.6.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.6.inc.fixed
@@ -1,0 +1,86 @@
+phpcs:set Universal.WhiteSpace.PrecisionAlignment indent 4
+
+<?php
+/*
+ * File with mostly tab based indentation.
+ * Using an explicit custom indent value of 4 with tab-width 4.
+ */
+	function exampleFunctionA() {} // OK: [tab].
+
+/*
+ * OK: [tab][space][space][space][space]. This sniff is not concerned with tabs vs spaces.
+ */
+	    function exampleFunctionB() {}
+
+/*
+ * OK: [tab][space][space][tab][space][tab]. Comes down to three tabs. This sniff is not concerned with tabs vs spaces.
+ */
+	  	 	function exampleFunctionC() {}
+
+	/**
+	 * OK: Doc comment is indented with tabs and one space for the star alignment.
+	 *
+     * @var string  <= Warning.
+	 * @access private
+	 */
+
+	/*
+		OK: Multi-line comment is indented with 2 tabs for the text alignment.
+    <= Warning, no star, but also not indented by multiples of 4 spaces.
+	    OK: Another line of text [tab][space][space][space][space].
+	 */
+
+	/*
+	 * OK: Multi-line comment is indented with tabs and one space for the star alignment.
+	 *
+        * <= Warning.
+	 */
+
+    function exampleFunctionD() {} // Warning: [tab][space].
+        function exampleFunctionE() {} // Warning: [tab][space][space].
+        function exampleFunctionF() {} // Warning: [tab][space][space][space].
+
+	$object->functioncall()
+		-> chained()
+		-> anothermethod();
+
+	$object->functioncall()
+            -> chained()        // Warning: [tab][tab][space][space][space].
+            -> anothermethod(); // Warning: [tab][tab][space][space][space].
+
+    ?> <!-- Warning: three spaces. -->
+
+	<p>
+        Warning: Some inline HTML with precision alignment.
+	</p>
+
+<?php // Warning: one space.
+
+// Testing empty line within a comment.
+/*
+
+*/
+
+// Testing that incorrectly aligned docblocks and multi-line inline comments do not trigger errors.
+// The incorrectly star alignment is not the concern of this sniff.
+	/**
+	* Provision some options
+	*/
+
+	/*
+	* Provision some options
+	*/
+
+?>
+
+<script type="text/javascript">
+	/*
+	 * Multi-line javascript comment should not trigger this sniff.
+	 */
+	alert('OK');
+        alert('bad'); <!-- Warning. -->
+</script>
+
+<?php
+
+// phpcs:set Universal.WhiteSpace.PrecisionAlignment indent

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.7.inc
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.7.inc
@@ -1,0 +1,86 @@
+phpcs:set Universal.WhiteSpace.PrecisionAlignment indent 3
+
+<?php
+/*
+ * File with mostly tab based indentation.
+ * Using an explicit custom indent value of 3 with tab-width 3.
+ */
+	function exampleFunctionA() {} // OK: [tab].
+
+/*
+ * OK: [tab][space][space][space]. This sniff is not concerned with tabs vs spaces.
+ */
+	   function exampleFunctionB() {}
+
+/*
+ * OK: [tab][space][space][tab][space][tab]. Comes down to three tabs. This sniff is not concerned with tabs vs spaces.
+ */
+	  	 	function exampleFunctionC() {}
+
+	/**
+	 * OK: Doc comment is indented with tabs and one space for the star alignment.
+	 *
+	  * @var string  <= Warning.
+	 * @access private
+	 */
+
+	/*
+		OK: Multi-line comment is indented with 2 tabs for the text alignment.
+	 <= Warning, no star, but also not indented by multiples of 3 spaces.
+	   OK: Another line of text [tab][space][space][space].
+	 */
+
+	/*
+	 * OK: Multi-line comment is indented with tabs and one space for the star alignment.
+	 *
+	  * <= Warning.
+	 */
+
+	 function exampleFunctionD() {} // Warning: [tab][space].
+	  function exampleFunctionE() {} // Warning: [tab][space][space].
+		 function exampleFunctionF() {} // Warning: [tab][tab][space].
+
+	$object->functioncall()
+		-> chained()
+		-> anothermethod();
+
+	$object->functioncall()
+		 -> chained()        // Warning: [tab][tab][space].
+		  -> anothermethod(); // Warning: [tab][tab][space][space].
+
+  ?> <!-- Warning: two spaces. -->
+
+	<p>
+	  Warning: Some inline HTML with precision alignment.
+	</p>
+
+ <?php // Warning: one space.
+
+// Testing empty line within a comment.
+/*
+
+*/
+
+// Testing that incorrectly aligned docblocks and multi-line inline comments do not trigger errors.
+// The incorrectly star alignment is not the concern of this sniff.
+	/**
+	* Provision some options
+	*/
+
+	/*
+	* Provision some options
+	*/
+
+?>
+
+<script type="text/javascript">
+	/*
+	 * Multi-line javascript comment should not trigger this sniff.
+	 */
+	alert('OK');
+	  alert('bad'); <!-- Warning. -->
+</script>
+
+<?php
+
+// phpcs:set Universal.WhiteSpace.PrecisionAlignment indent

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.7.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.7.inc.fixed
@@ -1,0 +1,86 @@
+phpcs:set Universal.WhiteSpace.PrecisionAlignment indent 3
+
+<?php
+/*
+ * File with mostly tab based indentation.
+ * Using an explicit custom indent value of 3 with tab-width 3.
+ */
+	function exampleFunctionA() {} // OK: [tab].
+
+/*
+ * OK: [tab][space][space][space]. This sniff is not concerned with tabs vs spaces.
+ */
+	   function exampleFunctionB() {}
+
+/*
+ * OK: [tab][space][space][tab][space][tab]. Comes down to three tabs. This sniff is not concerned with tabs vs spaces.
+ */
+	  	 	function exampleFunctionC() {}
+
+	/**
+	 * OK: Doc comment is indented with tabs and one space for the star alignment.
+	 *
+    * @var string  <= Warning.
+	 * @access private
+	 */
+
+	/*
+		OK: Multi-line comment is indented with 2 tabs for the text alignment.
+   <= Warning, no star, but also not indented by multiples of 3 spaces.
+	   OK: Another line of text [tab][space][space][space].
+	 */
+
+	/*
+	 * OK: Multi-line comment is indented with tabs and one space for the star alignment.
+	 *
+    * <= Warning.
+	 */
+
+   function exampleFunctionD() {} // Warning: [tab][space].
+      function exampleFunctionE() {} // Warning: [tab][space][space].
+      function exampleFunctionF() {} // Warning: [tab][tab][space].
+
+	$object->functioncall()
+		-> chained()
+		-> anothermethod();
+
+	$object->functioncall()
+      -> chained()        // Warning: [tab][tab][space].
+         -> anothermethod(); // Warning: [tab][tab][space][space].
+
+   ?> <!-- Warning: two spaces. -->
+
+	<p>
+      Warning: Some inline HTML with precision alignment.
+	</p>
+
+<?php // Warning: one space.
+
+// Testing empty line within a comment.
+/*
+
+*/
+
+// Testing that incorrectly aligned docblocks and multi-line inline comments do not trigger errors.
+// The incorrectly star alignment is not the concern of this sniff.
+	/**
+	* Provision some options
+	*/
+
+	/*
+	* Provision some options
+	*/
+
+?>
+
+<script type="text/javascript">
+	/*
+	 * Multi-line javascript comment should not trigger this sniff.
+	 */
+	alert('OK');
+      alert('bad'); <!-- Warning. -->
+</script>
+
+<?php
+
+// phpcs:set Universal.WhiteSpace.PrecisionAlignment indent

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.8.inc
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.8.inc
@@ -1,0 +1,86 @@
+phpcs:set Universal.WhiteSpace.PrecisionAlignment indent 2
+
+<?php
+/*
+ * File with mostly tab based indentation.
+ * Using an explicit custom indent value of 2 with tab-width 2.
+ */
+	function exampleFunctionA() {} // OK: [tab].
+
+/*
+ * OK: [tab][space][space][space][space]. This sniff is not concerned with tabs vs spaces.
+ */
+	    function exampleFunctionB() {}
+
+/*
+ * OK: [tab][space][space][tab][space][tab]. Comes down to four tabs. This sniff is not concerned with tabs vs spaces.
+ */
+	  	 	function exampleFunctionC() {}
+
+	/**
+	 * OK: Doc comment is indented with tabs and one space for the star alignment.
+	 *
+	  * @var string  <= NO Warning as this is still a multiple of 2.
+	 * @access private
+	 */
+
+	/*
+		OK: Multi-line comment is indented with 2 tabs for the text alignment.
+	 <= Warning, no star, but also not indented by multiples of 2 spaces.
+	    OK: Another line of text [tab][space][space][space][space].
+	 */
+
+	/*
+	 * OK: Multi-line comment is indented with tabs and one space for the star alignment.
+	 *
+	   * <= NO Warning as this is still a multiple of 2 (plus 1 space for the star).
+	 */
+
+	 function exampleFunctionD() {} // Warning: [tab][space].
+		 function exampleFunctionE() {} // Warning: [tab][tab][space].
+			 function exampleFunctionF() {} // Warning: [tab][tab][tab][space].
+
+	$object->functioncall()
+		-> chained()
+		-> anothermethod();
+
+	$object->functioncall()
+		   -> chained()        // Warning: [tab][tab][space][space][space].
+		   -> anothermethod(); // Warning: [tab][tab][space][space][space].
+
+   ?> <!-- Warning: three spaces. -->
+
+	<p>
+	 Warning: Some inline HTML with precision alignment.
+	</p>
+
+ <?php // Warning: one space.
+
+// Testing empty line within a comment.
+/*
+
+*/
+
+// Testing that incorrectly aligned docblocks and multi-line inline comments do not trigger errors.
+// The incorrectly star alignment is not the concern of this sniff.
+	/**
+	* Provision some options
+	*/
+
+	/*
+	* Provision some options
+	*/
+
+?>
+
+<script type="text/javascript">
+	/*
+	 * Multi-line javascript comment should not trigger this sniff.
+	 */
+	alert('OK');
+	 alert('bad'); <!-- Warning. -->
+</script>
+
+<?php
+
+// phpcs:set Universal.WhiteSpace.PrecisionAlignment indent

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.8.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.8.inc.fixed
@@ -1,0 +1,86 @@
+phpcs:set Universal.WhiteSpace.PrecisionAlignment indent 2
+
+<?php
+/*
+ * File with mostly tab based indentation.
+ * Using an explicit custom indent value of 2 with tab-width 2.
+ */
+	function exampleFunctionA() {} // OK: [tab].
+
+/*
+ * OK: [tab][space][space][space][space]. This sniff is not concerned with tabs vs spaces.
+ */
+	    function exampleFunctionB() {}
+
+/*
+ * OK: [tab][space][space][tab][space][tab]. Comes down to four tabs. This sniff is not concerned with tabs vs spaces.
+ */
+	  	 	function exampleFunctionC() {}
+
+	/**
+	 * OK: Doc comment is indented with tabs and one space for the star alignment.
+	 *
+	  * @var string  <= NO Warning as this is still a multiple of 2.
+	 * @access private
+	 */
+
+	/*
+		OK: Multi-line comment is indented with 2 tabs for the text alignment.
+    <= Warning, no star, but also not indented by multiples of 2 spaces.
+	    OK: Another line of text [tab][space][space][space][space].
+	 */
+
+	/*
+	 * OK: Multi-line comment is indented with tabs and one space for the star alignment.
+	 *
+	   * <= NO Warning as this is still a multiple of 2 (plus 1 space for the star).
+	 */
+
+    function exampleFunctionD() {} // Warning: [tab][space].
+      function exampleFunctionE() {} // Warning: [tab][tab][space].
+        function exampleFunctionF() {} // Warning: [tab][tab][tab][space].
+
+	$object->functioncall()
+		-> chained()
+		-> anothermethod();
+
+	$object->functioncall()
+        -> chained()        // Warning: [tab][tab][space][space][space].
+        -> anothermethod(); // Warning: [tab][tab][space][space][space].
+
+    ?> <!-- Warning: three spaces. -->
+
+	<p>
+    Warning: Some inline HTML with precision alignment.
+	</p>
+
+  <?php // Warning: one space.
+
+// Testing empty line within a comment.
+/*
+
+*/
+
+// Testing that incorrectly aligned docblocks and multi-line inline comments do not trigger errors.
+// The incorrectly star alignment is not the concern of this sniff.
+	/**
+	* Provision some options
+	*/
+
+	/*
+	* Provision some options
+	*/
+
+?>
+
+<script type="text/javascript">
+	/*
+	 * Multi-line javascript comment should not trigger this sniff.
+	 */
+	alert('OK');
+    alert('bad'); <!-- Warning. -->
+</script>
+
+<?php
+
+// phpcs:set Universal.WhiteSpace.PrecisionAlignment indent

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.9.inc
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.9.inc
@@ -1,0 +1,6 @@
+<!-- Test file only using short open echo tags, space-based. -->
+  <div><!-- Bad.-->
+      <p><a href="http://url/"><!-- Bad.-->
+          <?= 'print this string' ?><!-- Bad.-->
+      </a/></p><!-- Bad.-->
+  </div><!-- Bad.-->

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.9.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.9.inc.fixed
@@ -1,0 +1,6 @@
+<!-- Test file only using short open echo tags, space-based. -->
+    <div><!-- Bad.-->
+        <p><a href="http://url/"><!-- Bad.-->
+            <?= 'print this string' ?><!-- Bad.-->
+        </a/></p><!-- Bad.-->
+    </div><!-- Bad.-->

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.php
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\WhiteSpace;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHPCSUtils\BackCompat\Helper;
+
+/**
+ * Unit test class for the PrecisionAlignment sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\WhiteSpace\PrecisionAlignmentSniff
+ *
+ * @since 1.0.0
+ */
+final class PrecisionAlignmentUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Tab-indented test files.
+     *
+     * @var array<string, int> File name => tab width to set.
+     */
+    private $tabBasedFiles = [
+        'PrecisionAlignmentUnitTest.5.inc'  => 4,
+        'PrecisionAlignmentUnitTest.6.inc'  => 4,
+        'PrecisionAlignmentUnitTest.7.inc'  => 3,
+        'PrecisionAlignmentUnitTest.8.inc'  => 2,
+        'PrecisionAlignmentUnitTest.10.inc' => 4,
+        'PrecisionAlignmentUnitTest.15.inc' => 4,
+        'PrecisionAlignmentUnitTest.17.inc' => 4,
+        'PrecisionAlignmentUnitTest.2.css'  => 4,
+        'PrecisionAlignmentUnitTest.2.js'   => 4,
+    ];
+
+    /**
+     * Set CLI values before the file is tested.
+     *
+     * @param string                  $testFile The name of the file being tested.
+     * @param \PHP_CodeSniffer\Config $config   The config data for the test run.
+     *
+     * @return void
+     */
+    public function setCliValues($testFile, $config)
+    {
+        if (isset($this->tabBasedFiles[$testFile]) === true) {
+            $config->tabWidth = $this->tabBasedFiles[$testFile];
+        } else {
+            $config->tabWidth = 0;
+        }
+
+        // Testing a file with "--ignore-annotations".
+        if ($testFile === 'PrecisionAlignmentUnitTest.18.inc') {
+            $config->annotations = false;
+        } else {
+            $config->annotations = true;
+        }
+    }
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @param string $testFile The name of the file being tested.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList($testFile = '')
+    {
+        $phpcsVersion = Helper::getVersion();
+        $isPhpcs4     = \version_compare($phpcsVersion, '3.99.99', '>');
+
+        switch ($testFile) {
+            case 'PrecisionAlignmentUnitTest.1.inc': // Space-based, default indent.
+            case 'PrecisionAlignmentUnitTest.2.inc': // Space-based, custom indent 4.
+            case 'PrecisionAlignmentUnitTest.3.inc': // Space-based, custom indent 3.
+            case 'PrecisionAlignmentUnitTest.5.inc': // Tab-based, default indent, tab-width 4.
+            case 'PrecisionAlignmentUnitTest.6.inc': // Tab-based, custom indent 4, tab-width 4.
+            case 'PrecisionAlignmentUnitTest.7.inc': // Tab-based, custom indent 3, tab-width 3.
+                return [
+                    23 => 1,
+                    29 => 1,
+                    36 => 1,
+                    39 => 1,
+                    40 => 1,
+                    41 => 1,
+                    48 => 1,
+                    49 => 1,
+                    51 => 1,
+                    54 => 1,
+                    57 => 1,
+                    81 => 1,
+                ];
+
+            case 'PrecisionAlignmentUnitTest.4.inc': // Space-based, custom indent 2.
+            case 'PrecisionAlignmentUnitTest.8.inc': // Tab-based, custom indent 2, tab-width 2.
+                return [
+                    29 => 1,
+                    39 => 1,
+                    40 => 1,
+                    41 => 1,
+                    48 => 1,
+                    49 => 1,
+                    51 => 1,
+                    54 => 1,
+                    57 => 1,
+                    81 => 1,
+                ];
+
+            // Verify handling of files only containing short open echo tags.
+            case 'PrecisionAlignmentUnitTest.9.inc': // Space-based.
+            case 'PrecisionAlignmentUnitTest.10.inc': // Tab-based.
+                return [
+                    2 => 1,
+                    3 => 1,
+                    4 => 1,
+                    5 => 1,
+                    6 => 1,
+                ];
+
+            // Verify handling of hereodc/nowdocs closing identifiers.
+            case 'PrecisionAlignmentUnitTest.11.inc':
+                if (\PHP_VERSION_ID >= 70300) {
+                    return [
+                        54 => 1,
+                        60 => 1,
+                    ];
+                }
+
+                // PHP 7.2 or lower: PHP version which doesn't support flexible heredocs/nowdocs yet.
+                return [];
+
+            case 'PrecisionAlignmentUnitTest.12.inc':
+                // Testing that precision alignment on blank lines is ignored.
+                return [];
+
+            case 'PrecisionAlignmentUnitTest.13.inc':
+                // Testing that precision alignment on blank lines is NOT ignored.
+                return [
+                    19 => 1,
+                    26 => 1,
+                    35 => 1,
+                    44 => 1,
+                    57 => 1,
+                    64 => 1,
+                    73 => 1,
+                    82 => 1,
+                ];
+
+            // Testing ignoring the indentation before certain tokens.
+            case 'PrecisionAlignmentUnitTest.14.inc': // Space-based.
+            case 'PrecisionAlignmentUnitTest.15.inc': // Tab-based.
+                return [
+                    23 => 1,
+                    29 => 1,
+                    36 => 1,
+                    51 => 1,
+                    54 => 1,
+                    81 => 1,
+                ];
+
+            // Testing ignoring the indentation before certain tokens.
+            case 'PrecisionAlignmentUnitTest.16.inc': // Space-based.
+            case 'PrecisionAlignmentUnitTest.17.inc': // Tab-based.
+                return [
+                    39 => 1,
+                    40 => 1,
+                    41 => 1,
+                    48 => 1,
+                    49 => 1,
+                    51 => 1,
+                ];
+
+            // Verify detection of precision alignment for ignore annotation lines.
+            case 'PrecisionAlignmentUnitTest.18.inc':
+                return [
+                    4 => 1,
+                ];
+
+            case 'PrecisionAlignmentUnitTest.1.css': // Space-based.
+            case 'PrecisionAlignmentUnitTest.2.css': // Tab-based.
+                return [
+                    5 => ($isPhpcs4 === true ? 0 : 1),
+                ];
+
+            case 'PrecisionAlignmentUnitTest.1.js': // Space-based.
+            case 'PrecisionAlignmentUnitTest.2.js': // Tab-based.
+                return [
+                    5 => ($isPhpcs4 === true ? 0 : 1),
+                    6 => ($isPhpcs4 === true ? 0 : 1),
+                    7 => ($isPhpcs4 === true ? 0 : 1),
+                ];
+
+            default:
+                return [];
+        }
+    }
+}


### PR DESCRIPTION
New sniff to enforce indentation to always be a multiple of a tabstop, i.e. disallow precision alignment.

For space-based standards, the `Generic.WhiteSpace.DisallowTabIndent` sniff (unintentionally/incorrectly) already removes precision alignment.
For tab-based standards, the `Generic.WhiteSpace.DisallowSpaceIndent` sniff, however, does not remove precision alignment.
With that in mind, this sniff is mostly intended for standards which demand tabs for indentation.

In rare cases, spaces for precision alignment can be intentional and acceptable, but more often than not, precision alignment is a typo.

Notes:
* This sniff does not concern itself with tabs versus spaces.
    Use the PHPCS native `Generic.WhiteSpace.DisallowTabIndent` or the `Generic.WhiteSpace.DisallowSpaceIndent` sniffs for that.
* When using this sniff with tab-based standards, please ensure that the `tab-width` is set and either don't set the `$indent` property or set it to the tab-width (or a multiple thereof).
* Precision alignment *within* text strings (multi-line text strings, heredocs, nowdocs) will NOT be flagged by this sniff.
* Precision alignment in (trailing) whitespace on otherwise blank lines will not be flagged by default.
    Most standards will automatically remove trailing whitespace anyway using the `Squiz.WhiteSpace.SuperfluousWhitespace` sniff.
    If the Squiz sniff is not used, set the `ignoreBlankLines` property to `false` to enable reporting for this.
* The sniff also supports an option to ignore precision alignment in specific situations, like for multi-line chained method calls.

**Note**: the fixer works based on "best guess" and may not always result in the desired indentation. Combine this sniff with the `Generic.WhiteSpace.ScopeIndent` sniff for more precise indentation fixes.
If so desired, the fixer can be turned off by including the rule in a standard like so: `<rule phpcs-only="true" ref="Universal.WhiteSpace.PrecisionAlignment"/>`

As it is, the sniff supports both PHP, as well as JS and CSS, though the support for JS and CSS should be considered incidental and will be removed once PHPCS 4.0 will be released.

Includes fixer.
Includes unit tests.
Includes documentation.

_This sniffs is loosely based on a sniff I previously wrote for the same purpose for the WPCS standard._