### PR TITLE
Universal/PrecisionAlignment: best guess tabs vs spaces when fixing

### DIFF
--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.inc
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.inc
@@ -20,7 +20,7 @@
     /**
      * OK: Doc comment is indented with 4 spaces + one space for the star alignment.
      *
-      * @var string  <= Warning.
+      * @var string	<= Warning.
      * @access private
      */
 

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.inc.fixed
@@ -20,7 +20,7 @@
     /**
      * OK: Doc comment is indented with 4 spaces + one space for the star alignment.
      *
-     * @var string  <= Warning.
+     * @var string	<= Warning.
      * @access private
      */
 

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.10.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.10.inc.fixed
@@ -1,6 +1,6 @@
 <!-- Test file only using short open echo tags, tab-based. -->
     <div><!-- Bad.-->
-        <p><a href="http://url/"><!-- Bad.-->
-            <?= 'print this string' ?><!-- Bad.-->
-        </a/></p><!-- Bad.-->
+		<p><a href="http://url/"><!-- Bad.-->
+			<?= 'print this string' ?><!-- Bad.-->
+		</a/></p><!-- Bad.-->
     </div><!-- Bad.-->

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.15.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.15.inc.fixed
@@ -20,20 +20,20 @@ phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreAlignmentBefore[] T_FUNC
 	/**
 	 * OK: Doc comment is indented with tabs and one space for the star alignment.
 	 *
-     * @var string  <= Warning.
+	 * @var string  <= Warning.
 	 * @access private
 	 */
 
 	/*
 		OK: Multi-line comment is indented with 2 tabs for the text alignment.
-    <= Warning, no star, but also not indented by multiples of 4 spaces.
+	<= Warning, no star, but also not indented by multiples of 4 spaces.
 	    OK: Another line of text [tab][space][space][space][space].
 	 */
 
 	/*
 	 * OK: Multi-line comment is indented with tabs and one space for the star alignment.
 	 *
-        * <= Warning.
+		* <= Warning.
 	 */
 
 	 function exampleFunctionD() {} // Ignored.
@@ -51,7 +51,7 @@ phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreAlignmentBefore[] T_FUNC
     ?> <!-- Warning: three spaces. -->
 
 	<p>
-        Warning: Some inline HTML with precision alignment.
+		Warning: Some inline HTML with precision alignment.
 	</p>
 
  <?php // Ignored.
@@ -78,7 +78,7 @@ phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreAlignmentBefore[] T_FUNC
 	 * Multi-line javascript comment should not trigger this sniff.
 	 */
 	alert('OK');
-        alert('bad'); <!-- Warning. -->
+		alert('bad'); <!-- Warning. -->
 </script>
 
 <?php

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.17.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.17.inc.fixed
@@ -36,17 +36,17 @@ phpcs:set Universal.WhiteSpace.PrecisionAlignment ignoreAlignmentBefore[] T_DOC_
 	   * <= Ignored.
 	 */
 
-    function exampleFunctionD() {} // Warning: [tab][space].
-        function exampleFunctionE() {} // Warning: [tab][space][space].
-        function exampleFunctionF() {} // Warning: [tab][space][space][space].
+	function exampleFunctionD() {} // Warning: [tab][space].
+		function exampleFunctionE() {} // Warning: [tab][space][space].
+		function exampleFunctionF() {} // Warning: [tab][space][space][space].
 
 	$object->functioncall()
 		-> chained()
 		-> anothermethod();
 
 	$object->functioncall()
-            -> chained()        // Warning: [tab][tab][space][space][space].
-            -> anothermethod(); // Warning: [tab][tab][space][space][space].
+			-> chained()        // Warning: [tab][tab][space][space][space].
+			-> anothermethod(); // Warning: [tab][tab][space][space][space].
 
     ?> <!-- Warning: three spaces. -->
 

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.css.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.css.fixed
@@ -2,5 +2,5 @@
 #login-container {
 	margin-left: -225px;
 	width: 450px;
-    height: 450px; /* Bad. */
+	height: 450px; /* Bad. */
 }

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.inc
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.inc
@@ -20,7 +20,7 @@ phpcs:set Universal.WhiteSpace.PrecisionAlignment indent 4
     /**
      * OK: Doc comment is indented with 4 spaces + one space for the star alignment.
      *
-      * @var string  <= Warning.
+      * @var string	<= Warning.
      * @access private
      */
 

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.inc.fixed
@@ -20,7 +20,7 @@ phpcs:set Universal.WhiteSpace.PrecisionAlignment indent 4
     /**
      * OK: Doc comment is indented with 4 spaces + one space for the star alignment.
      *
-     * @var string  <= Warning.
+     * @var string	<= Warning.
      * @access private
      */
 

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.js.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.js.fixed
@@ -2,7 +2,7 @@
 var x = {
 	abc: 1,
 	zyz: 2,
-    mno: {
-        abc: 4
-    },
+	mno: {
+		abc: 4
+	},
 }

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.3.inc
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.3.inc
@@ -20,7 +20,7 @@ phpcs:set Universal.WhiteSpace.PrecisionAlignment indent 3
    /**
     * OK: Doc comment is indented with 3 spaces + one space for the star alignment.
     *
-     * @var string  <= Warning.
+     * @var string	<= Warning.
     * @access private
     */
 

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.3.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.3.inc.fixed
@@ -20,7 +20,7 @@ phpcs:set Universal.WhiteSpace.PrecisionAlignment indent 3
    /**
     * OK: Doc comment is indented with 3 spaces + one space for the star alignment.
     *
-    * @var string  <= Warning.
+    * @var string	<= Warning.
     * @access private
     */
 

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.4.inc
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.4.inc
@@ -78,7 +78,7 @@ phpcs:set Universal.WhiteSpace.PrecisionAlignment indent 2
      * Multi-line javascript comment should not trigger this sniff.
      */
     alert('OK');
-     alert('bad'); <!-- Warning. -->
+     alert('bad');	<!-- Warning. -->
 </script>
 
 <?php

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.4.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.4.inc.fixed
@@ -78,7 +78,7 @@ phpcs:set Universal.WhiteSpace.PrecisionAlignment indent 2
      * Multi-line javascript comment should not trigger this sniff.
      */
     alert('OK');
-      alert('bad'); <!-- Warning. -->
+      alert('bad');	<!-- Warning. -->
 </script>
 
 <?php

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.5.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.5.inc.fixed
@@ -20,38 +20,38 @@
 	/**
 	 * OK: Doc comment is indented with tabs and one space for the star alignment.
 	 *
-     * @var string  <= Warning.
+	 * @var string  <= Warning.
 	 * @access private
 	 */
 
 	/*
 		OK: Multi-line comment is indented with 2 tabs for the text alignment.
-    <= Warning, no star, but also not indented by multiples of 4 spaces.
+	<= Warning, no star, but also not indented by multiples of 4 spaces.
 	    OK: Another line of text [tab][space][space][space][space].
 	 */
 
 	/*
 	 * OK: Multi-line comment is indented with tabs and one space for the star alignment.
 	 *
-        * <= Warning.
+		* <= Warning.
 	 */
 
-    function exampleFunctionD() {} // Warning: [tab][space].
-        function exampleFunctionE() {} // Warning: [tab][space][space].
-        function exampleFunctionF() {} // Warning: [tab][space][space][space].
+	function exampleFunctionD() {} // Warning: [tab][space].
+		function exampleFunctionE() {} // Warning: [tab][space][space].
+		function exampleFunctionF() {} // Warning: [tab][space][space][space].
 
 	$object->functioncall()
 		-> chained()
 		-> anothermethod();
 
 	$object->functioncall()
-            -> chained()        // Warning: [tab][tab][space][space][space].
-            -> anothermethod(); // Warning: [tab][tab][space][space][space].
+			-> chained()        // Warning: [tab][tab][space][space][space].
+			-> anothermethod(); // Warning: [tab][tab][space][space][space].
 
     ?> <!-- Warning: three spaces. -->
 
 	<p>
-        Warning: Some inline HTML with precision alignment.
+		Warning: Some inline HTML with precision alignment.
 	</p>
 
 <?php // Warning: one space.
@@ -78,7 +78,7 @@
 	 * Multi-line javascript comment should not trigger this sniff.
 	 */
 	alert('OK');
-        alert('bad'); <!-- Warning. -->
+		alert('bad'); <!-- Warning. -->
 </script>
 
 <?php

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.6.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.6.inc.fixed
@@ -20,38 +20,38 @@ phpcs:set Universal.WhiteSpace.PrecisionAlignment indent 4
 	/**
 	 * OK: Doc comment is indented with tabs and one space for the star alignment.
 	 *
-     * @var string  <= Warning.
+	 * @var string  <= Warning.
 	 * @access private
 	 */
 
 	/*
 		OK: Multi-line comment is indented with 2 tabs for the text alignment.
-    <= Warning, no star, but also not indented by multiples of 4 spaces.
+	<= Warning, no star, but also not indented by multiples of 4 spaces.
 	    OK: Another line of text [tab][space][space][space][space].
 	 */
 
 	/*
 	 * OK: Multi-line comment is indented with tabs and one space for the star alignment.
 	 *
-        * <= Warning.
+		* <= Warning.
 	 */
 
-    function exampleFunctionD() {} // Warning: [tab][space].
-        function exampleFunctionE() {} // Warning: [tab][space][space].
-        function exampleFunctionF() {} // Warning: [tab][space][space][space].
+	function exampleFunctionD() {} // Warning: [tab][space].
+		function exampleFunctionE() {} // Warning: [tab][space][space].
+		function exampleFunctionF() {} // Warning: [tab][space][space][space].
 
 	$object->functioncall()
 		-> chained()
 		-> anothermethod();
 
 	$object->functioncall()
-            -> chained()        // Warning: [tab][tab][space][space][space].
-            -> anothermethod(); // Warning: [tab][tab][space][space][space].
+			-> chained()        // Warning: [tab][tab][space][space][space].
+			-> anothermethod(); // Warning: [tab][tab][space][space][space].
 
     ?> <!-- Warning: three spaces. -->
 
 	<p>
-        Warning: Some inline HTML with precision alignment.
+		Warning: Some inline HTML with precision alignment.
 	</p>
 
 <?php // Warning: one space.
@@ -78,7 +78,7 @@ phpcs:set Universal.WhiteSpace.PrecisionAlignment indent 4
 	 * Multi-line javascript comment should not trigger this sniff.
 	 */
 	alert('OK');
-        alert('bad'); <!-- Warning. -->
+		alert('bad'); <!-- Warning. -->
 </script>
 
 <?php

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.7.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.7.inc.fixed
@@ -20,38 +20,38 @@ phpcs:set Universal.WhiteSpace.PrecisionAlignment indent 3
 	/**
 	 * OK: Doc comment is indented with tabs and one space for the star alignment.
 	 *
-    * @var string  <= Warning.
+	 * @var string  <= Warning.
 	 * @access private
 	 */
 
 	/*
 		OK: Multi-line comment is indented with 2 tabs for the text alignment.
-   <= Warning, no star, but also not indented by multiples of 3 spaces.
+	<= Warning, no star, but also not indented by multiples of 3 spaces.
 	   OK: Another line of text [tab][space][space][space].
 	 */
 
 	/*
 	 * OK: Multi-line comment is indented with tabs and one space for the star alignment.
 	 *
-    * <= Warning.
+	 * <= Warning.
 	 */
 
-   function exampleFunctionD() {} // Warning: [tab][space].
-      function exampleFunctionE() {} // Warning: [tab][space][space].
-      function exampleFunctionF() {} // Warning: [tab][tab][space].
+	function exampleFunctionD() {} // Warning: [tab][space].
+		function exampleFunctionE() {} // Warning: [tab][space][space].
+		function exampleFunctionF() {} // Warning: [tab][tab][space].
 
 	$object->functioncall()
 		-> chained()
 		-> anothermethod();
 
 	$object->functioncall()
-      -> chained()        // Warning: [tab][tab][space].
-         -> anothermethod(); // Warning: [tab][tab][space][space].
+		-> chained()        // Warning: [tab][tab][space].
+			-> anothermethod(); // Warning: [tab][tab][space][space].
 
    ?> <!-- Warning: two spaces. -->
 
 	<p>
-      Warning: Some inline HTML with precision alignment.
+		Warning: Some inline HTML with precision alignment.
 	</p>
 
 <?php // Warning: one space.
@@ -78,7 +78,7 @@ phpcs:set Universal.WhiteSpace.PrecisionAlignment indent 3
 	 * Multi-line javascript comment should not trigger this sniff.
 	 */
 	alert('OK');
-      alert('bad'); <!-- Warning. -->
+		alert('bad'); <!-- Warning. -->
 </script>
 
 <?php

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.8.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.8.inc.fixed
@@ -26,7 +26,7 @@ phpcs:set Universal.WhiteSpace.PrecisionAlignment indent 2
 
 	/*
 		OK: Multi-line comment is indented with 2 tabs for the text alignment.
-    <= Warning, no star, but also not indented by multiples of 2 spaces.
+		<= Warning, no star, but also not indented by multiples of 2 spaces.
 	    OK: Another line of text [tab][space][space][space][space].
 	 */
 
@@ -36,22 +36,22 @@ phpcs:set Universal.WhiteSpace.PrecisionAlignment indent 2
 	   * <= NO Warning as this is still a multiple of 2 (plus 1 space for the star).
 	 */
 
-    function exampleFunctionD() {} // Warning: [tab][space].
-      function exampleFunctionE() {} // Warning: [tab][tab][space].
-        function exampleFunctionF() {} // Warning: [tab][tab][tab][space].
+		function exampleFunctionD() {} // Warning: [tab][space].
+			function exampleFunctionE() {} // Warning: [tab][tab][space].
+				function exampleFunctionF() {} // Warning: [tab][tab][tab][space].
 
 	$object->functioncall()
 		-> chained()
 		-> anothermethod();
 
 	$object->functioncall()
-        -> chained()        // Warning: [tab][tab][space][space][space].
-        -> anothermethod(); // Warning: [tab][tab][space][space][space].
+				-> chained()        // Warning: [tab][tab][space][space][space].
+				-> anothermethod(); // Warning: [tab][tab][space][space][space].
 
     ?> <!-- Warning: three spaces. -->
 
 	<p>
-    Warning: Some inline HTML with precision alignment.
+		Warning: Some inline HTML with precision alignment.
 	</p>
 
   <?php // Warning: one space.
@@ -78,7 +78,7 @@ phpcs:set Universal.WhiteSpace.PrecisionAlignment indent 2
 	 * Multi-line javascript comment should not trigger this sniff.
 	 */
 	alert('OK');
-    alert('bad'); <!-- Warning. -->
+		alert('bad'); <!-- Warning. -->
 </script>
 
 <?php


### PR DESCRIPTION
Enhancement to minimize fixer conflicts/speed up fixer runs.

With this change, the fixer will check whether tab replacement has been done on the indent in the original token content and if so, the fixer will use tabs for the indent replacement instead of spaces.

Includes updated unit tests.
Includes minor test adjustment to ensure that tabs used for inline alignment (vs indent) are disregarded when determining whether tabs or spaces should be used by the fixer.