### PR TITLE
Upgrade to PHPCSUtils 1.0.0-alpha4

### DIFF
--- a/NormalizedArrays/Sniffs/Arrays/ArrayBraceSpacingSniff.php
+++ b/NormalizedArrays/Sniffs/Arrays/ArrayBraceSpacingSniff.php
@@ -14,6 +14,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Fixers\SpacesFixer;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Arrays;
 
 /**
@@ -105,11 +106,7 @@ final class ArrayBraceSpacingSniff implements Sniff
      */
     public function register()
     {
-        return [
-            \T_ARRAY,
-            \T_OPEN_SHORT_ARRAY,
-            \T_OPEN_SQUARE_BRACKET,
-        ];
+        return Collections::arrayOpenTokensBC();
     }
 
    /**

--- a/NormalizedArrays/Sniffs/Arrays/CommaAfterLastSniff.php
+++ b/NormalizedArrays/Sniffs/Arrays/CommaAfterLastSniff.php
@@ -13,6 +13,7 @@ namespace PHPCSExtra\NormalizedArrays\Sniffs\Arrays;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Arrays;
 
 /**
@@ -81,11 +82,7 @@ final class CommaAfterLastSniff implements Sniff
      */
     public function register()
     {
-        return [
-            \T_ARRAY,
-            \T_OPEN_SHORT_ARRAY,
-            \T_OPEN_SQUARE_BRACKET,
-        ];
+        return Collections::arrayOpenTokensBC();
     }
 
     /**

--- a/Universal/Sniffs/Classes/DisallowFinalClassSniff.php
+++ b/Universal/Sniffs/Classes/DisallowFinalClassSniff.php
@@ -12,8 +12,8 @@ namespace PHPCSExtra\Universal\Sniffs\Classes;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
-use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\Utils\GetTokensAsString;
+use PHPCSUtils\Utils\ObjectDeclarations;
 
 /**
  * Forbids classes from being declared as "final".
@@ -50,11 +50,7 @@ final class DisallowFinalClassSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        /*
-         * Deliberately using the BCFile version of getClassProperties to allow
-         * for handling the parse error of classes declared as both final + abstract.
-         */
-        $classProp = BCFile::getClassProperties($phpcsFile, $stackPtr);
+        $classProp = ObjectDeclarations::getClassProperties($phpcsFile, $stackPtr);
         if ($classProp['is_final'] === false) {
             if ($classProp['is_abstract'] === true) {
                 $phpcsFile->recordMetric($stackPtr, 'Class declaration type', 'abstract');

--- a/Universal/Sniffs/Constants/UppercaseMagicConstantsSniff.php
+++ b/Universal/Sniffs/Constants/UppercaseMagicConstantsSniff.php
@@ -12,7 +12,7 @@ namespace PHPCSExtra\Universal\Sniffs\Constants;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
-use PHPCSUtils\Tokens\Collections;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Verifies that PHP native `__...__` magic constants are in uppercase when used.
@@ -33,7 +33,7 @@ final class UppercaseMagicConstantsSniff implements Sniff
      */
     public function register()
     {
-        return Collections::$magicConstants;
+        return Tokens::$magicConstants;
     }
 
     /**

--- a/Universal/Sniffs/ControlStructures/DisallowAlternativeSyntaxSniff.php
+++ b/Universal/Sniffs/ControlStructures/DisallowAlternativeSyntaxSniff.php
@@ -41,16 +41,7 @@ final class DisallowAlternativeSyntaxSniff implements Sniff
      */
     public function register()
     {
-        return [
-            \T_IF,
-            \T_ELSE,
-            \T_ELSEIF,
-            \T_FOR,
-            \T_FOREACH,
-            \T_SWITCH,
-            \T_WHILE,
-            \T_DECLARE,
-        ];
+        return Collections::alternativeControlStructureSyntaxes();
     }
 
     /**
@@ -142,7 +133,7 @@ final class DisallowAlternativeSyntaxSniff implements Sniff
         $phpcsFile->fixer->beginChangeset();
         $phpcsFile->fixer->replaceToken($opener, '{');
 
-        if (isset(Collections::$alternativeControlStructureSyntaxCloserTokens[$tokens[$closer]['code']]) === true) {
+        if (isset(Collections::alternativeControlStructureSyntaxClosers()[$tokens[$closer]['code']]) === true) {
             $phpcsFile->fixer->replaceToken($closer, '}');
 
             $semicolon = $phpcsFile->findNext(Tokens::$emptyTokens, ($closer + 1), null, true);

--- a/Universal/Sniffs/NamingConventions/NoReservedKeywordParameterNamesSniff.php
+++ b/Universal/Sniffs/NamingConventions/NoReservedKeywordParameterNamesSniff.php
@@ -144,7 +144,7 @@ final class NoReservedKeywordParameterNamesSniff implements Sniff
      */
     public function register()
     {
-        return Collections::functionDeclarationTokensBC();
+        return Collections::functionDeclarationTokens();
     }
 
     /**
@@ -171,7 +171,6 @@ final class NoReservedKeywordParameterNamesSniff implements Sniff
                 return;
             }
         } catch (RuntimeException $e) {
-            // Most likely a T_STRING which wasn't an arrow function.
             return;
         }
 

--- a/Universal/Sniffs/OOStructures/AlphabeticExtendsImplementsSniff.php
+++ b/Universal/Sniffs/OOStructures/AlphabeticExtendsImplementsSniff.php
@@ -86,7 +86,7 @@ final class AlphabeticExtendsImplementsSniff implements Sniff
      */
     public function register()
     {
-        return (Collections::$OOCanExtend + Collections::$OOCanImplement);
+        return (Collections::ooCanExtend() + Collections::ooCanImplement());
     }
 
     /**
@@ -122,7 +122,7 @@ final class AlphabeticExtendsImplementsSniff implements Sniff
         /*
          * Get the names.
          */
-        if (isset(Collections::$OOCanImplement[$tokens[$stackPtr]['code']]) === true) {
+        if (isset(Collections::ooCanImplement()[$tokens[$stackPtr]['code']]) === true) {
             $names = ObjectDeclarations::findImplementedInterfaceNames($phpcsFile, $stackPtr);
         } else {
             $names = ObjectDeclarations::findExtendedInterfaceNames($phpcsFile, $stackPtr);
@@ -165,7 +165,7 @@ final class AlphabeticExtendsImplementsSniff implements Sniff
          * Throw the error.
          */
         $keyword = \T_IMPLEMENTS;
-        if (isset(Collections::$OOCanImplement[$tokens[$stackPtr]['code']]) === false) {
+        if (isset(Collections::ooCanImplement()[$tokens[$stackPtr]['code']]) === false) {
             $keyword = \T_EXTENDS;
         }
 

--- a/Universal/Sniffs/Operators/DisallowStandalonePostIncrementDecrementSniff.php
+++ b/Universal/Sniffs/Operators/DisallowStandalonePostIncrementDecrementSniff.php
@@ -53,11 +53,11 @@ final class DisallowStandalonePostIncrementDecrementSniff implements Sniff
      */
     public function register()
     {
-        $this->allowedTokens += Collections::$OOHierarchyKeywords;
-        $this->allowedTokens += Collections::$objectOperators;
-        $this->allowedTokens += Collections::$OONameTokens;
+        $this->allowedTokens += Collections::ooHierarchyKeywords();
+        $this->allowedTokens += Collections::objectOperators();
+        $this->allowedTokens += Collections::namespacedNameTokens();
 
-        return Collections::$incrementDecrementOperators;
+        return Collections::incrementDecrementOperators();
     }
 
     /**
@@ -88,14 +88,15 @@ final class DisallowStandalonePostIncrementDecrementSniff implements Sniff
             return $end;
         }
 
-        $counter  = 0;
-        $lastCode = null;
+        $counter   = 0;
+        $lastCode  = null;
+        $operators = Collections::incrementDecrementOperators();
         for ($i = $start; $i < $end; $i++) {
             if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
                 continue;
             }
 
-            if (isset(Collections::$incrementDecrementOperators[$tokens[$i]['code']]) === true) {
+            if (isset($operators[$tokens[$i]['code']]) === true) {
                 $lastCode = $tokens[$i]['code'];
                 ++$counter;
                 continue;

--- a/Universal/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
+++ b/Universal/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
@@ -15,6 +15,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSExtra\Universal\Helpers\DummyTokenizer;
 use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\Tokens\Collections;
 
 /**
  * Enforces using spaces for mid-line alignment.
@@ -73,10 +74,7 @@ final class DisallowInlineTabsSniff implements Sniff
      */
     public function register()
     {
-        return [
-            \T_OPEN_TAG,
-            \T_OPEN_TAG_WITH_ECHO,
-        ];
+        return Collections::phpOpenTags();
     }
 
     /**

--- a/Universal/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
+++ b/Universal/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
@@ -14,6 +14,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\Tokens\Collections;
 
 /**
  * Detects when the indentation is not a multiple of a tab-width, i.e. when precision alignment is used.
@@ -140,10 +141,7 @@ final class PrecisionAlignmentSniff implements Sniff
         // Add the ignore annotation tokens to the list of tokens to check.
         $this->tokensToCheck += Tokens::$phpcsCommentTokens;
 
-        return [
-            \T_OPEN_TAG,
-            \T_OPEN_TAG_WITH_ECHO,
-        ];
+        return Collections::phpOpenTags();
     }
 
     /**


### PR DESCRIPTION
Upgrade to PHPCSUtils 1.0.0-alpha4

Take advantage of new features in PHPCSUtils 1.0.0-alpha4.

Ref: https://github.com/PHPCSStandards/PHPCSUtils/releases/tag/1.0.0-alpha4