### PR TITLE
Universal/PrecisionAlignment: bug fix - improved handling of heredoc/nowdoc closers

### DIFF
--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.11.inc
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.11.inc
@@ -17,6 +17,8 @@
  * The text lines are not checked and the closer MUST be at the start of the line,
  * as otherwise the code will result in a parse error.
  */
+
+// Space indent.
 $heredoc = <<<EOD
 some text
       some text
@@ -29,12 +31,33 @@ some text
   some text
 EOD;
 
+// Tab indent.
+$heredoc = <<<EOD
+some text
+	  some text
+	some text
+EOD;
+
+$nowdoc = <<<'EOD'
+some text
+	  some text
+  some text
+EOD;
+
 /*
  * PHP >= 7.3: flexible heredoc/nowdocs.
  *
  * In this case, the indentation before the closing identifier will be checked.
  * As before, the text lines will not be checked.
+ *
+ * Notes:
+ * - These tests also safeguard that for nowdoc/heredoc closers, the indent is always rounded DOWN
+ *   as rounding up could cause a parse error (invalid body indentation level)!
+ * - These tests also verify correct handling of spaces vs tabs in tokens in which PHPCS
+ *   may not have done the replacement natively.
  */
+
+// Space indent.
 $heredoc = <<<END
       a
      b
@@ -58,3 +81,48 @@ $nowdoc = <<<'END'
         b
       c
      END; // Warning.
+
+$heredoc = <<<END
+          a
+       b
+       END; // Warning.
+
+$nowdoc = <<<'END'
+          a
+       b
+       END; // Warning.
+
+// Tab indent.
+$heredoc = <<<END
+	  a
+	 b
+	c
+	END; // OK.
+
+$nowdoc = <<<'END'
+	  a
+	 b
+	c
+	END; // OK.
+
+$heredoc = <<<"END"
+		  a
+		b
+	  c
+	 END; // Warning.
+
+$nowdoc = <<<'END'
+		  a
+		b
+	  c
+	 END; // Warning.
+
+$heredoc = <<<END
+		  a
+	   b
+	   END; // Warning.
+
+$nowdoc = <<<'END'
+		  a
+	   b
+	   END; // Warning.

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.11.inc.fixed
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.11.inc.fixed
@@ -17,6 +17,8 @@
  * The text lines are not checked and the closer MUST be at the start of the line,
  * as otherwise the code will result in a parse error.
  */
+
+// Space indent.
 $heredoc = <<<EOD
 some text
       some text
@@ -29,12 +31,33 @@ some text
   some text
 EOD;
 
+// Tab indent.
+$heredoc = <<<EOD
+some text
+	  some text
+	some text
+EOD;
+
+$nowdoc = <<<'EOD'
+some text
+	  some text
+  some text
+EOD;
+
 /*
  * PHP >= 7.3: flexible heredoc/nowdocs.
  *
  * In this case, the indentation before the closing identifier will be checked.
  * As before, the text lines will not be checked.
+ *
+ * Notes:
+ * - These tests also safeguard that for nowdoc/heredoc closers, the indent is always rounded DOWN
+ *   as rounding up could cause a parse error (invalid body indentation level)!
+ * - These tests also verify correct handling of spaces vs tabs in tokens in which PHPCS
+ *   may not have done the replacement natively.
  */
+
+// Space indent.
 $heredoc = <<<END
       a
      b
@@ -58,3 +81,48 @@ $nowdoc = <<<'END'
         b
       c
     END; // Warning.
+
+$heredoc = <<<END
+          a
+       b
+    END; // Warning.
+
+$nowdoc = <<<'END'
+          a
+       b
+    END; // Warning.
+
+// Tab indent.
+$heredoc = <<<END
+	  a
+	 b
+	c
+	END; // OK.
+
+$nowdoc = <<<'END'
+	  a
+	 b
+	c
+	END; // OK.
+
+$heredoc = <<<"END"
+		  a
+		b
+	  c
+	END; // Warning.
+
+$nowdoc = <<<'END'
+		  a
+		b
+	  c
+	END; // Warning.
+
+$heredoc = <<<END
+		  a
+	   b
+	END; // Warning.
+
+$nowdoc = <<<'END'
+		  a
+	   b
+	END; // Warning.

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.php
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.php
@@ -34,6 +34,7 @@ final class PrecisionAlignmentUnitTest extends AbstractSniffUnitTest
         'PrecisionAlignmentUnitTest.7.inc'  => 3,
         'PrecisionAlignmentUnitTest.8.inc'  => 2,
         'PrecisionAlignmentUnitTest.10.inc' => 4,
+        'PrecisionAlignmentUnitTest.11.inc' => 4,
         'PrecisionAlignmentUnitTest.15.inc' => 4,
         'PrecisionAlignmentUnitTest.17.inc' => 4,
         'PrecisionAlignmentUnitTest.2.css'  => 4,
@@ -138,8 +139,14 @@ final class PrecisionAlignmentUnitTest extends AbstractSniffUnitTest
             case 'PrecisionAlignmentUnitTest.11.inc':
                 if (\PHP_VERSION_ID >= 70300) {
                     return [
-                        54 => 1,
-                        60 => 1,
+                        77  => 1,
+                        83  => 1,
+                        88  => 1,
+                        93  => 1,
+                        112 => 1,
+                        118 => 1,
+                        123 => 1,
+                        128 => 1,
                     ];
                 }
 


### PR DESCRIPTION
This commit fixes two bugs:
1. When a heredoc/nowdoc closer (PHP 7.3+ flexible syntax) is indented with tabs, PHPCS does not replace tabs with spaces in the token.
    This means the token `'length'` key will also be tab-based, which leads to incorrrect calculations and false positives with incorrect fixes.
    Fixed now by handling tab replacement in heredoc/nowdoc closer tokens in the sniff itself.
2. A heredoc/nowdoc closer using flexible syntax is not allowed to have a larger indent than any of the content of the heredoc/nowdoc. Doing so results in a parse error.
    With the "best guess" rounding of the indent, the sniff had a risk of introducing these kind of parse errors.
    Fixed now by always rounding the expected indent down to the nearest tabstop for these tokens.

Includes additional unit tests to cover the changes.