### PR TITLE
DisallowInlineTabsUnitTest: skip on PHP 5.5

### DIFF
--- a/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
+++ b/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
@@ -23,6 +23,24 @@ final class DisallowInlineTabsUnitTest extends AbstractSniffUnitTest
 {
 
     /**
+     * Should this test be skipped for some reason.
+     *
+     * @return boolean
+     */
+    protected function shouldSkipTest()
+    {
+        /*
+         * Skip these tests on PHP 5.5 as there is something weird going on
+         * which intermittently causes CI to fail on PHP 5.5 (and only on PHP 5.5).
+         * It is unclear why the tests would fail, it cannot be reproduced locally,
+         * and will some of the time pass on CI as well, so debugging this is
+         * next to impossible.
+         * But having to continuously restart builds is getting silly.
+         */
+        return (PHP_MAJOR_VERSION === 5 && PHP_MINOR_VERSION === 5);
+    }
+
+    /**
      * Set CLI values before the file is tested.
      *
      * @param string                  $testFile The name of the file being tested.


### PR DESCRIPTION
For some weird and unknown reason, the tests for this sniff have started to fail intermittently in CI on PHP 5.5 (and only on PHP 5.5).
* The tests pass on PHP 5.4 and PHP 5.6-8.2.
* The tests regularly pass on PHP 5.5 after restarting the build (?!).
* The tests pass locally on PHP 5.5 when running with the exact same PHP version and PHPUnit versions.

In other words, this is one of those mystery bugs.

For now, I'm just going to skip running these tests on PHP 5.5 as the build failures are blocking PRs for unrelated features.