### PR TITLE
QA: always declare metric names as class constants

### DIFF
--- a/NormalizedArrays/Sniffs/Arrays/CommaAfterLastSniff.php
+++ b/NormalizedArrays/Sniffs/Arrays/CommaAfterLastSniff.php
@@ -27,6 +27,15 @@ final class CommaAfterLastSniff implements Sniff
 {
 
     /**
+     * Name of the metric.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const METRIC_NAME = '%s array - comma after last item';
+
+    /**
      * Whether or not to enforce a comma after the last array item in a single-line array.
      *
      * Valid values:
@@ -140,7 +149,7 @@ final class CommaAfterLastSniff implements Sniff
 
         $phpcsFile->recordMetric(
             $stackPtr,
-            \ucfirst($phrase) . ' array - comma after last item',
+            \sprintf(self::METRIC_NAME, \ucfirst($phrase)),
             ($isComma === true ? 'yes' : 'no')
         );
 

--- a/Universal/Sniffs/Classes/DisallowAnonClassParenthesesSniff.php
+++ b/Universal/Sniffs/Classes/DisallowAnonClassParenthesesSniff.php
@@ -24,6 +24,15 @@ final class DisallowAnonClassParenthesesSniff implements Sniff
 {
 
     /**
+     * Name of the metric.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const METRIC_NAME = 'Anon class declaration with parenthesis';
+
+    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @since 1.0.0
@@ -57,13 +66,13 @@ final class DisallowAnonClassParenthesesSniff implements Sniff
             || $tokens[$nextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS
         ) {
             // No parentheses found.
-            $phpcsFile->recordMetric($stackPtr, 'Anon class declaration with parenthesis', 'no');
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'no');
             return;
         }
 
         if (isset($tokens[$nextNonEmpty]['parenthesis_closer']) === false) {
             // Incomplete set of parentheses. Ignore.
-            $phpcsFile->recordMetric($stackPtr, 'Anon class declaration with parenthesis', 'yes');
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'yes');
             return;
         }
 
@@ -71,11 +80,11 @@ final class DisallowAnonClassParenthesesSniff implements Sniff
         $hasParams = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonEmpty + 1), $closer, true);
         if ($hasParams !== false) {
             // There is something between the parentheses. Ignore.
-            $phpcsFile->recordMetric($stackPtr, 'Anon class declaration with parenthesis', 'yes, with parameter');
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'yes, with parameter');
             return;
         }
 
-        $phpcsFile->recordMetric($stackPtr, 'Anon class declaration with parenthesis', 'yes');
+        $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'yes');
 
         $fix = $phpcsFile->addFixableError(
             'Parenthesis not allowed when creating a new anonymous class without passing parameters',

--- a/Universal/Sniffs/Classes/DisallowFinalClassSniff.php
+++ b/Universal/Sniffs/Classes/DisallowFinalClassSniff.php
@@ -24,6 +24,15 @@ final class DisallowFinalClassSniff implements Sniff
 {
 
     /**
+     * Name of the metric.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const METRIC_NAME = 'Class declaration type';
+
+    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @since 1.0.0
@@ -53,10 +62,10 @@ final class DisallowFinalClassSniff implements Sniff
         $classProp = ObjectDeclarations::getClassProperties($phpcsFile, $stackPtr);
         if ($classProp['is_final'] === false) {
             if ($classProp['is_abstract'] === true) {
-                $phpcsFile->recordMetric($stackPtr, 'Class declaration type', 'abstract');
+                $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'abstract');
             }
 
-            $phpcsFile->recordMetric($stackPtr, 'Class declaration type', 'not abstract, not final');
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'not abstract, not final');
             return;
         }
 
@@ -66,7 +75,7 @@ final class DisallowFinalClassSniff implements Sniff
             return;
         }
 
-        $phpcsFile->recordMetric($stackPtr, 'Class declaration type', 'final');
+        $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'final');
 
         // No extra safeguards needed, we know the keyword will exist based on the check above.
         $finalKeyword = $phpcsFile->findPrevious(\T_FINAL, ($stackPtr - 1));

--- a/Universal/Sniffs/Classes/RequireAnonClassParenthesesSniff.php
+++ b/Universal/Sniffs/Classes/RequireAnonClassParenthesesSniff.php
@@ -23,6 +23,15 @@ final class RequireAnonClassParenthesesSniff implements Sniff
 {
 
     /**
+     * Name of the metric.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const METRIC_NAME = 'Anon class declaration with parenthesis';
+
+    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @since 1.0.0
@@ -56,11 +65,11 @@ final class RequireAnonClassParenthesesSniff implements Sniff
             && $tokens[$nextNonEmpty]['code'] === \T_OPEN_PARENTHESIS
         ) {
             // Parentheses found.
-            $phpcsFile->recordMetric($stackPtr, 'Anon class declaration with parenthesis', 'yes');
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'yes');
             return;
         }
 
-        $phpcsFile->recordMetric($stackPtr, 'Anon class declaration with parenthesis', 'no');
+        $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'no');
 
         $fix = $phpcsFile->addFixableError(
             'Parenthesis required when creating a new anonymous class.',

--- a/Universal/Sniffs/Classes/RequireFinalClassSniff.php
+++ b/Universal/Sniffs/Classes/RequireFinalClassSniff.php
@@ -24,6 +24,15 @@ final class RequireFinalClassSniff implements Sniff
 {
 
     /**
+     * Name of the metric.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const METRIC_NAME = 'Class declaration type';
+
+    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @since 1.0.0
@@ -52,13 +61,13 @@ final class RequireFinalClassSniff implements Sniff
     {
         $classProp = ObjectDeclarations::getClassProperties($phpcsFile, $stackPtr);
         if ($classProp['is_final'] === true) {
-            $phpcsFile->recordMetric($stackPtr, 'Class declaration type', 'final');
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'final');
             return;
         }
 
         if ($classProp['is_abstract'] === true) {
             // Abstract classes can't be final.
-            $phpcsFile->recordMetric($stackPtr, 'Class declaration type', 'abstract');
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'abstract');
             return;
         }
 
@@ -68,7 +77,7 @@ final class RequireFinalClassSniff implements Sniff
             return;
         }
 
-        $phpcsFile->recordMetric($stackPtr, 'Class declaration type', 'not abstract, not final');
+        $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'not abstract, not final');
 
         $snippet = GetTokensAsString::compact($phpcsFile, $stackPtr, $tokens[$stackPtr]['scope_opener'], true);
         $fix     = $phpcsFile->addFixableError(

--- a/Universal/Sniffs/Constants/LowercaseClassResolutionKeywordSniff.php
+++ b/Universal/Sniffs/Constants/LowercaseClassResolutionKeywordSniff.php
@@ -26,6 +26,15 @@ final class LowercaseClassResolutionKeywordSniff implements Sniff
 {
 
     /**
+     * Name of the metric.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const METRIC_NAME = 'Magic ::class constant case';
+
+    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @since 1.0.0
@@ -66,7 +75,7 @@ final class LowercaseClassResolutionKeywordSniff implements Sniff
         }
 
         if ($contentLC === $content) {
-            $phpcsFile->recordMetric($stackPtr, 'Magic ::class constant case', 'lowercase');
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'lowercase');
             return;
         }
 
@@ -79,10 +88,10 @@ final class LowercaseClassResolutionKeywordSniff implements Sniff
         $errorCode = '';
         if (\strtoupper($content) === $content) {
             $errorCode = 'Uppercase';
-            $phpcsFile->recordMetric($stackPtr, 'Magic ::class constant case', 'uppercase');
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'uppercase');
         } else {
             $errorCode = 'Mixedcase';
-            $phpcsFile->recordMetric($stackPtr, 'Magic ::class constant case', 'mixed case');
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'mixed case');
         }
 
         $fix = $phpcsFile->addFixableError($error, $stackPtr, $errorCode, $data);

--- a/Universal/Sniffs/Constants/UppercaseMagicConstantsSniff.php
+++ b/Universal/Sniffs/Constants/UppercaseMagicConstantsSniff.php
@@ -25,6 +25,15 @@ final class UppercaseMagicConstantsSniff implements Sniff
 {
 
     /**
+     * Name of the metric.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const METRIC_NAME = 'Magic constant case';
+
+    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @since 1.0.0
@@ -53,7 +62,7 @@ final class UppercaseMagicConstantsSniff implements Sniff
         $content   = $tokens[$stackPtr]['content'];
         $contentUC = \strtoupper($content);
         if ($contentUC === $content) {
-            $phpcsFile->recordMetric($stackPtr, 'Magic constant case', 'uppercase');
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'uppercase');
             return;
         }
 
@@ -66,10 +75,10 @@ final class UppercaseMagicConstantsSniff implements Sniff
 
         if (\strtolower($content) === $content) {
             $errorCode = 'Lowercase';
-            $phpcsFile->recordMetric($stackPtr, 'Magic constant case', 'lowercase');
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'lowercase');
         } else {
             $errorCode = 'Mixedcase';
-            $phpcsFile->recordMetric($stackPtr, 'Magic constant case', 'mixed case');
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'mixed case');
         }
 
         $fix = $phpcsFile->addFixableError($error, $stackPtr, $errorCode, $data);

--- a/Universal/Sniffs/ControlStructures/DisallowAlternativeSyntaxSniff.php
+++ b/Universal/Sniffs/ControlStructures/DisallowAlternativeSyntaxSniff.php
@@ -25,6 +25,15 @@ final class DisallowAlternativeSyntaxSniff implements Sniff
 {
 
     /**
+     * Name of the metric.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const METRIC_NAME = 'Control structure style';
+
+    /**
      * Whether to allow the alternative syntax when it is wrapped around
      * inline HTML, as is often seen in views.
      *
@@ -82,7 +91,7 @@ final class DisallowAlternativeSyntaxSniff implements Sniff
          */
         if (isset($tokens[$stackPtr]['scope_opener'], $tokens[$stackPtr]['scope_closer']) === false) {
             // No scope opener found: inline control structure or parse error.
-            $phpcsFile->recordMetric($stackPtr, 'Control structure style', 'inline');
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'inline');
             return;
         }
 
@@ -91,7 +100,7 @@ final class DisallowAlternativeSyntaxSniff implements Sniff
 
         if ($tokens[$opener]['code'] !== \T_COLON) {
             // Curly brace syntax (not our concern).
-            $phpcsFile->recordMetric($stackPtr, 'Control structure style', 'curly braces');
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'curly braces');
             return;
         }
 
@@ -102,9 +111,9 @@ final class DisallowAlternativeSyntaxSniff implements Sniff
         );
 
         if ($hasInlineHTML !== false) {
-            $phpcsFile->recordMetric($stackPtr, 'Control structure style', 'alternative syntax with inline HTML');
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'alternative syntax with inline HTML');
         } else {
-            $phpcsFile->recordMetric($stackPtr, 'Control structure style', 'alternative syntax');
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'alternative syntax');
         }
 
         if ($hasInlineHTML !== false && $this->allowWithInlineHTML === true) {

--- a/Universal/Sniffs/ControlStructures/IfElseDeclarationSniff.php
+++ b/Universal/Sniffs/ControlStructures/IfElseDeclarationSniff.php
@@ -32,6 +32,15 @@ final class IfElseDeclarationSniff implements Sniff
 {
 
     /**
+     * Name of the metric.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const METRIC_NAME = 'Else(if) on a new line';
+
+    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @since 1.0.0
@@ -90,11 +99,11 @@ final class IfElseDeclarationSniff implements Sniff
         }
 
         if ($tokens[$prevNonEmpty]['line'] !== $tokens[$stackPtr]['line']) {
-            $phpcsFile->recordMetric($stackPtr, 'Else(if) on a new line', 'yes');
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'yes');
             return;
         }
 
-        $phpcsFile->recordMetric($stackPtr, 'Else(if) on a new line', 'no');
+        $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'no');
 
         $errorBase = \strtoupper($tokens[$stackPtr]['content']);
         $error     = $errorBase . ' statement must be on a new line.';

--- a/Universal/Sniffs/Files/SeparateFunctionsFromOOSniff.php
+++ b/Universal/Sniffs/Files/SeparateFunctionsFromOOSniff.php
@@ -34,6 +34,15 @@ final class SeparateFunctionsFromOOSniff implements Sniff
 {
 
     /**
+     * Name of the metric.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const METRIC_NAME = 'Functions or OO declarations ?';
+
+    /**
      * Tokens this sniff searches for.
      *
      * Enhanced from within the register() methods.
@@ -148,7 +157,7 @@ final class SeparateFunctionsFromOOSniff implements Sniff
         }
 
         if ($functionCount > 0 && $OOCount > 0) {
-            $phpcsFile->recordMetric($stackPtr, 'Functions or OO declarations ?', 'Both function and OO declarations');
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'Both function and OO declarations');
 
             $reportToken = \max($firstFunction, $firstOO);
 
@@ -167,11 +176,11 @@ final class SeparateFunctionsFromOOSniff implements Sniff
                 ]
             );
         } elseif ($functionCount > 0) {
-            $phpcsFile->recordMetric($stackPtr, 'Functions or OO declarations ?', 'Only function(s)');
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'Only function(s)');
         } elseif ($OOCount > 0) {
-            $phpcsFile->recordMetric($stackPtr, 'Functions or OO declarations ?', 'Only OO structure(s)');
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'Only OO structure(s)');
         } else {
-            $phpcsFile->recordMetric($stackPtr, 'Functions or OO declarations ?', 'Neither');
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'Neither');
         }
 
         // Ignore the rest of the file.

--- a/Universal/Sniffs/Namespaces/DisallowCurlyBraceSyntaxSniff.php
+++ b/Universal/Sniffs/Namespaces/DisallowCurlyBraceSyntaxSniff.php
@@ -23,6 +23,15 @@ final class DisallowCurlyBraceSyntaxSniff implements Sniff
 {
 
     /**
+     * Name of the metric.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const METRIC_NAME = 'Namespace declaration using curly brace syntax';
+
+    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @since 1.0.0
@@ -57,11 +66,11 @@ final class DisallowCurlyBraceSyntaxSniff implements Sniff
         if (isset($tokens[$stackPtr]['scope_condition']) === false
             || $tokens[$stackPtr]['scope_condition'] !== $stackPtr
         ) {
-            $phpcsFile->recordMetric($stackPtr, 'Namespace declaration using curly brace syntax', 'no');
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'no');
             return;
         }
 
-        $phpcsFile->recordMetric($stackPtr, 'Namespace declaration using curly brace syntax', 'yes');
+        $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'yes');
 
         $phpcsFile->addError(
             'Namespace declarations using the curly brace syntax are not allowed.',

--- a/Universal/Sniffs/Namespaces/EnforceCurlyBraceSyntaxSniff.php
+++ b/Universal/Sniffs/Namespaces/EnforceCurlyBraceSyntaxSniff.php
@@ -23,6 +23,15 @@ final class EnforceCurlyBraceSyntaxSniff implements Sniff
 {
 
     /**
+     * Name of the metric.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const METRIC_NAME = 'Namespace declaration using curly brace syntax';
+
+    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @since 1.0.0
@@ -57,11 +66,11 @@ final class EnforceCurlyBraceSyntaxSniff implements Sniff
         if (isset($tokens[$stackPtr]['scope_condition']) === true
             && $tokens[$stackPtr]['scope_condition'] === $stackPtr
         ) {
-            $phpcsFile->recordMetric($stackPtr, 'Namespace declaration using curly brace syntax', 'yes');
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'yes');
             return;
         }
 
-        $phpcsFile->recordMetric($stackPtr, 'Namespace declaration using curly brace syntax', 'no');
+        $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'no');
 
         $phpcsFile->addError(
             'Namespace declarations without curly braces are not allowed.',

--- a/Universal/Sniffs/Operators/DisallowLogicalAndOrSniff.php
+++ b/Universal/Sniffs/Operators/DisallowLogicalAndOrSniff.php
@@ -26,6 +26,15 @@ final class DisallowLogicalAndOrSniff implements Sniff
 {
 
     /**
+     * Name of the metric.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const METRIC_NAME = 'Type of and/or operator used';
+
+    /**
      * The tokens this sniff records metrics for.
      *
      * @since 1.0.0
@@ -85,7 +94,7 @@ final class DisallowLogicalAndOrSniff implements Sniff
         $tokens    = $phpcsFile->getTokens();
         $tokenCode = $tokens[$stackPtr]['code'];
 
-        $phpcsFile->recordMetric($stackPtr, 'Type of and/or operator used', $this->metricType[$tokenCode]);
+        $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, $this->metricType[$tokenCode]);
 
         if (isset($this->targetTokenInfo[$tokenCode]) === false) {
             // Already using boolean operator.

--- a/Universal/Sniffs/Operators/DisallowShortTernarySniff.php
+++ b/Universal/Sniffs/Operators/DisallowShortTernarySniff.php
@@ -27,6 +27,15 @@ final class DisallowShortTernarySniff implements Sniff
 {
 
     /**
+     * Name of the metric.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const METRIC_NAME = 'Ternary usage';
+
+    /**
      * Registers the tokens that this sniff wants to listen for.
      *
      * @since 1.0.0
@@ -52,11 +61,11 @@ final class DisallowShortTernarySniff implements Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         if (Operators::isShortTernary($phpcsFile, $stackPtr) === false) {
-            $phpcsFile->recordMetric($stackPtr, 'Ternary usage', 'long');
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'long');
             return;
         }
 
-        $phpcsFile->recordMetric($stackPtr, 'Ternary usage', 'short');
+        $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'short');
 
         $phpcsFile->addError(
             'Using short ternaries is not allowed as they are rarely used correctly',

--- a/Universal/Sniffs/Operators/DisallowStandalonePostIncrementDecrementSniff.php
+++ b/Universal/Sniffs/Operators/DisallowStandalonePostIncrementDecrementSniff.php
@@ -32,6 +32,15 @@ final class DisallowStandalonePostIncrementDecrementSniff implements Sniff
 {
 
     /**
+     * Name of the metric.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const METRIC_NAME = 'In/decrement usage in stand-alone statements';
+
+    /**
      * Tokens which can be expected in a stand-alone in/decrement statement.
      *
      * {@internal This array is enriched in the register() method.}
@@ -146,7 +155,7 @@ final class DisallowStandalonePostIncrementDecrementSniff implements Sniff
         $lastNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($end - 1), $start, true);
         if ($start === $stackPtr && $lastNonEmpty !== $stackPtr) {
             // This is already pre-in/decrement.
-            $phpcsFile->recordMetric($stackPtr, 'In/decrement usage in stand-alone statements', 'pre-' . $type);
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'pre-' . $type);
             return $end;
         }
 
@@ -155,7 +164,7 @@ final class DisallowStandalonePostIncrementDecrementSniff implements Sniff
             return $end;
         }
 
-        $phpcsFile->recordMetric($stackPtr, 'In/decrement usage in stand-alone statements', 'post-' . $type);
+        $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'post-' . $type);
 
         $error        = 'Stand-alone post-%1$s statement found. Use pre-%1$s instead: %2$s.';
         $errorCode    = 'Post' . \ucfirst($type) . 'Found';

--- a/Universal/Sniffs/Operators/StrictComparisonsSniff.php
+++ b/Universal/Sniffs/Operators/StrictComparisonsSniff.php
@@ -25,6 +25,15 @@ final class StrictComparisonsSniff implements Sniff
 {
 
     /**
+     * Name of the metric.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const METRIC_NAME = 'Type of comparison used';
+
+    /**
      * The tokens this sniff records metrics for.
      *
      * @since 1.0.0
@@ -84,7 +93,7 @@ final class StrictComparisonsSniff implements Sniff
         $tokens    = $phpcsFile->getTokens();
         $tokenCode = $tokens[$stackPtr]['code'];
 
-        $phpcsFile->recordMetric($stackPtr, 'Type of comparison used', $this->metricType[$tokenCode]);
+        $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, $this->metricType[$tokenCode]);
 
         if (isset($this->targetTokenInfo[$tokenCode]) === false) {
             // Already using strict comparison operator.


### PR DESCRIPTION
... to reduce the risk of metrics not recording correctly due to typos in one of the instances recording the metrics.

Note: the metrics in the "Disallow short/long list" sniffs will be addressed separately.