### PR TITLE
Universal/DisallowAlternativeSyntax: bug fix - handle if/elseif statements in one go

### DIFF
--- a/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.1.inc
+++ b/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.1.inc
@@ -147,6 +147,16 @@ A is something else
 <?php enddeclare; ?>
 
 <?php
+// Test handling if/else structures in one go.
+if ($a == 5): ?>
+Inline HTML in the if, but nowhere else.
+<?php
+elseif ($a == 7):
+    echo 'no HTML here, but that\'s okay';
+else:
+    echo 'no HTML here, but that\'s okay';
+endif;
+
 // phpcs:set Universal.ControlStructures.DisallowAlternativeSyntax allowWithInlineHTML true
 
 /*
@@ -260,6 +270,94 @@ declare (ticks = 1):
         <?php
     }
 enddeclare;
+
+/*
+ * Test: you can't mix alternative syntax with curlies, so if one part of the statement has HTML, ignore the rest.
+ * This only really comes into play with if/elseif/else as that's the only potentially multi-part control structure
+ * which allows for alternative syntax.
+ */
+if ($a == 5):
+    echo 'no HTML here';
+elseif ($a == 7):
+    echo 'no HTML here';
+else:
+    echo 'no HTML here';
+endif;
+
+if ($a == 5): ?>
+Inline HTML in the if, but nowhere else.
+<?php
+elseif ($a == 7):
+    echo 'no HTML here, but that\'s okay';
+else:
+    echo 'no HTML here, but that\'s okay';
+endif;
+
+if ($a == 5):
+    echo 'no HTML here, but that\'s okay';
+elseif ($a == 7): ?>
+Inline HTML in the elseif, but nowhere else.
+<?php
+else:
+    echo 'no HTML here, but that\'s okay';
+endif;
+
+if ($a == 5):
+    echo 'no HTML here, but that\'s okay';
+elseif ($a == 7):
+    echo 'no HTML here, but that\'s okay';
+else: ?>
+Inline HTML in the else, but nowhere else.
+<?php
+endif;
+
+if ($a == 5): ?>
+Inline HTML in every leaf.
+<?php
+elseif ($a == 7): ?>
+Inline HTML in every leaf.
+<?php
+else: ?>
+Inline HTML in every leaf.
+<?php
+endif;
+
+// Safeguard that nested control structures will still be examined on their own merit.
+if ($a == 5): ?>
+Inline HTML in the if, but nowhere else.
+<?php
+elseif ($a == 7):
+    if ($foo):
+        doSomething();
+    else:
+        doSomethingElse();
+    endif;
+else:
+    echo 'no HTML here, but that\'s okay';
+endif;
+
+// Safeguard that "parent" control structures will take HTML in nested control structures into account.
+if ($a == 5):
+    doSomething();
+elseif ($a == 7):
+    if ($foo): ?>
+    Inline HTML in the nested if, but nowhere else.
+    <?php
+    endif;
+else:
+    echo 'no HTML here, but that\'s okay';
+endif;
+
+// Safeguard this has no influence on non-multi-part control structures.
+switch ($foo):
+    case 1:
+        if ($bar): ?>
+        <div>Inline HTML</div>
+        <?php
+        endif;
+    default;
+        echo 'no HTML here, but that\'s okay';
+endswitch;
 
 // phpcs:set Universal.ControlStructures.DisallowAlternativeSyntax allowWithInlineHTML false
 

--- a/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.1.inc.fixed
+++ b/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.1.inc.fixed
@@ -147,6 +147,16 @@ A is something else
 <?php } ?>
 
 <?php
+// Test handling if/else structures in one go.
+if ($a == 5){ ?>
+Inline HTML in the if, but nowhere else.
+<?php
+} elseif ($a == 7){
+    echo 'no HTML here, but that\'s okay';
+} else{
+    echo 'no HTML here, but that\'s okay';
+}
+
 // phpcs:set Universal.ControlStructures.DisallowAlternativeSyntax allowWithInlineHTML true
 
 /*
@@ -260,6 +270,94 @@ declare (ticks = 1){
         <?php
     }
 }
+
+/*
+ * Test: you can't mix alternative syntax with curlies, so if one part of the statement has HTML, ignore the rest.
+ * This only really comes into play with if/elseif/else as that's the only potentially multi-part control structure
+ * which allows for alternative syntax.
+ */
+if ($a == 5){
+    echo 'no HTML here';
+} elseif ($a == 7){
+    echo 'no HTML here';
+} else{
+    echo 'no HTML here';
+}
+
+if ($a == 5): ?>
+Inline HTML in the if, but nowhere else.
+<?php
+elseif ($a == 7):
+    echo 'no HTML here, but that\'s okay';
+else:
+    echo 'no HTML here, but that\'s okay';
+endif;
+
+if ($a == 5):
+    echo 'no HTML here, but that\'s okay';
+elseif ($a == 7): ?>
+Inline HTML in the elseif, but nowhere else.
+<?php
+else:
+    echo 'no HTML here, but that\'s okay';
+endif;
+
+if ($a == 5):
+    echo 'no HTML here, but that\'s okay';
+elseif ($a == 7):
+    echo 'no HTML here, but that\'s okay';
+else: ?>
+Inline HTML in the else, but nowhere else.
+<?php
+endif;
+
+if ($a == 5): ?>
+Inline HTML in every leaf.
+<?php
+elseif ($a == 7): ?>
+Inline HTML in every leaf.
+<?php
+else: ?>
+Inline HTML in every leaf.
+<?php
+endif;
+
+// Safeguard that nested control structures will still be examined on their own merit.
+if ($a == 5): ?>
+Inline HTML in the if, but nowhere else.
+<?php
+elseif ($a == 7):
+    if ($foo){
+        doSomething();
+    } else{
+        doSomethingElse();
+    }
+else:
+    echo 'no HTML here, but that\'s okay';
+endif;
+
+// Safeguard that "parent" control structures will take HTML in nested control structures into account.
+if ($a == 5):
+    doSomething();
+elseif ($a == 7):
+    if ($foo): ?>
+    Inline HTML in the nested if, but nowhere else.
+    <?php
+    endif;
+else:
+    echo 'no HTML here, but that\'s okay';
+endif;
+
+// Safeguard this has no influence on non-multi-part control structures.
+switch ($foo):
+    case 1:
+        if ($bar): ?>
+        <div>Inline HTML</div>
+        <?php
+        endif;
+    default;
+        echo 'no HTML here, but that\'s okay';
+endswitch;
 
 // phpcs:set Universal.ControlStructures.DisallowAlternativeSyntax allowWithInlineHTML false
 

--- a/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.2.inc
+++ b/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.2.inc
@@ -1,0 +1,9 @@
+<?php
+
+// Live coding.
+// Intentional parse error. This test has to be the last in the file.
+    if ($a) :
+        function_call($a);
+    else
+        // The above else if missing the colon!
+    endif;

--- a/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.3.inc
+++ b/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.3.inc
@@ -1,0 +1,10 @@
+<?php
+
+// Live coding.
+// Intentional parse error. This test has to be the last in the file.
+if ($a) : ?>
+    Inline HTML in the nested if, but nowhere else.
+    <?php
+else 
+    // The above else if missing the colon!
+endif;

--- a/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.4.inc
+++ b/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.4.inc
@@ -1,0 +1,8 @@
+<?php
+
+// Live coding.
+// Intentional parse error. This test has to be the last in the file.
+    if ($a) :
+        function_call($a);
+    else
+        function_call();

--- a/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.php
+++ b/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.php
@@ -25,10 +25,16 @@ final class DisallowAlternativeSyntaxUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
+     * @param string $testFile The name of the file being tested.
+     *
      * @return array <int line number> => <int number of errors>
      */
-    public function getErrorList()
+    public function getErrorList($testFile = '')
     {
+        if ($testFile !== 'DisallowAlternativeSyntaxUnitTest.1.inc') {
+            return [];
+        }
+
         return [
             80  => 1,
             82  => 1,
@@ -46,18 +52,26 @@ final class DisallowAlternativeSyntaxUnitTest extends AbstractSniffUnitTest
             134 => 1,
             138 => 1,
             145 => 1,
-            155 => 1,
-            157 => 1,
-            159 => 1,
-            164 => 1,
-            168 => 1,
-            172 => 1,
-            176 => 1,
-            185 => 1,
-            229 => 1,
-            235 => 1,
-            246 => 1,
+            151 => 1,
+            154 => 1,
+            156 => 1,
+            165 => 1,
+            167 => 1,
+            169 => 1,
+            174 => 1,
+            178 => 1,
+            182 => 1,
+            186 => 1,
+            195 => 1,
+            239 => 1,
+            245 => 1,
             256 => 1,
+            266 => 1,
+            279 => 1,
+            281 => 1,
+            283 => 1,
+            330 => 1,
+            332 => 1,
         ];
     }
 


### PR DESCRIPTION
Follow up to PR #90 - note: this bug has not been in a tagged release, only in `develop` after #90.

As things were, the sniff would examine - and potentially fix - each control structure keyword which could be used with alternative syntax individually.

For potentially multi-part control structures, like `if` - `elseif` - `else`, this could lead to parse errors in the fixed code as mixing curly braces with alternative syntax within the same control structure "chain" is not allowed.

This only comes into play when the `$allowWithInlineHTML` property has been set to `true` as that's the only time when an `if` would potentially be treated differently from the associated `else` (one containing inline HTML being left alone, the other not containing inline HTML being "fixed").

While `try` - `catch` and `do` - `while` are also potentially multi-part control structures, these do not allow for using the alternative control structure syntax, so for the purposes of this sniff, `if` - `elseif` - `else` chains are the only ones we need to take into account.

Also take note of the fact that `else if` (with a space between) is not allowed when using alternative syntax, so we don't need to take the keyword potentially being split into account.

This commit adjusts the sniff to handle these chains in one go and to prevent the potential parse error, by:
* No longer sniffing for `T_ELSEIF` or `T_ELSE` tokens. Note: this does affect how the metrics are recorded. Previously a metric would be recorded for each keyword. Now a metric will be recorded only for the _first_ keyword in a chain. This doesn't make a difference for non-chained control structures, but it does make a difference for chained `if/else` sets. Also note: the metric will only be recorded for control structure keywords which support alternative syntax, not for _all_ control structures. This remains the same as before.
* When examining the control structure for inline HTML, the sniff will now loop from the first matching control structure keyword till the `end*` and remembering each control structure keyword (opener/closer) encountered along the way in case of a chain. For multi-part chains, once an inline HTML token has been encountered, subsequent "leafs" will no longer be examined for inline HTML. This should yield a small performance improvement.
* The error messages will now be thrown via a loop based on the remembered information about each keyword encountered in a chain.
* Along the same lines, the fixer will now make all fixes for a "chain" in one go based on the remembered information about each keyword encountered in the chain. This should also help prevent potential fixer conflicts between sniffs.

Includes a range of additional unit tests for this issue.

Also includes additional unit tests to safeguard that the behaviour of PHPCS regarding parse errors in chained control structures will not change, as the sniff has a build-in presumption about the PHPCS behaviour with control structures using alternative syntax, so if at any point in the future, the PHPCS token stream for this would change, the sniff will need adjusting.