### PR TITLE
:sparkles: New `Universal.Constants.ModifierKeywordOrder` sniff

### DIFF
--- a/Universal/Docs/Constants/ModifierKeywordOrderStandard.xml
+++ b/Universal/Docs/Constants/ModifierKeywordOrderStandard.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Constant Modifier Keyword Order"
+    >
+    <standard>
+    <![CDATA[
+    Requires that constant modifier keywords consistently use the same keyword order.
+
+    By default the expected order is "final visibility", but this can be changed via the sniff configuration.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Modifier keywords ordered correctly.">
+        <![CDATA[
+class CorrectOrder {
+    <em>final public</em> const FOO = 'foo';
+}
+        ]]>
+        </code>
+        <code title="Invalid: Modifier keywords in reverse order.">
+        <![CDATA[
+class IncorrectOrder {
+    #[SomeAttribute]
+    <em>protected final</em> const BAR = 'foo';
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/Constants/ModifierKeywordOrderSniff.php
+++ b/Universal/Sniffs/Constants/ModifierKeywordOrderSniff.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2022 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\Constants;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\Scopes;
+
+/**
+ * Standardize the modifier keyword order for OO constant declarations.
+ *
+ * @since 1.0.0-alpha4
+ */
+final class ModifierKeywordOrderSniff implements Sniff
+{
+
+    /**
+     * Name of the metric.
+     *
+     * @since 1.0.0-alpha4
+     *
+     * @var string
+     */
+    const METRIC_NAME = 'OO constant modifier keyword order';
+
+    /**
+     * Order preference: final visibility.
+     *
+     * @since 1.0.0-alpha4
+     *
+     * @var string
+     */
+    const FINAL_VISIBILITY = 'final visibility';
+
+    /**
+     * Order preference: visibility final.
+     *
+     * @since 1.0.0-alpha4
+     *
+     * @var string
+     */
+    const VISIBILITY_FINAL = 'visibility final';
+
+    /**
+     * Preferred order for the modifier keywords.
+     *
+     * Accepted values:
+     * - "final visibility".
+     * - or "visibility final".
+     *
+     * Defaults to "final visibility".
+     *
+     * @since 1.0.0-alpha4
+     *
+     * @var string
+     */
+    public $order = self::FINAL_VISIBILITY;
+
+    /**
+     * Tokens which can be constant modifier keywords.
+     *
+     * @since 1.0.0-alpha4
+     *
+     * @var array
+     */
+    private $constantModifierKeywords = [
+        \T_FINAL => \T_FINAL,
+    ];
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0-alpha4
+     *
+     * @return array
+     */
+    public function register()
+    {
+        // Add the visibility keywords to the constant modifier keywords.
+        $this->constantModifierKeywords += Tokens::$scopeModifiers;
+
+        return [\T_CONST];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0-alpha4
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (Scopes::isOOConstant($phpcsFile, $stackPtr) === false) {
+            return;
+        }
+
+        /*
+         * Note to self: This can be switched to use the `Collections::constantModifierKeywords()`
+         * method as of the next version of PHPCSUtils.
+         */
+        $tokens = $phpcsFile->getTokens();
+        $valid  = $this->constantModifierKeywords + Tokens::$emptyTokens;
+
+        $finalPtr      = false;
+        $visibilityPtr = false;
+
+        for ($i = ($stackPtr - 1); $i > 0; $i--) {
+            if (isset($valid[$tokens[$i]['code']]) === false) {
+                break;
+            }
+
+            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+                continue;
+            }
+
+            if ($tokens[$i]['code'] === \T_FINAL) {
+                $finalPtr = $i;
+            } else {
+                $visibilityPtr = $i;
+            }
+        }
+
+        if ($finalPtr === false || $visibilityPtr === false) {
+            /*
+             * Either no modifier keywords found at all; or only one type of modifier
+             * keyword (final or visibility) declared, but not both. No ordering needed.
+             */
+            return;
+        }
+
+        if ($visibilityPtr < $finalPtr) {
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, self::VISIBILITY_FINAL);
+        } else {
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, self::FINAL_VISIBILITY);
+        }
+
+        $message = 'OO constant modifier keywords are not in the correct order. Expected: "%s", found: "%s"';
+
+        switch ($this->order) {
+            case self::VISIBILITY_FINAL:
+                if ($visibilityPtr < $finalPtr) {
+                    // Order is correct. Nothing to do.
+                    return;
+                }
+
+                $this->handleError($phpcsFile, $finalPtr, $visibilityPtr);
+                break;
+
+            case self::FINAL_VISIBILITY:
+            default:
+                if ($finalPtr < $visibilityPtr) {
+                    // Order is correct. Nothing to do.
+                    return;
+                }
+
+                $this->handleError($phpcsFile, $visibilityPtr, $finalPtr);
+                break;
+        }
+    }
+
+    /**
+     * Throw the error and potentially fix it.
+     *
+     * @since 1.0.0-alpha4
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile     The file being scanned.
+     * @param int                         $firstKeyword  The position of the first keyword found.
+     * @param int                         $secondKeyword The position of the second keyword token.
+     *
+     * @return void
+     */
+    private function handleError(File $phpcsFile, $firstKeyword, $secondKeyword)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $message = 'Constant modifier keywords are not in the correct order. Expected: "%s", found: "%s"';
+        $data    = [
+            $tokens[$secondKeyword]['content'] . ' ' . $tokens[$firstKeyword]['content'],
+            $tokens[$firstKeyword]['content'] . ' ' . $tokens[$secondKeyword]['content'],
+        ];
+
+        $fix = $phpcsFile->addFixableError($message, $firstKeyword, 'Incorrect', $data);
+
+        if ($fix === true) {
+            $phpcsFile->fixer->beginChangeset();
+
+            $phpcsFile->fixer->replaceToken($secondKeyword, '');
+
+            // Prevent leaving behind trailing whitespace.
+            $i = ($secondKeyword + 1);
+            while ($tokens[$i]['code'] === \T_WHITESPACE) {
+                $phpcsFile->fixer->replaceToken($i, '');
+                $i++;
+            }
+
+            // Use the original token content as the case used for keywords is not the concern of this sniff.
+            $phpcsFile->fixer->addContentBefore($firstKeyword, $tokens[$secondKeyword]['content'] . ' ');
+
+            $phpcsFile->fixer->endChangeset();
+        }
+    }
+}

--- a/Universal/Tests/Constants/ModifierKeywordOrderUnitTest.inc
+++ b/Universal/Tests/Constants/ModifierKeywordOrderUnitTest.inc
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * Not our targets, no keyword possible.
+ * Includes some safeguarding against potential tokenizer issues.
+ */
+namespace Foo\const\bar;
+const NAMESPACED = 123;
+function_call(const: $var);
+class Foo {
+    public function const() {}
+}
+
+/*
+ * OK, no or single keyword, no ordering needed.
+ */
+class NoOrderingNeeded {
+    const NO_MODIFIERS = false;
+
+    public const ONLY_VISIBILITY_PUBLIC = true,
+        SECOND_CONSTANT_USING_SAME_MODIFIERS = true;
+    protected const ONLY_VISIBILITY_PROTECTED = true;
+    private const ONLY_VISIBILITY_PRIVATE = true;
+    final const ONLY_FINAL = true;
+}
+
+/*
+ * OK, expected order with default settings.
+ */
+class CorrectOrderFinalFirst {
+    final public const FINAL_PUBLIC = 'foo';
+
+    #[SomeAttribute]
+    final protected const FINAL_PROTECTED = 'foo';
+
+    // "final private" is an oxymoron (and fatal error), but that's not the concern of this sniff.
+    final /*comment*/ private const FINAL_PRIVATE = 'foo', FINAL_PRIVATE_TOO = 'bar';
+}
+
+/*
+ * Bad with default settings.
+ */
+class IncorrectOrderFinalFirst {
+    public final /*comment*/ const PUBLIC_FINAL = 'foo';
+
+    #[SomeAttribute]
+    Protected Final const PROTECTED_FINAL = 'foo', PROTECTED_FINAL_TOO = 'bar';
+
+    private
+    // comment
+    final
+    // phpcs:ignore Stdn.Cat.SniffName -- for reasons.
+    const PRIVATE_FINAL = 'foo';
+}
+
+
+// phpcs:set Universal.Constants.ModifierKeywordOrder order visibility final
+
+/*
+ * OK, expected order with custom settings.
+ */
+class CorrectOrderFirst {
+    public final const FINAL_PUBLIC = 'foo';
+
+    #[SomeAttribute]
+    protected final const FINAL_PROTECTED = 'foo';
+
+    /**
+     * Docblock.
+     */
+    private final const FINAL_PRIVATE = 'foo', FINAL_PRIVATE_TOO = 'bar';
+}
+
+/*
+ * Bad with custom settings.
+ */
+class IncorrectOrderVisibilityFirst {
+    final /*comment*/ public const PUBLIC_FINAL = 'foo';
+
+    #[SomeAttribute]
+    final protected const PROTECTED_FINAL = 'foo', PROTECTED_FINAL_TOO = 'bar';
+
+    FINAL
+    // comment
+    PRIVATE
+    // phpcs:ignore Stdn.Cat.SniffName -- for reasons.
+    const PRIVATE_FINAL = 'foo';
+}
+
+
+// phpcs:set Universal.Constants.ModifierKeywordOrder order scope final
+
+/*
+ * OK, expected order with invalid settings (default is used).
+ */
+class CorrectOrderUsingDefaultOrderPref {
+    final public const FINAL_PUBLIC = 'foo';
+}
+
+/*
+ * Bad with invalid settings (default is used).
+ */
+class IncorrectOrderUsingDefaultOrderPref {
+    #[SomeAttribute]
+    protected final const PROTECTED_FINAL = 'foo', PROTECTED_FINAL_TOO = 'bar';
+}
+
+// Reset to default.
+// phpcs:set Universal.Constants.ModifierKeywordOrder order final visibility
+
+// Live coding. Ignore as class boundaries cannot be determined yet. This must be the last test in the file.
+class LiveCoding {
+    protected final const

--- a/Universal/Tests/Constants/ModifierKeywordOrderUnitTest.inc.fixed
+++ b/Universal/Tests/Constants/ModifierKeywordOrderUnitTest.inc.fixed
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * Not our targets, no keyword possible.
+ * Includes some safeguarding against potential tokenizer issues.
+ */
+namespace Foo\const\bar;
+const NAMESPACED = 123;
+function_call(const: $var);
+class Foo {
+    public function const() {}
+}
+
+/*
+ * OK, no or single keyword, no ordering needed.
+ */
+class NoOrderingNeeded {
+    const NO_MODIFIERS = false;
+
+    public const ONLY_VISIBILITY_PUBLIC = true,
+        SECOND_CONSTANT_USING_SAME_MODIFIERS = true;
+    protected const ONLY_VISIBILITY_PROTECTED = true;
+    private const ONLY_VISIBILITY_PRIVATE = true;
+    final const ONLY_FINAL = true;
+}
+
+/*
+ * OK, expected order with default settings.
+ */
+class CorrectOrderFinalFirst {
+    final public const FINAL_PUBLIC = 'foo';
+
+    #[SomeAttribute]
+    final protected const FINAL_PROTECTED = 'foo';
+
+    // "final private" is an oxymoron (and fatal error), but that's not the concern of this sniff.
+    final /*comment*/ private const FINAL_PRIVATE = 'foo', FINAL_PRIVATE_TOO = 'bar';
+}
+
+/*
+ * Bad with default settings.
+ */
+class IncorrectOrderFinalFirst {
+    final public /*comment*/ const PUBLIC_FINAL = 'foo';
+
+    #[SomeAttribute]
+    Final Protected const PROTECTED_FINAL = 'foo', PROTECTED_FINAL_TOO = 'bar';
+
+    final private
+    // comment
+    // phpcs:ignore Stdn.Cat.SniffName -- for reasons.
+    const PRIVATE_FINAL = 'foo';
+}
+
+
+// phpcs:set Universal.Constants.ModifierKeywordOrder order visibility final
+
+/*
+ * OK, expected order with custom settings.
+ */
+class CorrectOrderFirst {
+    public final const FINAL_PUBLIC = 'foo';
+
+    #[SomeAttribute]
+    protected final const FINAL_PROTECTED = 'foo';
+
+    /**
+     * Docblock.
+     */
+    private final const FINAL_PRIVATE = 'foo', FINAL_PRIVATE_TOO = 'bar';
+}
+
+/*
+ * Bad with custom settings.
+ */
+class IncorrectOrderVisibilityFirst {
+    public final /*comment*/ const PUBLIC_FINAL = 'foo';
+
+    #[SomeAttribute]
+    protected final const PROTECTED_FINAL = 'foo', PROTECTED_FINAL_TOO = 'bar';
+
+    PRIVATE FINAL
+    // comment
+    // phpcs:ignore Stdn.Cat.SniffName -- for reasons.
+    const PRIVATE_FINAL = 'foo';
+}
+
+
+// phpcs:set Universal.Constants.ModifierKeywordOrder order scope final
+
+/*
+ * OK, expected order with invalid settings (default is used).
+ */
+class CorrectOrderUsingDefaultOrderPref {
+    final public const FINAL_PUBLIC = 'foo';
+}
+
+/*
+ * Bad with invalid settings (default is used).
+ */
+class IncorrectOrderUsingDefaultOrderPref {
+    #[SomeAttribute]
+    final protected const PROTECTED_FINAL = 'foo', PROTECTED_FINAL_TOO = 'bar';
+}
+
+// Reset to default.
+// phpcs:set Universal.Constants.ModifierKeywordOrder order final visibility
+
+// Live coding. Ignore as class boundaries cannot be determined yet. This must be the last test in the file.
+class LiveCoding {
+    protected final const

--- a/Universal/Tests/Constants/ModifierKeywordOrderUnitTest.php
+++ b/Universal/Tests/Constants/ModifierKeywordOrderUnitTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2022 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\Constants;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the Constants\ModifierKeywordOrder sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\Constants\ModifierKeywordOrderSniff
+ *
+ * @since 1.0.0
+ */
+final class ModifierKeywordOrderUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getErrorList()
+    {
+        return [
+            44  => 1,
+            47  => 1,
+            49  => 1,
+            78  => 1,
+            81  => 1,
+            83  => 1,
+            105 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array <int line number> => <int number of warnings>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Sniff to standardize the modifier keyword order for OO constant declarations.

The sniff contains a `public` `$order` property which allows for configuring the preferred order.
Allowed values:
* `'final visibility'` (= default)
* `'visibility final'`

Includes fixer.
Includes unit tests.
Includes documentation.
Includes metrics.

Refs:
* PHP 8.1: https://wiki.php.net/rfc/final_class_const
* PHP 7.1: https://wiki.php.net/rfc/class_const_visibility