### PR TITLE
QA: make all classes `final`

### DIFF
--- a/NormalizedArrays/Sniffs/Arrays/ArrayBraceSpacingSniff.php
+++ b/NormalizedArrays/Sniffs/Arrays/ArrayBraceSpacingSniff.php
@@ -31,7 +31,7 @@ use PHPCSUtils\Utils\Arrays;
  *
  * @since 1.0.0
  */
-class ArrayBraceSpacingSniff implements Sniff
+final class ArrayBraceSpacingSniff implements Sniff
 {
 
     /**

--- a/NormalizedArrays/Sniffs/Arrays/CommaAfterLastSniff.php
+++ b/NormalizedArrays/Sniffs/Arrays/CommaAfterLastSniff.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\Arrays;
  *
  * @since 1.0.0
  */
-class CommaAfterLastSniff implements Sniff
+final class CommaAfterLastSniff implements Sniff
 {
 
     /**

--- a/NormalizedArrays/Tests/Arrays/ArrayBraceSpacingUnitTest.php
+++ b/NormalizedArrays/Tests/Arrays/ArrayBraceSpacingUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class ArrayBraceSpacingUnitTest extends AbstractSniffUnitTest
+final class ArrayBraceSpacingUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/NormalizedArrays/Tests/Arrays/CommaAfterLastUnitTest.php
+++ b/NormalizedArrays/Tests/Arrays/CommaAfterLastUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class CommaAfterLastUnitTest extends AbstractSniffUnitTest
+final class CommaAfterLastUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Helpers/DummyTokenizer.php
+++ b/Universal/Helpers/DummyTokenizer.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tokenizers\Tokenizer;
  *
  * @since 1.0.0
  */
-class DummyTokenizer extends Tokenizer
+final class DummyTokenizer extends Tokenizer
 {
 
     /**

--- a/Universal/Sniffs/Arrays/DisallowShortArraySyntaxSniff.php
+++ b/Universal/Sniffs/Arrays/DisallowShortArraySyntaxSniff.php
@@ -26,7 +26,7 @@ use PHPCSUtils\Utils\Arrays;
  * @since 1.0.0 This sniff is loosely based on and inspired by the upstream
  *              `Generic.Arrays.DisallowShortArraySyntax` sniff.
  */
-class DisallowShortArraySyntaxSniff implements Sniff
+final class DisallowShortArraySyntaxSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/Arrays/DuplicateArrayKeySniff.php
+++ b/Universal/Sniffs/Arrays/DuplicateArrayKeySniff.php
@@ -22,7 +22,7 @@ use PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff;
  *
  * @since 1.0.0
  */
-class DuplicateArrayKeySniff extends AbstractArrayDeclarationSniff
+final class DuplicateArrayKeySniff extends AbstractArrayDeclarationSniff
 {
 
     /**

--- a/Universal/Sniffs/Arrays/MixedArrayKeyTypesSniff.php
+++ b/Universal/Sniffs/Arrays/MixedArrayKeyTypesSniff.php
@@ -19,7 +19,7 @@ use PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff;
  *
  * @since 1.0.0
  */
-class MixedArrayKeyTypesSniff extends AbstractArrayDeclarationSniff
+final class MixedArrayKeyTypesSniff extends AbstractArrayDeclarationSniff
 {
 
     /**

--- a/Universal/Sniffs/Arrays/MixedKeyedUnkeyedArraySniff.php
+++ b/Universal/Sniffs/Arrays/MixedKeyedUnkeyedArraySniff.php
@@ -19,7 +19,7 @@ use PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff;
  *
  * @since 1.0.0
  */
-class MixedKeyedUnkeyedArraySniff extends AbstractArrayDeclarationSniff
+final class MixedKeyedUnkeyedArraySniff extends AbstractArrayDeclarationSniff
 {
 
     /**

--- a/Universal/Sniffs/Classes/DisallowAnonClassParenthesesSniff.php
+++ b/Universal/Sniffs/Classes/DisallowAnonClassParenthesesSniff.php
@@ -20,7 +20,7 @@ use PHP_CodeSniffer\Util\Tokens;
  *
  * @since 1.0.0
  */
-class DisallowAnonClassParenthesesSniff implements Sniff
+final class DisallowAnonClassParenthesesSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/Classes/DisallowFinalClassSniff.php
+++ b/Universal/Sniffs/Classes/DisallowFinalClassSniff.php
@@ -20,7 +20,7 @@ use PHPCSUtils\Utils\GetTokensAsString;
  *
  * @since 1.0.0
  */
-class DisallowFinalClassSniff implements Sniff
+final class DisallowFinalClassSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/Classes/RequireAnonClassParenthesesSniff.php
+++ b/Universal/Sniffs/Classes/RequireAnonClassParenthesesSniff.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Util\Tokens;
  *
  * @since 1.0.0
  */
-class RequireAnonClassParenthesesSniff implements Sniff
+final class RequireAnonClassParenthesesSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/Classes/RequireFinalClassSniff.php
+++ b/Universal/Sniffs/Classes/RequireFinalClassSniff.php
@@ -20,7 +20,7 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  *
  * @since 1.0.0
  */
-class RequireFinalClassSniff implements Sniff
+final class RequireFinalClassSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/CodeAnalysis/ForeachUniqueAssignmentSniff.php
+++ b/Universal/Sniffs/CodeAnalysis/ForeachUniqueAssignmentSniff.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\GetTokensAsString;
  *
  * @since 1.0.0
  */
-class ForeachUniqueAssignmentSniff implements Sniff
+final class ForeachUniqueAssignmentSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/Constants/LowercaseClassResolutionKeywordSniff.php
+++ b/Universal/Sniffs/Constants/LowercaseClassResolutionKeywordSniff.php
@@ -22,7 +22,7 @@ use PHP_CodeSniffer\Util\Tokens;
  *
  * @since 1.0.0
  */
-class LowercaseClassResolutionKeywordSniff implements Sniff
+final class LowercaseClassResolutionKeywordSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/Constants/UppercaseMagicConstantsSniff.php
+++ b/Universal/Sniffs/Constants/UppercaseMagicConstantsSniff.php
@@ -21,7 +21,7 @@ use PHPCSUtils\Tokens\Collections;
  *
  * @since 1.0.0
  */
-class UppercaseMagicConstantsSniff implements Sniff
+final class UppercaseMagicConstantsSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/ControlStructures/DisallowAlternativeSyntaxSniff.php
+++ b/Universal/Sniffs/ControlStructures/DisallowAlternativeSyntaxSniff.php
@@ -21,7 +21,7 @@ use PHPCSUtils\Utils\ControlStructures;
  *
  * @since 1.0.0
  */
-class DisallowAlternativeSyntaxSniff implements Sniff
+final class DisallowAlternativeSyntaxSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/ControlStructures/DisallowLonelyIfSniff.php
+++ b/Universal/Sniffs/ControlStructures/DisallowLonelyIfSniff.php
@@ -27,7 +27,7 @@ use PHPCSUtils\Utils\GetTokensAsString;
  *
  * @since 1.0.0
  */
-class DisallowLonelyIfSniff implements Sniff
+final class DisallowLonelyIfSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/ControlStructures/IfElseDeclarationSniff.php
+++ b/Universal/Sniffs/ControlStructures/IfElseDeclarationSniff.php
@@ -28,7 +28,7 @@ use PHP_CodeSniffer\Util\Tokens;
  *
  * @since 1.0.0
  */
-class IfElseDeclarationSniff implements Sniff
+final class IfElseDeclarationSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/Lists/DisallowLongListSyntaxSniff.php
+++ b/Universal/Sniffs/Lists/DisallowLongListSyntaxSniff.php
@@ -19,7 +19,7 @@ use PHPCSUtils\Utils\Lists;
  *
  * @since 1.0.0
  */
-class DisallowLongListSyntaxSniff implements Sniff
+final class DisallowLongListSyntaxSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/Lists/DisallowShortListSyntaxSniff.php
+++ b/Universal/Sniffs/Lists/DisallowShortListSyntaxSniff.php
@@ -19,7 +19,7 @@ use PHPCSUtils\Utils\Lists;
  *
  * @since 1.0.0
  */
-class DisallowShortListSyntaxSniff implements Sniff
+final class DisallowShortListSyntaxSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/Namespaces/DisallowCurlyBraceSyntaxSniff.php
+++ b/Universal/Sniffs/Namespaces/DisallowCurlyBraceSyntaxSniff.php
@@ -19,7 +19,7 @@ use PHPCSUtils\Utils\Namespaces;
  *
  * @since 1.0.0
  */
-class DisallowCurlyBraceSyntaxSniff implements Sniff
+final class DisallowCurlyBraceSyntaxSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/Namespaces/DisallowDeclarationWithoutNameSniff.php
+++ b/Universal/Sniffs/Namespaces/DisallowDeclarationWithoutNameSniff.php
@@ -19,7 +19,7 @@ use PHPCSUtils\Utils\Namespaces;
  *
  * @since 1.0.0
  */
-class DisallowDeclarationWithoutNameSniff implements Sniff
+final class DisallowDeclarationWithoutNameSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/Namespaces/EnforceCurlyBraceSyntaxSniff.php
+++ b/Universal/Sniffs/Namespaces/EnforceCurlyBraceSyntaxSniff.php
@@ -19,7 +19,7 @@ use PHPCSUtils\Utils\Namespaces;
  *
  * @since 1.0.0
  */
-class EnforceCurlyBraceSyntaxSniff implements Sniff
+final class EnforceCurlyBraceSyntaxSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/Namespaces/OneDeclarationPerFileSniff.php
+++ b/Universal/Sniffs/Namespaces/OneDeclarationPerFileSniff.php
@@ -19,7 +19,7 @@ use PHPCSUtils\Utils\Namespaces;
  *
  * @since 1.0.0
  */
-class OneDeclarationPerFileSniff implements Sniff
+final class OneDeclarationPerFileSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/NamingConventions/NoReservedKeywordParameterNamesSniff.php
+++ b/Universal/Sniffs/NamingConventions/NoReservedKeywordParameterNamesSniff.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  *
  * @since 1.0.0
  */
-class NoReservedKeywordParameterNamesSniff implements Sniff
+final class NoReservedKeywordParameterNamesSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/OOStructures/AlphabeticExtendsImplementsSniff.php
+++ b/Universal/Sniffs/OOStructures/AlphabeticExtendsImplementsSniff.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  *
  * @since 1.0.0
  */
-class AlphabeticExtendsImplementsSniff implements Sniff
+final class AlphabeticExtendsImplementsSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/Operators/DisallowLogicalAndOrSniff.php
+++ b/Universal/Sniffs/Operators/DisallowLogicalAndOrSniff.php
@@ -22,7 +22,7 @@ use PHP_CodeSniffer\Files\File;
  *
  * @since 1.0.0
  */
-class DisallowLogicalAndOrSniff implements Sniff
+final class DisallowLogicalAndOrSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/Operators/DisallowShortTernarySniff.php
+++ b/Universal/Sniffs/Operators/DisallowShortTernarySniff.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\Operators;
  *
  * @since 1.0.0
  */
-class DisallowShortTernarySniff implements Sniff
+final class DisallowShortTernarySniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/Operators/DisallowStandalonePostIncrementDecrementSniff.php
+++ b/Universal/Sniffs/Operators/DisallowStandalonePostIncrementDecrementSniff.php
@@ -28,7 +28,7 @@ use PHPCSUtils\Utils\GetTokensAsString;
  *
  * @since 1.0.0
  */
-class DisallowStandalonePostIncrementDecrementSniff implements Sniff
+final class DisallowStandalonePostIncrementDecrementSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/Operators/StrictComparisonsSniff.php
+++ b/Universal/Sniffs/Operators/StrictComparisonsSniff.php
@@ -21,7 +21,7 @@ use PHP_CodeSniffer\Files\File;
  *
  * @since 1.0.0
  */
-class StrictComparisonsSniff implements Sniff
+final class StrictComparisonsSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/PHP/OneStatementInShortEchoTagSniff.php
+++ b/Universal/Sniffs/PHP/OneStatementInShortEchoTagSniff.php
@@ -24,7 +24,7 @@ use PHP_CodeSniffer\Util\Tokens;
  *
  * @since 1.0.0
  */
-class OneStatementInShortEchoTagSniff implements Sniff
+final class OneStatementInShortEchoTagSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/UseStatements/DisallowUseClassSniff.php
+++ b/Universal/Sniffs/UseStatements/DisallowUseClassSniff.php
@@ -26,7 +26,7 @@ use PHPCSUtils\Utils\UseStatements;
  *
  * @since 1.0.0
  */
-class DisallowUseClassSniff implements Sniff
+final class DisallowUseClassSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/UseStatements/DisallowUseConstSniff.php
+++ b/Universal/Sniffs/UseStatements/DisallowUseConstSniff.php
@@ -26,7 +26,7 @@ use PHPCSUtils\Utils\UseStatements;
  *
  * @since 1.0.0
  */
-class DisallowUseConstSniff implements Sniff
+final class DisallowUseConstSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/UseStatements/DisallowUseFunctionSniff.php
+++ b/Universal/Sniffs/UseStatements/DisallowUseFunctionSniff.php
@@ -26,7 +26,7 @@ use PHPCSUtils\Utils\UseStatements;
  *
  * @since 1.0.0
  */
-class DisallowUseFunctionSniff implements Sniff
+final class DisallowUseFunctionSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/UseStatements/LowercaseFunctionConstSniff.php
+++ b/Universal/Sniffs/UseStatements/LowercaseFunctionConstSniff.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\UseStatements;
  *
  * @since 1.0.0
  */
-class LowercaseFunctionConstSniff implements Sniff
+final class LowercaseFunctionConstSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/UseStatements/NoLeadingBackslashSniff.php
+++ b/Universal/Sniffs/UseStatements/NoLeadingBackslashSniff.php
@@ -24,7 +24,7 @@ use PHPCSUtils\Utils\UseStatements;
  *
  * @since 1.0.0
  */
-class NoLeadingBackslashSniff implements Sniff
+final class NoLeadingBackslashSniff implements Sniff
 {
 
     /**

--- a/Universal/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
+++ b/Universal/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
@@ -38,7 +38,7 @@ use PHPCSUtils\BackCompat\Helper;
  *
  * @since 1.0.0
  */
-class DisallowInlineTabsSniff implements Sniff
+final class DisallowInlineTabsSniff implements Sniff
 {
 
     /**

--- a/Universal/Tests/Arrays/DisallowShortArraySyntaxUnitTest.php
+++ b/Universal/Tests/Arrays/DisallowShortArraySyntaxUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class DisallowShortArraySyntaxUnitTest extends AbstractSniffUnitTest
+final class DisallowShortArraySyntaxUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/Arrays/DuplicateArrayKeyUnitTest.php
+++ b/Universal/Tests/Arrays/DuplicateArrayKeyUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class DuplicateArrayKeyUnitTest extends AbstractSniffUnitTest
+final class DuplicateArrayKeyUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/Arrays/MixedArrayKeyTypesUnitTest.php
+++ b/Universal/Tests/Arrays/MixedArrayKeyTypesUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class MixedArrayKeyTypesUnitTest extends AbstractSniffUnitTest
+final class MixedArrayKeyTypesUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/Arrays/MixedKeyedUnkeyedArrayUnitTest.php
+++ b/Universal/Tests/Arrays/MixedKeyedUnkeyedArrayUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class MixedKeyedUnkeyedArrayUnitTest extends AbstractSniffUnitTest
+final class MixedKeyedUnkeyedArrayUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/Classes/DisallowAnonClassParenthesesUnitTest.php
+++ b/Universal/Tests/Classes/DisallowAnonClassParenthesesUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class DisallowAnonClassParenthesesUnitTest extends AbstractSniffUnitTest
+final class DisallowAnonClassParenthesesUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/Classes/DisallowFinalClassUnitTest.php
+++ b/Universal/Tests/Classes/DisallowFinalClassUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class DisallowFinalClassUnitTest extends AbstractSniffUnitTest
+final class DisallowFinalClassUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/Classes/RequireAnonClassParenthesesUnitTest.php
+++ b/Universal/Tests/Classes/RequireAnonClassParenthesesUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class RequireAnonClassParenthesesUnitTest extends AbstractSniffUnitTest
+final class RequireAnonClassParenthesesUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/Classes/RequireFinalClassUnitTest.php
+++ b/Universal/Tests/Classes/RequireFinalClassUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class RequireFinalClassUnitTest extends AbstractSniffUnitTest
+final class RequireFinalClassUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/CodeAnalysis/ForeachUniqueAssignmentUnitTest.php
+++ b/Universal/Tests/CodeAnalysis/ForeachUniqueAssignmentUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class ForeachUniqueAssignmentUnitTest extends AbstractSniffUnitTest
+final class ForeachUniqueAssignmentUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/Constants/LowercaseClassResolutionKeywordUnitTest.php
+++ b/Universal/Tests/Constants/LowercaseClassResolutionKeywordUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class LowercaseClassResolutionKeywordUnitTest extends AbstractSniffUnitTest
+final class LowercaseClassResolutionKeywordUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/Constants/UppercaseMagicConstantsUnitTest.php
+++ b/Universal/Tests/Constants/UppercaseMagicConstantsUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class UppercaseMagicConstantsUnitTest extends AbstractSniffUnitTest
+final class UppercaseMagicConstantsUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.php
+++ b/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class DisallowAlternativeSyntaxUnitTest extends AbstractSniffUnitTest
+final class DisallowAlternativeSyntaxUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/ControlStructures/DisallowLonelyIfUnitTest.php
+++ b/Universal/Tests/ControlStructures/DisallowLonelyIfUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class DisallowLonelyIfUnitTest extends AbstractSniffUnitTest
+final class DisallowLonelyIfUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/ControlStructures/IfElseDeclarationUnitTest.php
+++ b/Universal/Tests/ControlStructures/IfElseDeclarationUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class IfElseDeclarationUnitTest extends AbstractSniffUnitTest
+final class IfElseDeclarationUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/Lists/DisallowLongListSyntaxUnitTest.php
+++ b/Universal/Tests/Lists/DisallowLongListSyntaxUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class DisallowLongListSyntaxUnitTest extends AbstractSniffUnitTest
+final class DisallowLongListSyntaxUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.php
+++ b/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class DisallowShortListSyntaxUnitTest extends AbstractSniffUnitTest
+final class DisallowShortListSyntaxUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/Namespaces/DisallowCurlyBraceSyntaxUnitTest.php
+++ b/Universal/Tests/Namespaces/DisallowCurlyBraceSyntaxUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class DisallowCurlyBraceSyntaxUnitTest extends AbstractSniffUnitTest
+final class DisallowCurlyBraceSyntaxUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/Namespaces/DisallowDeclarationWithoutNameUnitTest.php
+++ b/Universal/Tests/Namespaces/DisallowDeclarationWithoutNameUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class DisallowDeclarationWithoutNameUnitTest extends AbstractSniffUnitTest
+final class DisallowDeclarationWithoutNameUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/Namespaces/EnforceCurlyBraceSyntaxUnitTest.php
+++ b/Universal/Tests/Namespaces/EnforceCurlyBraceSyntaxUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class EnforceCurlyBraceSyntaxUnitTest extends AbstractSniffUnitTest
+final class EnforceCurlyBraceSyntaxUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/Namespaces/OneDeclarationPerFileUnitTest.php
+++ b/Universal/Tests/Namespaces/OneDeclarationPerFileUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class OneDeclarationPerFileUnitTest extends AbstractSniffUnitTest
+final class OneDeclarationPerFileUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.php
+++ b/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class NoReservedKeywordParameterNamesUnitTest extends AbstractSniffUnitTest
+final class NoReservedKeywordParameterNamesUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/OOStructures/AlphabeticExtendsImplementsUnitTest.php
+++ b/Universal/Tests/OOStructures/AlphabeticExtendsImplementsUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class AlphabeticExtendsImplementsUnitTest extends AbstractSniffUnitTest
+final class AlphabeticExtendsImplementsUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/Operators/DisallowLogicalAndOrUnitTest.php
+++ b/Universal/Tests/Operators/DisallowLogicalAndOrUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class DisallowLogicalAndOrUnitTest extends AbstractSniffUnitTest
+final class DisallowLogicalAndOrUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/Operators/DisallowShortTernaryUnitTest.php
+++ b/Universal/Tests/Operators/DisallowShortTernaryUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class DisallowShortTernaryUnitTest extends AbstractSniffUnitTest
+final class DisallowShortTernaryUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/Operators/DisallowStandalonePostIncrementDecrementUnitTest.php
+++ b/Universal/Tests/Operators/DisallowStandalonePostIncrementDecrementUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class DisallowStandalonePostIncrementDecrementUnitTest extends AbstractSniffUnitTest
+final class DisallowStandalonePostIncrementDecrementUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/Operators/StrictComparisonsUnitTest.php
+++ b/Universal/Tests/Operators/StrictComparisonsUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class StrictComparisonsUnitTest extends AbstractSniffUnitTest
+final class StrictComparisonsUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/PHP/OneStatementInShortEchoTagUnitTest.php
+++ b/Universal/Tests/PHP/OneStatementInShortEchoTagUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class OneStatementInShortEchoTagUnitTest extends AbstractSniffUnitTest
+final class OneStatementInShortEchoTagUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/UseStatements/DisallowUseClassUnitTest.php
+++ b/Universal/Tests/UseStatements/DisallowUseClassUnitTest.php
@@ -22,7 +22,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class DisallowUseClassUnitTest extends AbstractSniffUnitTest
+final class DisallowUseClassUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/UseStatements/DisallowUseConstUnitTest.php
+++ b/Universal/Tests/UseStatements/DisallowUseConstUnitTest.php
@@ -22,7 +22,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class DisallowUseConstUnitTest extends AbstractSniffUnitTest
+final class DisallowUseConstUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/UseStatements/DisallowUseFunctionUnitTest.php
+++ b/Universal/Tests/UseStatements/DisallowUseFunctionUnitTest.php
@@ -22,7 +22,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class DisallowUseFunctionUnitTest extends AbstractSniffUnitTest
+final class DisallowUseFunctionUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/UseStatements/LowercaseFunctionConstUnitTest.php
+++ b/Universal/Tests/UseStatements/LowercaseFunctionConstUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class LowercaseFunctionConstUnitTest extends AbstractSniffUnitTest
+final class LowercaseFunctionConstUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.php
+++ b/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class NoLeadingBackslashUnitTest extends AbstractSniffUnitTest
+final class NoLeadingBackslashUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
+++ b/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-class DisallowInlineTabsUnitTest extends AbstractSniffUnitTest
+final class DisallowInlineTabsUnitTest extends AbstractSniffUnitTest
 {
 
     /**


### PR DESCRIPTION
Sniffs extending other sniffs which are not explicitly `abstract` is not a good idea and can lead to problems with the sniff autoloading.

By making all sniffs in the package `final`, that problem should be prevented.