### PR TITLE
Universal/ConstructorDestructorReturn: improve return type fixer

### DIFF
--- a/Universal/Sniffs/CodeAnalysis/ConstructorDestructorReturnSniff.php
+++ b/Universal/Sniffs/CodeAnalysis/ConstructorDestructorReturnSniff.php
@@ -107,6 +107,11 @@ final class ConstructorDestructorReturnSniff implements Sniff
 
                 $parensCloser = $tokens[$stackPtr]['parenthesis_closer'];
                 for ($i = ($parensCloser + 1); $i <= $properties['return_type_end_token']; $i++) {
+                    if (isset(Tokens::$commentTokens[$tokens[$i]['code']])) {
+                        // Ignore comments and leave them be.
+                        continue;
+                    }
+
                     $phpcsFile->fixer->replaceToken($i, '');
                 }
 

--- a/Universal/Tests/CodeAnalysis/ConstructorDestructorReturnUnitTest.inc
+++ b/Universal/Tests/CodeAnalysis/ConstructorDestructorReturnUnitTest.inc
@@ -119,7 +119,7 @@ trait AbstractConstructorDestructorReturnTypes {
 }
 
 interface InterfaceMethodReturnTypes {
-    public function __construct(): void;
+    public function __construct(): /*comment*/ void;
 
     public function __destruct(): void;
 }

--- a/Universal/Tests/CodeAnalysis/ConstructorDestructorReturnUnitTest.inc.fixed
+++ b/Universal/Tests/CodeAnalysis/ConstructorDestructorReturnUnitTest.inc.fixed
@@ -118,7 +118,7 @@ trait AbstractConstructorDestructorReturnTypes {
 }
 
 interface InterfaceMethodReturnTypes {
-    public function __construct();
+    public function __construct()/*comment*/;
 
     public function __destruct();
 }


### PR DESCRIPTION
... to prevent it from removing comments.

Includes adjusting a pre-existing test to cover the change.