### PR TITLE
Universal/Disallow[Long|Short]ListSyntax: improve metrics

### DIFF
--- a/Universal/Sniffs/Lists/DisallowLongListSyntaxSniff.php
+++ b/Universal/Sniffs/Lists/DisallowLongListSyntaxSniff.php
@@ -53,8 +53,6 @@ final class DisallowLongListSyntaxSniff implements Sniff
             return;
         }
 
-        $phpcsFile->recordMetric($stackPtr, 'Short list syntax used', 'no');
-
         $fix = $phpcsFile->addFixableError('Long list syntax is not allowed', $stackPtr, 'Found');
 
         if ($fix === true) {


### PR DESCRIPTION
### Universal/DisallowLongListSyntax: don't record metrics

... as recording just and only the `no` is not a useful metric and adding the logic to also record the `yes` would severely impact the performance of the sniff.

### Universal/DisallowShortListSyntax: improve metric recording

Record both the `yes` as well as the `no`, which makes the metric feature complete.