### PR TITLE
Universal/DisallowShortListSyntax: allow for tokenizer issue in PHPCS 3.7.1

### DIFF
--- a/Universal/Sniffs/Lists/DisallowShortListSyntaxSniff.php
+++ b/Universal/Sniffs/Lists/DisallowShortListSyntaxSniff.php
@@ -12,6 +12,7 @@ namespace PHPCSExtra\Universal\Sniffs\Lists;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Lists;
 
 /**
@@ -31,7 +32,7 @@ final class DisallowShortListSyntaxSniff implements Sniff
      */
     public function register()
     {
-        return [\T_OPEN_SHORT_ARRAY];
+        return Collections::shortArrayListOpenTokensBC();
     }
 
     /**

--- a/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.inc
+++ b/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.inc
@@ -19,5 +19,10 @@ list($a, list($b, $c, $d)) = $array;
     ],
 ] = $array;
 
+// Test for a specific tokenizer issue which still exists in PHPCS 3.7.1 (fixed in 3.7.2).
+if ( true )
+    [ $a ] = [ 'hi' ];
+return $a ?? '';
+
 // Intentional parse error. This has to be the last test in the file.
 [ $a, $b

--- a/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.inc.fixed
+++ b/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.inc.fixed
@@ -19,5 +19,10 @@ list(
     ),
 ) = $array;
 
+// Test for a specific tokenizer issue which still exists in PHPCS 3.7.1 (fixed in 3.7.2).
+if ( true )
+    list( $a ) = [ 'hi' ];
+return $a ?? '';
+
 // Intentional parse error. This has to be the last test in the file.
 [ $a, $b

--- a/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.php
+++ b/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.php
@@ -38,6 +38,7 @@ final class DisallowShortListSyntaxUnitTest extends AbstractSniffUnitTest
             12 => 2,
             13 => 1,
             15 => 1,
+            24 => 1,
         ];
     }
 


### PR DESCRIPTION
... which was fixed in 3.7.2.

The utility methods used from PHPCSUtils 1.0.0-alpha4 already take this into account, so this should be handled without problems.

Includes test.

Ref:
* squizlabs/PHP_CodeSniffer#3632
* PHPCSStandards/PHPCSUtils#392