### PR TITLE
Universal/DisallowAlternativeSyntax: improve error message

### DIFF
--- a/Universal/Sniffs/ControlStructures/DisallowAlternativeSyntaxSniff.php
+++ b/Universal/Sniffs/ControlStructures/DisallowAlternativeSyntaxSniff.php
@@ -124,11 +124,11 @@ final class DisallowAlternativeSyntaxSniff implements Sniff
             return;
         }
 
-        $error = 'Using control structures with the alternative syntax - %1$s(): ... end%1$s; - is not allowed';
+        $error = 'Using control structures with the alternative syntax is not allowed';
         if ($this->allowWithInlineHTML === true) {
             $error .= ' unless the control structure contains inline HTML';
         }
-        $error .= '.';
+        $error .= '. Found: %1$s(): ... end%1$s;';
 
         $code = 'Found' . \ucfirst($tokens[$stackPtr]['content']);
         $data = [$tokens[$stackPtr]['content']];

--- a/Universal/Sniffs/ControlStructures/DisallowAlternativeSyntaxSniff.php
+++ b/Universal/Sniffs/ControlStructures/DisallowAlternativeSyntaxSniff.php
@@ -131,14 +131,13 @@ final class DisallowAlternativeSyntaxSniff implements Sniff
         $error .= '. Found: %1$s(): ... end%1$s;';
 
         $code = 'Found' . \ucfirst($tokens[$stackPtr]['content']);
-        $data = [$tokens[$stackPtr]['content']];
-
-        if ($tokens[$stackPtr]['code'] === \T_ELSEIF || $tokens[$stackPtr]['code'] === \T_ELSE) {
-            $data = ['if'];
-        }
-
         if ($hasInlineHTML !== false) {
             $code .= 'WithInlineHTML';
+        }
+
+        $data = [$tokens[$stackPtr]['content']];
+        if ($tokens[$stackPtr]['code'] === \T_ELSEIF || $tokens[$stackPtr]['code'] === \T_ELSE) {
+            $data = ['if'];
         }
 
         $fix = $phpcsFile->addFixableError($error, $tokens[$stackPtr]['scope_opener'], $code, $data);

--- a/Universal/Sniffs/ControlStructures/DisallowAlternativeSyntaxSniff.php
+++ b/Universal/Sniffs/ControlStructures/DisallowAlternativeSyntaxSniff.php
@@ -124,9 +124,15 @@ final class DisallowAlternativeSyntaxSniff implements Sniff
             return;
         }
 
-        $error = 'Using control structures with the alternative syntax - %1$s(): ... end%1$s; - is not allowed.';
-        $code  = 'Found' . \ucfirst($tokens[$stackPtr]['content']);
-        $data  = [$tokens[$stackPtr]['content']];
+        $error = 'Using control structures with the alternative syntax - %1$s(): ... end%1$s; - is not allowed';
+        if ($this->allowWithInlineHTML === true) {
+            $error .= ' unless the control structure contains inline HTML';
+        }
+        $error .= '.';
+
+        $code = 'Found' . \ucfirst($tokens[$stackPtr]['content']);
+        $data = [$tokens[$stackPtr]['content']];
+
         if ($tokens[$stackPtr]['code'] === \T_ELSEIF || $tokens[$stackPtr]['code'] === \T_ELSE) {
             $data = ['if'];
         }


### PR DESCRIPTION
### Universal/DisallowAlternativeSyntax: improve the error message [1]

When the `$allowWithInlineHTML` property is set to `true`, the error message could be regarded as confusing and lead to (unfounded) bug reports as the error message doesn't indicate that alternative control structures, in that case, are still allowed in combination with inline HTML.

This commit adjusts the error message based on the `$allowWithInlineHTML` property to be more descriptive.

### Universal/DisallowAlternativeSyntax: improve the error message [2]

Improve the readability of the error message by moving the variable part to the end of the message.

### Universal/DisallowAlternativeSyntax: minor tweak

Group the setting of the `$code` and `$data` variables for the error message with the conditions which may adjust their value.