### PR TITLE
Composer/GH Actions: start using PHPCSDevTools 1.2.0

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -61,7 +61,7 @@ jobs:
       # @link https://github.com/marketplace/actions/xmllint-problem-matcher
       - uses: korelstar/xmllint-problem-matcher@v1
 
-      # Validate the XML file.
+      # Validate the Ruleset XML file.
       # @link http://xmlsoft.org/xmllint.html
       - name: Validate rulesets against schema
         run: xmllint --noout --schema vendor/squizlabs/php_codesniffer/phpcs.xsd ./*/ruleset.xml
@@ -71,6 +71,10 @@ jobs:
         run: |
           diff -B ./NormalizedArrays/ruleset.xml <(xmllint --format "./NormalizedArrays/ruleset.xml")
           diff -B ./Universal/ruleset.xml <(xmllint --format "./Universal/ruleset.xml")
+
+      # Validate the Documentation XML files.
+      - name: Validate documentation against schema
+        run: xmllint --noout --schema vendor/phpcsstandards/phpcsdevtools/DocsXsd/phpcsdocs.xsd ./*/Docs/*/*Standard.xml
 
       # Check the code-style consistency of the PHP files.
       - name: Check PHP code style

--- a/NormalizedArrays/Docs/Arrays/ArrayBraceSpacingStandard.xml
+++ b/NormalizedArrays/Docs/Arrays/ArrayBraceSpacingStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Array Brace Spacing">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Array Brace Spacing"
+    >
     <standard>
     <![CDATA[
         There should be no space between the "array" keyword and the array open brace.

--- a/NormalizedArrays/Docs/Arrays/CommaAfterLastStandard.xml
+++ b/NormalizedArrays/Docs/Arrays/CommaAfterLastStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Comma After Last Array Item">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Comma After Last Array Item"
+    >
     <standard>
     <![CDATA[
       For single-line arrays, there should be <em>no</em> comma after the last array item.

--- a/Universal/Docs/Arrays/DisallowShortArraySyntaxStandard.xml
+++ b/Universal/Docs/Arrays/DisallowShortArraySyntaxStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Disallow Short Array Syntax">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Disallow Short Array Syntax"
+    >
     <standard>
     <![CDATA[
     The array keyword must be used to define arrays.

--- a/Universal/Docs/Arrays/DuplicateArrayKeyStandard.xml
+++ b/Universal/Docs/Arrays/DuplicateArrayKeyStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Duplicate Array Key">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Duplicate Array Key"
+    >
     <standard>
     <![CDATA[
         When a second array item with the same key is declared, it will overwrite the first.

--- a/Universal/Docs/Arrays/MixedArrayKeyTypesStandard.xml
+++ b/Universal/Docs/Arrays/MixedArrayKeyTypesStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Mixed Array Key Types">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Mixed Array Key Types"
+    >
     <standard>
     <![CDATA[
         In an array where the items have keys, all items should either have a numeric key assigned or a string key. A mix of numeric and string keys is not allowed.

--- a/Universal/Docs/Arrays/MixedKeyedUnkeyedArrayStandard.xml
+++ b/Universal/Docs/Arrays/MixedKeyedUnkeyedArrayStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Mixed Keyed Unkeyed Array">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Mixed Keyed Unkeyed Array"
+    >
     <standard>
     <![CDATA[
         All items in an array should either have an explicit key assigned or none. A mix of keyed and unkeyed items is not allowed.

--- a/Universal/Docs/Classes/DisallowAnonClassParenthesesStandard.xml
+++ b/Universal/Docs/Classes/DisallowAnonClassParenthesesStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Disallow Anonymous Class Parentheses">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Disallow Anonymous Class Parentheses"
+    >
     <standard>
     <![CDATA[
     Disallows the use of parentheses when declaring an anonymous class without passing parameters.

--- a/Universal/Docs/Classes/DisallowFinalClassStandard.xml
+++ b/Universal/Docs/Classes/DisallowFinalClassStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Disallow Final Class">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Disallow Final Class"
+    >
     <standard>
     <![CDATA[
     Disallows the use of the `final` keyword for class declarations.

--- a/Universal/Docs/Classes/RequireAnonClassParenthesesStandard.xml
+++ b/Universal/Docs/Classes/RequireAnonClassParenthesesStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Require Anonymous Class Parentheses">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Require Anonymous Class Parentheses"
+    >
     <standard>
     <![CDATA[
     Require the use of parentheses when declaring an anonymous class.

--- a/Universal/Docs/Classes/RequireFinalClassStandard.xml
+++ b/Universal/Docs/Classes/RequireFinalClassStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Require Final Class">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Require Final Class"
+    >
     <standard>
     <![CDATA[
     Requires the use of the `final` keyword for non-abstract class declarations.

--- a/Universal/Docs/CodeAnalysis/ForeachUniqueAssignmentStandard.xml
+++ b/Universal/Docs/CodeAnalysis/ForeachUniqueAssignmentStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Foreach Unique Assignment">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Foreach Unique Assignment"
+    >
     <standard>
     <![CDATA[
     When a foreach control structure uses the same variable for both the $key as well as the $value assignment, the key will be disregarded and be inaccessible and the variable will contain the value.

--- a/Universal/Docs/CodeAnalysis/StaticInFinalClassStandard.xml
+++ b/Universal/Docs/CodeAnalysis/StaticInFinalClassStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Static in Final Class">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Static in Final Class"
+    >
     <standard>
     <![CDATA[
     When a class is declared as final, using the `static` keyword for late static binding is unnecessary and redundant.

--- a/Universal/Docs/Constants/LowercaseClassResolutionKeywordStandard.xml
+++ b/Universal/Docs/Constants/LowercaseClassResolutionKeywordStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Lowercase Class Resolution Keyword">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Lowercase Class Resolution Keyword"
+    >
     <standard>
     <![CDATA[
     The "class" keyword when used for class name resolution, i.e. `::class`, must be in lowercase.

--- a/Universal/Docs/Constants/UppercaseMagicConstantsStandard.xml
+++ b/Universal/Docs/Constants/UppercaseMagicConstantsStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Uppercase Magic Constants">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Uppercase Magic Constants"
+    >
     <standard>
     <![CDATA[
     The PHP native `__...__` magic constant should be in uppercase.

--- a/Universal/Docs/ControlStructures/DisallowAlternativeSyntaxStandard.xml
+++ b/Universal/Docs/ControlStructures/DisallowAlternativeSyntaxStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Disallow Alternative Control Structure Syntax">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Disallow Alternative Control Structure Syntax"
+    >
     <standard>
     <![CDATA[
     The use of the alternative syntax for control structures is not allowed.

--- a/Universal/Docs/ControlStructures/DisallowLonelyIfStandard.xml
+++ b/Universal/Docs/ControlStructures/DisallowLonelyIfStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Disallow Lonely If">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Disallow Lonely If"
+    >
     <standard>
     <![CDATA[
     Disallows `if` statements as the only statement in an `else` block.

--- a/Universal/Docs/ControlStructures/IfElseDeclarationStandard.xml
+++ b/Universal/Docs/ControlStructures/IfElseDeclarationStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="If-else Declarations">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="If-else Declarations"
+    >
     <standard>
     <![CDATA[
     The `else` and `elseif` keywords should be on a new line.

--- a/Universal/Docs/Lists/DisallowLongListSyntaxStandard.xml
+++ b/Universal/Docs/Lists/DisallowLongListSyntaxStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Disallow Long List Syntax">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Disallow Long List Syntax"
+    >
     <standard>
     <![CDATA[
     Short list syntax must be used.

--- a/Universal/Docs/Lists/DisallowShortListSyntaxStandard.xml
+++ b/Universal/Docs/Lists/DisallowShortListSyntaxStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Disallow Short List Syntax">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Disallow Short List Syntax"
+    >
     <standard>
     <![CDATA[
     Long list syntax must be used.

--- a/Universal/Docs/Namespaces/DisallowCurlyBraceSyntaxStandard.xml
+++ b/Universal/Docs/Namespaces/DisallowCurlyBraceSyntaxStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Disallow Curly Brace Namespace Syntax">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Disallow Curly Brace Namespace Syntax"
+    >
     <standard>
     <![CDATA[
     Namespace declarations using the curly brace syntax are not allowed.

--- a/Universal/Docs/Namespaces/DisallowDeclarationWithoutNameStandard.xml
+++ b/Universal/Docs/Namespaces/DisallowDeclarationWithoutNameStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Disallow Namespace Declaration Without Name">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Disallow Namespace Declaration Without Name"
+    >
     <standard>
     <![CDATA[
     Namespace declarations without a namespace name are not allowed.

--- a/Universal/Docs/Namespaces/EnforceCurlyBraceSyntaxStandard.xml
+++ b/Universal/Docs/Namespaces/EnforceCurlyBraceSyntaxStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Enforce Curly Brace Namespace Syntax">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Enforce Curly Brace Namespace Syntax"
+    >
     <standard>
     <![CDATA[
     Namespace declarations without curly braces are not allowed.

--- a/Universal/Docs/Namespaces/OneDeclarationPerFileStandard.xml
+++ b/Universal/Docs/Namespaces/OneDeclarationPerFileStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="One Namespace Declaration Per File">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="One Namespace Declaration Per File"
+    >
     <standard>
     <![CDATA[
     There should be only one namespace declaration per file.

--- a/Universal/Docs/NamingConventions/NoReservedKeywordParameterNamesStandard.xml
+++ b/Universal/Docs/NamingConventions/NoReservedKeywordParameterNamesStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="No Reserved Keyword Parameter Names">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="No Reserved Keyword Parameter Names"
+    >
     <standard>
     <![CDATA[
     It is recommended not to use reserved keywords as parameter names as this can become confusing when people use them in function calls using named parameters.

--- a/Universal/Docs/OOStructures/AlphabeticExtendsImplementsStandard.xml
+++ b/Universal/Docs/OOStructures/AlphabeticExtendsImplementsStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Alphabetic Extends Implements">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Alphabetic Extends Implements"
+    >
     <standard>
     <![CDATA[
     The names used in class "implements" or interface "extends" statements should be listed in alphabetic order.

--- a/Universal/Docs/Operators/DisallowLogicalAndOrStandard.xml
+++ b/Universal/Docs/Operators/DisallowLogicalAndOrStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Disallow Logical And Or">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Disallow Logical And Or"
+    >
     <standard>
     <![CDATA[
     Using the logical "and" and "or" operators is not allowed.

--- a/Universal/Docs/Operators/DisallowShortTernaryStandard.xml
+++ b/Universal/Docs/Operators/DisallowShortTernaryStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Disallow Short Ternary">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Disallow Short Ternary"
+    >
     <standard>
     <![CDATA[
     Using short ternaries is not allowed.

--- a/Universal/Docs/Operators/DisallowStandalonePostIncrementDecrementStandard.xml
+++ b/Universal/Docs/Operators/DisallowStandalonePostIncrementDecrementStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Disallow Standalone Post-Increment/Decrement">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Disallow Standalone Post-Increment/Decrement"
+    >
     <standard>
     <![CDATA[
     In a stand-alone in/decrement statement, pre-in/decrement should always be favoured over post-in/decrement.

--- a/Universal/Docs/Operators/StrictComparisonsStandard.xml
+++ b/Universal/Docs/Operators/StrictComparisonsStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Strict Comparisons">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Strict Comparisons"
+    >
     <standard>
     <![CDATA[
     Using loose comparisons is not allowed.

--- a/Universal/Docs/Operators/TypeSeparatorSpacingStandard.xml
+++ b/Universal/Docs/Operators/TypeSeparatorSpacingStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Type Separator Spacing">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Type Separator Spacing"
+    >
     <standard>
     <![CDATA[
     There should be no spacing around the union type separator or the intersection type separator.

--- a/Universal/Docs/PHP/OneStatementInShortEchoTagStandard.xml
+++ b/Universal/Docs/PHP/OneStatementInShortEchoTagStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="One Statement In Short Echo Tag">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="One Statement In Short Echo Tag"
+    >
     <standard>
     <![CDATA[
     Best practice: Short open echo tags should only ever contain *one* statement.

--- a/Universal/Docs/UseStatements/DisallowUseClassStandard.xml
+++ b/Universal/Docs/UseStatements/DisallowUseClassStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Disallow Use Class/Trait/Interface">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Disallow Use Class/Trait/Interface"
+    >
     <standard>
     <![CDATA[
     Disallow the use of `use` import statements for classes, traits and interfaces, with or without alias.

--- a/Universal/Docs/UseStatements/DisallowUseConstStandard.xml
+++ b/Universal/Docs/UseStatements/DisallowUseConstStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Disallow Use Const">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Disallow Use Const"
+    >
     <standard>
     <![CDATA[
     Disallow the use of `use const` import statements, with or without alias.

--- a/Universal/Docs/UseStatements/DisallowUseFunctionStandard.xml
+++ b/Universal/Docs/UseStatements/DisallowUseFunctionStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Disallow Use Function">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Disallow Use Function"
+    >
     <standard>
     <![CDATA[
     Disallow the use of `use function` import statements, with or without alias.

--- a/Universal/Docs/UseStatements/LowercaseFunctionConstStandard.xml
+++ b/Universal/Docs/UseStatements/LowercaseFunctionConstStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Lowercase Function Const">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Lowercase Function Const"
+    >
     <standard>
     <![CDATA[
     `function` and `const` keywords in import `use` statements should be in lowercase.

--- a/Universal/Docs/UseStatements/NoLeadingBackslashStandard.xml
+++ b/Universal/Docs/UseStatements/NoLeadingBackslashStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="No Leading Backslash">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="No Leading Backslash"
+    >
     <standard>
     <![CDATA[
     Import `use` statements must never begin with a leading backslash as they should always be fully qualified.

--- a/Universal/Docs/WhiteSpace/AnonClassKeywordSpacingStandard.xml
+++ b/Universal/Docs/WhiteSpace/AnonClassKeywordSpacingStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Anonymous Class Keyword Spacing">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Anonymous Class Keyword Spacing"
+    >
     <standard>
     <![CDATA[
     Checks the spacing between the "class" keyword and the open parenthesis for anonymous classes with parentheses.

--- a/Universal/Docs/WhiteSpace/DisallowInlineTabsStandard.xml
+++ b/Universal/Docs/WhiteSpace/DisallowInlineTabsStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Disallow Inline Tabs">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Disallow Inline Tabs"
+    >
     <standard>
     <![CDATA[
     Spaces must be used for mid-line alignment.

--- a/Universal/Docs/WhiteSpace/PrecisionAlignmentStandard.xml
+++ b/Universal/Docs/WhiteSpace/PrecisionAlignmentStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Precision Alignment">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Precision Alignment"
+    >
     <standard>
     <![CDATA[
     Detects when the indentation is not a multiple of a tab-width, i.e. when precision alignment is used.

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require-dev" : {
         "php-parallel-lint/php-parallel-lint": "^1.3.2",
         "php-parallel-lint/php-console-highlighter": "^1.0",
-        "phpcsstandards/phpcsdevtools": "^1.0",
+        "phpcsstandards/phpcsdevtools": "^1.2.0",
         "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0"
     },
     "extra": {


### PR DESCRIPTION
### Composer/GH Actions: start using PHPCSDevTools 1.2.0

PHPCSDevTools 1.2.0 introduces an XSD for the XML docs which can accompany sniffs.

This commit:
* Updates the PHPCSDevTools to version 1.2.0.
* Adds a new check against the XSD for all sniff XML Docs files.

Ref: https://github.com/PHPCSStandards/PHPCSDevTools/releases/tag/1.2.0

### Sniff XML docs: add schema to docs

Includes adding the `<?xml..?>` header if it didn't exist in the file.