### PR TITLE
NormalizedArrays/ArrayBraceSpacing: safeguard upstream bugfix

### DIFF
--- a/NormalizedArrays/Tests/Arrays/ArrayBraceSpacingUnitTest.inc
+++ b/NormalizedArrays/Tests/Arrays/ArrayBraceSpacingUnitTest.inc
@@ -316,3 +316,8 @@ $array = array($a,
 // phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesWhenEmpty 0
 // phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesSingleLine 0
 // phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesMultiLine newline
+
+$foo = array(
+    'key' => 'value', // Comment.
+    // Comment.
+);

--- a/NormalizedArrays/Tests/Arrays/ArrayBraceSpacingUnitTest.inc.fixed
+++ b/NormalizedArrays/Tests/Arrays/ArrayBraceSpacingUnitTest.inc.fixed
@@ -306,3 +306,8 @@ $array = array($a,
 // phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesWhenEmpty 0
 // phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesSingleLine 0
 // phpcs:set NormalizedArrays.Arrays.ArrayBraceSpacing spacesMultiLine newline
+
+$foo = array(
+    'key' => 'value', // Comment.
+    // Comment.
+);


### PR DESCRIPTION
The `SpacesFixer` in PHPCSUtils contains a bugfix for a specific situation which affected this sniff.

This adds an extra unit test for the sniff to safeguard that bugfix.

Ref: PHPCSStandards/PHPCSUtils#229