### PR TITLE
Composer: up the minimum PHPCS version to 3.7.1

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         php: ['5.4', 'latest']
-        phpcs_version: ['3.7.0', 'dev-master']
+        phpcs_version: ['3.7.1', 'dev-master']
 
     name: "QTest${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
         php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '8.0', '8.1']
-        phpcs_version: ['3.7.0', 'dev-master']
+        phpcs_version: ['3.7.1', 'dev-master']
         experimental: [false]
 
         include:
@@ -137,7 +137,7 @@ jobs:
       matrix:
         # 7.4 should be updated to 8.0 when higher PHPUnit versions can be supported.
         php: ['5.4', '7.4']
-        phpcs_version: ['3.7.0', 'dev-master']
+        phpcs_version: ['3.7.1', 'dev-master']
 
     name: "Coverage${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Minimum Requirements
 -------------------------------------------
 
 * PHP 5.4 or higher.
-* [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **3.7.0** or higher.
+* [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **3.7.1** or higher.
 * [PHPCSUtils](https://github.com/PHPCSStandards/PHPCSUtils) version **1.0.0** or higher.
 
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require" : {
         "php" : ">=5.4",
-        "squizlabs/php_codesniffer" : "^3.7.0",
+        "squizlabs/php_codesniffer" : "^3.7.1",
         "dealerdirect/phpcodesniffer-composer-installer" : "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
         "phpcsstandards/phpcsutils" : "^1.0 || dev-develop"
     },


### PR DESCRIPTION
Raise the minimum supported PHPCS version to PHPCS 3.7.1, in line with PHPCSUtils.

Includes updating the GH Actions matrixes for this change.

Refs: https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.7.1