### PR TITLE
Universal/AlphabeticExtendsImplements: docs/test update for enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Disallow the use of multiple namespaces within a file.
 
 #### `Universal.OOStructures.AlphabeticExtendsImplements` :wrench: :bar_chart: :books:
 
-Enforce that the names used in a class "implements" statement or an interface "extends" statement are listed in alphabetic order.
+Enforce that the names used in a class/enum "implements" statement or an interface "extends" statement are listed in alphabetic order.
 
 * This sniff contains a `orderby` property to determine the sort order to use for the statement.
     If all names used are unqualified, the sort order won't make a difference.

--- a/Universal/Sniffs/OOStructures/AlphabeticExtendsImplementsSniff.php
+++ b/Universal/Sniffs/OOStructures/AlphabeticExtendsImplementsSniff.php
@@ -17,7 +17,7 @@ use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\ObjectDeclarations;
 
 /**
- * Verifies that the names used in a class "implements" statement or an interface "extends" statement
+ * Verifies that the interface names used in a class/enum "implements" statement or an interface "extends" statement,
  * are listed in alphabetic order.
  *
  * @since 1.0.0
@@ -32,7 +32,7 @@ final class AlphabeticExtendsImplementsSniff implements Sniff
      *
      * @var string
      */
-    const METRIC_NAME_ALPHA = 'Interface names in implements/extends order alphabetically (%s)';
+    const METRIC_NAME_ALPHA = 'Interface names in implements/extends ordered alphabetically (%s)';
 
     /**
      * Name of the "interface count" metric.
@@ -129,7 +129,7 @@ final class AlphabeticExtendsImplementsSniff implements Sniff
         }
 
         if (\is_array($names) === false) {
-            // Class/interface doesn't extend or implement.
+            // Class/interface/enum doesn't extend or implement.
             $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME_COUNT, 0);
             $phpcsFile->recordMetric($stackPtr, $metricNameAlpha, 'n/a');
             return;

--- a/Universal/Tests/OOStructures/AlphabeticExtendsImplementsUnitTest.inc
+++ b/Universal/Tests/OOStructures/AlphabeticExtendsImplementsUnitTest.inc
@@ -75,6 +75,11 @@ class WithComments implements
 // Reset to default.
 // phpcs:set Universal.OOStructures.AlphabeticExtendsImplements orderby name
 
+enum Suit implements ArrayAccess, Colorful {} // OK.
+
+enum Suit: string implements Colorful, ArrayAccess {}
+
+
 // Test parse error/live coding.
 // Intentional parse error. This has to be the last test in the file.
 class Unfinished extends

--- a/Universal/Tests/OOStructures/AlphabeticExtendsImplementsUnitTest.inc.fixed
+++ b/Universal/Tests/OOStructures/AlphabeticExtendsImplementsUnitTest.inc.fixed
@@ -72,6 +72,11 @@ class WithComments implements
 // Reset to default.
 // phpcs:set Universal.OOStructures.AlphabeticExtendsImplements orderby name
 
+enum Suit implements ArrayAccess, Colorful {} // OK.
+
+enum Suit: string implements ArrayAccess, Colorful {}
+
+
 // Test parse error/live coding.
 // Intentional parse error. This has to be the last test in the file.
 class Unfinished extends

--- a/Universal/Tests/OOStructures/AlphabeticExtendsImplementsUnitTest.php
+++ b/Universal/Tests/OOStructures/AlphabeticExtendsImplementsUnitTest.php
@@ -41,6 +41,7 @@ final class AlphabeticExtendsImplementsUnitTest extends AbstractSniffUnitTest
             54 => 1,
             62 => 1,
             68 => 1,
+            80 => 1,
         ];
     }
 


### PR DESCRIPTION
This commit adds tests confirming that `enum ... implements ...` statements are handled correctly by the sniff.

Additionally, it updates the documentation to include `enum`s and makes a minor grammar fix to one of the metric names.