### PR TITLE
Universal/DisallowShortListSyntax: bug fix - don't skip over nested brackets

### DIFF
--- a/Universal/Sniffs/Lists/DisallowShortListSyntaxSniff.php
+++ b/Universal/Sniffs/Lists/DisallowShortListSyntaxSniff.php
@@ -53,11 +53,6 @@ final class DisallowShortListSyntaxSniff implements Sniff
 
         if ($openClose === false) {
             // Not a short list, live coding or parse error.
-            if (isset($tokens[$stackPtr]['bracket_closer']) === true) {
-                // No need to examine nested subs of this short array/array access.
-                return $tokens[$stackPtr]['bracket_closer'];
-            }
-
             return;
         }
 

--- a/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.inc
+++ b/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.inc
@@ -24,5 +24,10 @@ if ( true )
     [ $a ] = [ 'hi' ];
 return $a ?? '';
 
+// Short list in short array.
+$array = [
+    'key' => [$a, $b] = $args,
+];
+
 // Intentional parse error. This has to be the last test in the file.
 [ $a, $b

--- a/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.inc.fixed
+++ b/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.inc.fixed
@@ -24,5 +24,10 @@ if ( true )
     list( $a ) = [ 'hi' ];
 return $a ?? '';
 
+// Short list in short array.
+$array = [
+    'key' => list($a, $b) = $args,
+];
+
 // Intentional parse error. This has to be the last test in the file.
 [ $a, $b

--- a/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.php
+++ b/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.php
@@ -39,6 +39,7 @@ final class DisallowShortListSyntaxUnitTest extends AbstractSniffUnitTest
             13 => 1,
             15 => 1,
             24 => 1,
+            29 => 1,
         ];
     }
 


### PR DESCRIPTION
... as short arrays can contain short lists and those still need to be examined.

Includes test to safeguard this.