### PR TITLE
Universal/DisallowShortArraySyntax: don't skip over short lists

### DIFF
--- a/Universal/Sniffs/Arrays/DisallowShortArraySyntaxSniff.php
+++ b/Universal/Sniffs/Arrays/DisallowShortArraySyntaxSniff.php
@@ -57,8 +57,7 @@ final class DisallowShortArraySyntaxSniff implements Sniff
         $tokens = $phpcsFile->getTokens();
 
         if (Arrays::isShortArray($phpcsFile, $stackPtr) === false) {
-            // No need to examine nested subs of this short list.
-            return $tokens[$stackPtr]['bracket_closer'];
+            return;
         }
 
         $error = 'Short array syntax is not allowed';

--- a/Universal/Tests/Arrays/DisallowShortArraySyntaxUnitTest.inc
+++ b/Universal/Tests/Arrays/DisallowShortArraySyntaxUnitTest.inc
@@ -14,3 +14,6 @@ $foo = [
 
 // Short list, not short array.
 [$a, [$b]] = $array;
+
+// Short array in short list. Short list should be left untouched, short array should be fixed.
+['key' => $a, ['key'] => $b] = $array;

--- a/Universal/Tests/Arrays/DisallowShortArraySyntaxUnitTest.inc.fixed
+++ b/Universal/Tests/Arrays/DisallowShortArraySyntaxUnitTest.inc.fixed
@@ -14,3 +14,6 @@ $foo = array(
 
 // Short list, not short array.
 [$a, [$b]] = $array;
+
+// Short array in short list. Short list should be left untouched, short array should be fixed.
+['key' => $a, array('key') => $b] = $array;

--- a/Universal/Tests/Arrays/DisallowShortArraySyntaxUnitTest.php
+++ b/Universal/Tests/Arrays/DisallowShortArraySyntaxUnitTest.php
@@ -38,6 +38,7 @@ final class DisallowShortArraySyntaxUnitTest extends AbstractSniffUnitTest
             8  => 1,
             9  => 1,
             11 => 1,
+            19 => 1,
         ];
     }
 


### PR DESCRIPTION
... as for some unfanthomable reason (short) arrays can be used as keys for short lists and if so, those should still be found and fixed.

Includes test to safeguard this.