### PR TITLE
Universal/OneStatementInShortEchoTag: improve error code

### DIFF
--- a/Universal/Sniffs/PHP/OneStatementInShortEchoTagSniff.php
+++ b/Universal/Sniffs/PHP/OneStatementInShortEchoTagSniff.php
@@ -75,7 +75,7 @@ final class OneStatementInShortEchoTagSniff implements Sniff
             'Only one statement is allowed when using short open echo PHP tags.'
                 . ' Use the "<?php" open tag for multi-statement PHP.',
             $nextNonEmpty,
-            'Found'
+            'MultipleFound'
         );
 
         if ($fix === true) {


### PR DESCRIPTION
As the name of the sniff is `OneStatementInShortEchoTag`, "Found" would imply that one statement was found, while in actual fact the sniff throws an error when _multiple_ statements are found.