### PR TITLE
Universal/DisallowFinalClass: various tweaks

### DIFF
--- a/Universal/Sniffs/Classes/DisallowFinalClassSniff.php
+++ b/Universal/Sniffs/Classes/DisallowFinalClassSniff.php
@@ -70,13 +70,13 @@ final class DisallowFinalClassSniff implements Sniff
             return;
         }
 
+        $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'final');
+
         $tokens = $phpcsFile->getTokens();
         if (isset($tokens[$stackPtr]['scope_opener']) === false) {
             // Live coding or parse error.
             return;
         }
-
-        $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'final');
 
         // No extra safeguards needed, we know the keyword will exist based on the check above.
         $finalKeyword = $phpcsFile->findPrevious(\T_FINAL, ($stackPtr - 1));

--- a/Universal/Sniffs/Classes/DisallowFinalClassSniff.php
+++ b/Universal/Sniffs/Classes/DisallowFinalClassSniff.php
@@ -12,6 +12,7 @@ namespace PHPCSExtra\Universal\Sniffs\Classes;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\ObjectDeclarations;
 
@@ -72,21 +73,29 @@ final class DisallowFinalClassSniff implements Sniff
 
         $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'final');
 
-        $tokens = $phpcsFile->getTokens();
-        if (isset($tokens[$stackPtr]['scope_opener']) === false) {
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($nextNonEmpty === false) {
             // Live coding or parse error.
             return;
         }
 
         // No extra safeguards needed, we know the keyword will exist based on the check above.
         $finalKeyword = $phpcsFile->findPrevious(\T_FINAL, ($stackPtr - 1));
+        $snippetEnd   = $nextNonEmpty;
+        $classCloser  = '';
 
-        $snippet = GetTokensAsString::compact($phpcsFile, $finalKeyword, $tokens[$stackPtr]['scope_opener'], true);
+        $tokens = $phpcsFile->getTokens();
+        if (isset($tokens[$stackPtr]['scope_opener']) === true) {
+            $snippetEnd  = $tokens[$stackPtr]['scope_opener'];
+            $classCloser = '}';
+        }
+
+        $snippet = GetTokensAsString::compact($phpcsFile, $finalKeyword, $snippetEnd, true);
         $fix     = $phpcsFile->addFixableError(
-            'Declaring a class as final is not allowed. Found: %s}',
+            'Declaring a class as final is not allowed. Found: %s%s',
             $finalKeyword,
             'FinalClassFound',
-            [$snippet]
+            [$snippet, $classCloser]
         );
 
         if ($fix === true) {

--- a/Universal/Sniffs/Classes/DisallowFinalClassSniff.php
+++ b/Universal/Sniffs/Classes/DisallowFinalClassSniff.php
@@ -63,6 +63,7 @@ final class DisallowFinalClassSniff implements Sniff
         if ($classProp['is_final'] === false) {
             if ($classProp['is_abstract'] === true) {
                 $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'abstract');
+                return;
             }
 
             $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'not abstract, not final');

--- a/Universal/Tests/Classes/DisallowFinalClassUnitTest.inc
+++ b/Universal/Tests/Classes/DisallowFinalClassUnitTest.inc
@@ -40,5 +40,8 @@ final readonly class FinalReadonlyClass {}
 // Parse error. Remove the final keyword.
 final abstract class ForbiddenAbstractFinal {}
 
+// Parse error, but not one which concerns us. Remove the final keyword.
+final class UnfinishedDeclare
+
 // Live coding. Ignore. This must be the last test in the file.
 final class

--- a/Universal/Tests/Classes/DisallowFinalClassUnitTest.inc
+++ b/Universal/Tests/Classes/DisallowFinalClassUnitTest.inc
@@ -22,7 +22,7 @@ class FooC {
 /*
  * Bad.
  */
-final class BazA {}
+final class FinalClass {}
 
 final
 
@@ -30,15 +30,15 @@ final
 
     final class CheckHandlingOfIndentation {}
 
-final /*comment*/ class BazC implements MyInterface {}
+final /*comment*/ class CheckHandlingOfComments implements MyInterface {}
 
 // Test fixer when combined with PHP 8.2 "readonly" modifier.
-readonly final class BazD {}
+readonly final class ReadonlyFinalClass {}
 
-final readonly class BazE {}
+final readonly class FinalReadonlyClass {}
 
 // Parse error. Remove the final keyword.
-final abstract class BazD {}
+final abstract class ForbiddenAbstractFinal {}
 
 // Live coding. Ignore. This must be the last test in the file.
 final class

--- a/Universal/Tests/Classes/DisallowFinalClassUnitTest.inc.fixed
+++ b/Universal/Tests/Classes/DisallowFinalClassUnitTest.inc.fixed
@@ -22,21 +22,21 @@ class FooC {
 /*
  * Bad.
  */
-class BazA {}
+class FinalClass {}
 
 class CheckHandlingOfSuperfluousWhitespace extends Something {}
 
     class CheckHandlingOfIndentation {}
 
-/*comment*/ class BazC implements MyInterface {}
+/*comment*/ class CheckHandlingOfComments implements MyInterface {}
 
 // Test fixer when combined with PHP 8.2 "readonly" modifier.
-readonly class BazD {}
+readonly class ReadonlyFinalClass {}
 
-readonly class BazE {}
+readonly class FinalReadonlyClass {}
 
 // Parse error. Remove the final keyword.
-abstract class BazD {}
+abstract class ForbiddenAbstractFinal {}
 
 // Live coding. Ignore. This must be the last test in the file.
 final class

--- a/Universal/Tests/Classes/DisallowFinalClassUnitTest.inc.fixed
+++ b/Universal/Tests/Classes/DisallowFinalClassUnitTest.inc.fixed
@@ -38,5 +38,8 @@ readonly class FinalReadonlyClass {}
 // Parse error. Remove the final keyword.
 abstract class ForbiddenAbstractFinal {}
 
+// Parse error, but not one which concerns us. Remove the final keyword.
+class UnfinishedDeclare
+
 // Live coding. Ignore. This must be the last test in the file.
 final class

--- a/Universal/Tests/Classes/DisallowFinalClassUnitTest.php
+++ b/Universal/Tests/Classes/DisallowFinalClassUnitTest.php
@@ -37,6 +37,7 @@ final class DisallowFinalClassUnitTest extends AbstractSniffUnitTest
             36 => 1,
             38 => 1,
             41 => 1,
+            44 => 1,
         ];
     }
 


### PR DESCRIPTION
### Universal/DisallowFinalClass: minor code tweak

When a class is declared as `abstract`, it would attempt to record both for the `abstract`, as well as the `not abstract, not final` metric.

As a metric can only be recorded once per token, this didn't actually cause any issues, but it still made the code confusing. Fixed now.

### Universal/DisallowFinalClass: make tests more descriptive

### Universal/DisallowFinalClass: always record the metric

As things were, the sniff would bow out if the opening brace for the class could not be found (yet) and would also not record the `final` metric in that case, even though for similar code using `abstract`, the metric _would_ be recorded.

This commit ensures the `final` metric will now be recorded either way.

### Universal/DisallowFinalClass: act on more cases

As things were, the sniff would bow out if the opening brace for the class could not be found (yet).

This commit changes the sniff to act in more cases, i.e. it does require for a (non-empty) token after the `class` keyword, but once that token is found, the sniff will act.

Includes minor changes to how the message text is build up to prevent weird code snippets being show in the message.

Includes additional test.