### PR TITLE
Universal/[Require/Disallow]FinalClass: docs/test update for readonly classes

### DIFF
--- a/Universal/Sniffs/Classes/DisallowFinalClassSniff.php
+++ b/Universal/Sniffs/Classes/DisallowFinalClassSniff.php
@@ -30,7 +30,7 @@ final class DisallowFinalClassSniff implements Sniff
      *
      * @var string
      */
-    const METRIC_NAME = 'Class declaration type';
+    const METRIC_NAME = 'Class is abstract or final ?';
 
     /**
      * Returns an array of tokens this test wants to listen for.

--- a/Universal/Sniffs/Classes/RequireFinalClassSniff.php
+++ b/Universal/Sniffs/Classes/RequireFinalClassSniff.php
@@ -30,7 +30,7 @@ final class RequireFinalClassSniff implements Sniff
      *
      * @var string
      */
-    const METRIC_NAME = 'Class declaration type';
+    const METRIC_NAME = 'Class is abstract or final ?';
 
     /**
      * Returns an array of tokens this test wants to listen for.

--- a/Universal/Tests/Classes/DisallowFinalClassUnitTest.inc
+++ b/Universal/Tests/Classes/DisallowFinalClassUnitTest.inc
@@ -32,6 +32,11 @@ final
 
 final /*comment*/ class BazC implements MyInterface {}
 
+// Test fixer when combined with PHP 8.2 "readonly" modifier.
+readonly final class BazD {}
+
+final readonly class BazE {}
+
 // Parse error. Remove the final keyword.
 final abstract class BazD {}
 

--- a/Universal/Tests/Classes/DisallowFinalClassUnitTest.inc.fixed
+++ b/Universal/Tests/Classes/DisallowFinalClassUnitTest.inc.fixed
@@ -30,6 +30,11 @@ class CheckHandlingOfSuperfluousWhitespace extends Something {}
 
 /*comment*/ class BazC implements MyInterface {}
 
+// Test fixer when combined with PHP 8.2 "readonly" modifier.
+readonly class BazD {}
+
+readonly class BazE {}
+
 // Parse error. Remove the final keyword.
 abstract class BazD {}
 

--- a/Universal/Tests/Classes/DisallowFinalClassUnitTest.php
+++ b/Universal/Tests/Classes/DisallowFinalClassUnitTest.php
@@ -35,6 +35,8 @@ final class DisallowFinalClassUnitTest extends AbstractSniffUnitTest
             31 => 1,
             33 => 1,
             36 => 1,
+            38 => 1,
+            41 => 1,
         ];
     }
 

--- a/Universal/Tests/Classes/RequireFinalClassUnitTest.inc
+++ b/Universal/Tests/Classes/RequireFinalClassUnitTest.inc
@@ -27,5 +27,7 @@ class BazA {}
 
 class BazC implements MyInterface {}
 
+readonly class BazD {}
+
 // Live coding. Ignore. This must be the last test in the file.
 class LiveCoding

--- a/Universal/Tests/Classes/RequireFinalClassUnitTest.inc.fixed
+++ b/Universal/Tests/Classes/RequireFinalClassUnitTest.inc.fixed
@@ -27,5 +27,7 @@ final class BazA {}
 
 final class BazC implements MyInterface {}
 
+readonly final class BazD {}
+
 // Live coding. Ignore. This must be the last test in the file.
 class LiveCoding

--- a/Universal/Tests/Classes/RequireFinalClassUnitTest.php
+++ b/Universal/Tests/Classes/RequireFinalClassUnitTest.php
@@ -33,6 +33,7 @@ final class RequireFinalClassUnitTest extends AbstractSniffUnitTest
             24 => 1,
             26 => 1,
             28 => 1,
+            30 => 1,
         ];
     }
 


### PR DESCRIPTION
### Universal/[Require/Disallow]FinalClass: rename metric

What with PHP 8.2 introducing `readonly` classes, the metric name `Class declaration type` would become ambiguous as `readonly` is not taken into account for the metric (and doesn't need to be as it doesn't have a direct relationship to `abstract`/`final`).

To prevent confusion about what the metric records, the metric name has been updated.

### Universal/[Require/Disallow]FinalClass: add tests with readonly classes

... to ensure the fixer continues to work correctly when the class is also `readonly`.