### PR TITLE
Universal/ConstructorDestructorReturn: add auto-fixer for return type

### DIFF
--- a/Universal/Tests/CodeAnalysis/ConstructorDestructorReturnUnitTest.inc.fixed
+++ b/Universal/Tests/CodeAnalysis/ConstructorDestructorReturnUnitTest.inc.fixed
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * OK.
+ */
+
+// Global function, not a constructor/destructor.
+function __construct() : int {
+    return 123;
+}
+
+function __destruct() : float {
+    return 321;
+}
+
+// Methods which are not constructors can be disregarded.
+class NotAConstructor {
+    public function __set($name, $value): void {
+        // Do something.
+    }
+
+    public function Foo(): void {
+        // Do something.
+    }
+
+    public function Bar() {
+        return $this;
+    }
+}
+
+// Constructor/Destructor without a return statement or return type.
+class NoReturn {
+    protected function __construct()
+    {
+        // Do something.
+    }
+
+    protected function __destruct()
+    {
+        // Do something.
+    }
+
+    // Also applies to PHP4-style constructors/destructors.
+    function NoReturn()
+    {
+        // Do something.
+    }
+
+    function _NoReturn()
+    {
+        // Do something.
+    }
+}
+
+// Constructor/Destructor with return statement, but no value.
+$anon = new class extends ReturnNoValue {
+    public function __construct() {
+        if ($foo) {
+            return   ;
+        } else {
+            return /* comments are fine */
+            // Even when spread over multiple lines.
+            ;
+        }
+
+        return;
+    }
+
+    public function __destruct() {
+        // Do something.
+        return;
+    }
+
+    // Non-constructor/destructor method returning.
+    public function returnsavalue() {
+        return 'php4style';
+    }
+};
+
+
+/*
+ * Not OK.
+ */
+class ReturnsAValue {
+    public function __construct() {
+        return $this;
+    }
+
+    public function __destruct() {
+        return 'destructed';
+    }
+
+    function returnsavalue()
+    {
+        return 'php4style';
+    }
+}
+
+$anon = new class() extends ReturnsAValue {
+    public function __Construct()
+    {
+        return $this;
+    }
+
+    public function __deStRucT() {
+        return 'destructed';
+    }
+};
+
+/*
+ * Return types are not allowed on constructor/destructor methods (fatal error).
+ */
+
+trait AbstractConstructorDestructorReturnTypes {
+    abstract public function __construct();
+
+    abstract public function __destruct();
+}
+
+interface InterfaceMethodReturnTypes {
+    public function __construct();
+
+    public function __destruct();
+}


### PR DESCRIPTION
Follow up on #137

The "returns a value" warning cannot be auto-fixed as it should be looked at by a developer. However, the "return type found" error _can_ be auto-fixed, so let's do so.