### PR TITLE
Universal/RequireFinalClass: various tweaks

### DIFF
--- a/Universal/Sniffs/Classes/RequireFinalClassSniff.php
+++ b/Universal/Sniffs/Classes/RequireFinalClassSniff.php
@@ -71,13 +71,13 @@ final class RequireFinalClassSniff implements Sniff
             return;
         }
 
+        $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'not abstract, not final');
+
         $tokens = $phpcsFile->getTokens();
         if (isset($tokens[$stackPtr]['scope_opener']) === false) {
             // Live coding or parse error.
             return;
         }
-
-        $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'not abstract, not final');
 
         $snippet = GetTokensAsString::compact($phpcsFile, $stackPtr, $tokens[$stackPtr]['scope_opener'], true);
         $fix     = $phpcsFile->addFixableError(

--- a/Universal/Sniffs/Classes/RequireFinalClassSniff.php
+++ b/Universal/Sniffs/Classes/RequireFinalClassSniff.php
@@ -12,6 +12,7 @@ namespace PHPCSExtra\Universal\Sniffs\Classes;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\ObjectDeclarations;
 
@@ -73,18 +74,27 @@ final class RequireFinalClassSniff implements Sniff
 
         $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'not abstract, not final');
 
-        $tokens = $phpcsFile->getTokens();
-        if (isset($tokens[$stackPtr]['scope_opener']) === false) {
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($nextNonEmpty === false) {
             // Live coding or parse error.
             return;
         }
 
-        $snippet = GetTokensAsString::compact($phpcsFile, $stackPtr, $tokens[$stackPtr]['scope_opener'], true);
+        $snippetEnd  = $nextNonEmpty;
+        $classCloser = '';
+
+        $tokens = $phpcsFile->getTokens();
+        if (isset($tokens[$stackPtr]['scope_opener']) === true) {
+            $snippetEnd  = $tokens[$stackPtr]['scope_opener'];
+            $classCloser = '}';
+        }
+
+        $snippet = GetTokensAsString::compact($phpcsFile, $stackPtr, $snippetEnd, true);
         $fix     = $phpcsFile->addFixableError(
-            'A non-abstract class should be declared as final. Found: %s}',
+            'A non-abstract class should be declared as final. Found: %s%s',
             $stackPtr,
             'NonFinalClassFound',
-            [$snippet]
+            [$snippet, $classCloser]
         );
 
         if ($fix === true) {

--- a/Universal/Tests/Classes/RequireFinalClassUnitTest.inc
+++ b/Universal/Tests/Classes/RequireFinalClassUnitTest.inc
@@ -16,18 +16,18 @@ abstract class AbstractBarC implements MyInterface {}
 $a = new MyClass() {}
 
 // Parse error. Not our concern.
-final abstract class BazD {}
+final abstract class FinalAbstractClass {}
 
 /*
  * Bad.
  */
-class BazA {}
+class PlainClass {}
 
     class CheckHandlingOfIndentation extends Something {}
 
-class BazC implements MyInterface {}
+class ClassImplementing implements MyInterface {}
 
-readonly class BazD {}
+readonly class ReadonlyClass {}
 
 // Live coding. Ignore. This must be the last test in the file.
 class LiveCoding

--- a/Universal/Tests/Classes/RequireFinalClassUnitTest.inc
+++ b/Universal/Tests/Classes/RequireFinalClassUnitTest.inc
@@ -29,5 +29,8 @@ class ClassImplementing implements MyInterface {}
 
 readonly class ReadonlyClass {}
 
-// Live coding. Ignore. This must be the last test in the file.
+// Live coding/parse error, but not one which concerns us. Add the final keyword.
 class LiveCoding
+
+// Live coding. Ignore. This must be the last test in the file.
+class

--- a/Universal/Tests/Classes/RequireFinalClassUnitTest.inc.fixed
+++ b/Universal/Tests/Classes/RequireFinalClassUnitTest.inc.fixed
@@ -16,18 +16,18 @@ abstract class AbstractBarC implements MyInterface {}
 $a = new MyClass() {}
 
 // Parse error. Not our concern.
-final abstract class BazD {}
+final abstract class FinalAbstractClass {}
 
 /*
  * Bad.
  */
-final class BazA {}
+final class PlainClass {}
 
     final class CheckHandlingOfIndentation extends Something {}
 
-final class BazC implements MyInterface {}
+final class ClassImplementing implements MyInterface {}
 
-readonly final class BazD {}
+readonly final class ReadonlyClass {}
 
 // Live coding. Ignore. This must be the last test in the file.
 class LiveCoding

--- a/Universal/Tests/Classes/RequireFinalClassUnitTest.inc.fixed
+++ b/Universal/Tests/Classes/RequireFinalClassUnitTest.inc.fixed
@@ -29,5 +29,8 @@ final class ClassImplementing implements MyInterface {}
 
 readonly final class ReadonlyClass {}
 
+// Live coding/parse error, but not one which concerns us. Add the final keyword.
+final class LiveCoding
+
 // Live coding. Ignore. This must be the last test in the file.
-class LiveCoding
+class

--- a/Universal/Tests/Classes/RequireFinalClassUnitTest.php
+++ b/Universal/Tests/Classes/RequireFinalClassUnitTest.php
@@ -34,6 +34,7 @@ final class RequireFinalClassUnitTest extends AbstractSniffUnitTest
             26 => 1,
             28 => 1,
             30 => 1,
+            33 => 1,
         ];
     }
 


### PR DESCRIPTION
### Universal/RequireFinalClass: make tests more descriptive

### Universal/RequireFinalClass: always record the metric

As things were, the sniff would bow out if the opening brace for the class could not be found (yet) and would also not record the `not abstract, not final` metric in that case, even though for similar code using `abstract` or `final`, the metric _would_ be recorded.

This commit ensures the `not abstract, not final` metric will now be recorded either way.

### Universal/RequireFinalClass: act on more cases

As things were, the sniff would bow out if the opening brace for the class could not be found (yet).

This commit changes the sniff to act in more cases, i.e. it does require for a (non-empty) token after the `class` keyword, but once that token is found, the sniff will act.

Includes minor changes to how the message text is build up to prevent weird code snippets being show in the message.

Includes additional test.