### PR TITLE
DisallowStandalonePostIncrementDecrement: prevent looking for nullsafe object operator

### DIFF
--- a/Universal/Sniffs/Operators/DisallowStandalonePostIncrementDecrementSniff.php
+++ b/Universal/Sniffs/Operators/DisallowStandalonePostIncrementDecrementSniff.php
@@ -57,6 +57,12 @@ final class DisallowStandalonePostIncrementDecrementSniff implements Sniff
         $this->allowedTokens += Collections::objectOperators();
         $this->allowedTokens += Collections::namespacedNameTokens();
 
+        /*
+         * Remove potential nullsafe object operator. In/decrement not allowed in write context,
+         * so ignore.
+         */
+        unset($this->allowedTokens[\T_NULLSAFE_OBJECT_OPERATOR]);
+
         return Collections::incrementDecrementOperators();
     }
 

--- a/Universal/Tests/Operators/DisallowStandalonePostIncrementDecrementUnitTest.inc
+++ b/Universal/Tests/Operators/DisallowStandalonePostIncrementDecrementUnitTest.inc
@@ -70,5 +70,8 @@ $a = 10 + $i++ - 5;
 
 return $a['key'][$i++];
 
+// Intentional parse error. Nullsafe operator not allowed in write-context. Ignore.
+$obj?->prop++;
+
 // Intentional parse error.
 ++;

--- a/Universal/Tests/Operators/DisallowStandalonePostIncrementDecrementUnitTest.inc.fixed
+++ b/Universal/Tests/Operators/DisallowStandalonePostIncrementDecrementUnitTest.inc.fixed
@@ -70,5 +70,8 @@ $a = 10 + $i++ - 5;
 
 return $a['key'][$i++];
 
+// Intentional parse error. Nullsafe operator not allowed in write-context. Ignore.
+$obj?->prop++;
+
 // Intentional parse error.
 ++;


### PR DESCRIPTION
The PHPCSUtils `Collections::$objectOperators` property has been deprecated in favour of a `Collections::objectOperators()` method to allow for the PHP 8.0 `T_NULLSAFE_OBJECT_OPERATOR` token which may not be available.

As the `T_NULLSAFE_OBJECT_OPERATOR` is not allowed in write-context and in/decrement is write-context, remove the token for this sniff.