### PR TITLE
Universal/DisallowAlternativeSyntax: bug fix - ignore inline HTML in nested closed scopes

### DIFF
--- a/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.inc
+++ b/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.inc
@@ -222,6 +222,45 @@ A is something else
 <?php enddeclare; ?>
 
 <?php
+/*
+ * Tests specifically for the "has inline HTML ?" determination to make sure inline HTML
+ * in nested closed scopes is ignored.
+ */
+if (true):
+    echo 'no inline HTML';
+    ?><?php
+    echo 'between close and open tag';
+endif;
+
+if (!class_exists('Foo')) :
+    class Foo {
+        // Long piece of code
+        function bar() {
+            ?>
+            Inline HTML in closed scopes should be disregarded.
+            <?php
+        }
+    }
+endif;
+
+switch ($foo) :
+    case 1:
+        $closure = function () {
+            ?>
+            Inline HTML in closed scopes should be disregarded.
+            <?php
+        };
+        break;
+endswitch;
+
+declare (ticks = 1):
+    function showTicks() {
+        ?>
+        Inline HTML in closed scopes should be disregarded.
+        <?php
+    }
+enddeclare;
+
 // phpcs:set Universal.ControlStructures.DisallowAlternativeSyntax allowWithInlineHTML false
 
 // Live coding.

--- a/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.inc.fixed
+++ b/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.inc.fixed
@@ -222,6 +222,45 @@ A is something else
 <?php enddeclare; ?>
 
 <?php
+/*
+ * Tests specifically for the "has inline HTML ?" determination to make sure inline HTML
+ * in nested closed scopes is ignored.
+ */
+if (true){
+    echo 'no inline HTML';
+    ?><?php
+    echo 'between close and open tag';
+}
+
+if (!class_exists('Foo')) {
+    class Foo {
+        // Long piece of code
+        function bar() {
+            ?>
+            Inline HTML in closed scopes should be disregarded.
+            <?php
+        }
+    }
+}
+
+switch ($foo) {
+    case 1:
+        $closure = function () {
+            ?>
+            Inline HTML in closed scopes should be disregarded.
+            <?php
+        };
+        break;
+}
+
+declare (ticks = 1){
+    function showTicks() {
+        ?>
+        Inline HTML in closed scopes should be disregarded.
+        <?php
+    }
+}
+
 // phpcs:set Universal.ControlStructures.DisallowAlternativeSyntax allowWithInlineHTML false
 
 // Live coding.

--- a/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.php
+++ b/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.php
@@ -54,6 +54,10 @@ final class DisallowAlternativeSyntaxUnitTest extends AbstractSniffUnitTest
             172 => 1,
             176 => 1,
             185 => 1,
+            229 => 1,
+            235 => 1,
+            246 => 1,
+            256 => 1,
         ];
     }
 


### PR DESCRIPTION
... as the HTML in that case is not necessarily echo-ed out when the control structure is executed, but rather is executed when the function in the nested closed scope is called and executed, so the inline HTML does not "belong" with the control structure.

This should also potentially improve performance of the sniff when large chunks of code without inline HTML are wrapped within a control structure.

Includes tests.