### PR TITLE
Universal/OneStatementInShortEchoTag: prevent false positive

### DIFF
--- a/Universal/Sniffs/PHP/OneStatementInShortEchoTagSniff.php
+++ b/Universal/Sniffs/PHP/OneStatementInShortEchoTagSniff.php
@@ -56,8 +56,22 @@ final class OneStatementInShortEchoTagSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($stackPtr + 1));
-        if ($endOfStatement === false
+        for ($endOfStatement = ($stackPtr + 1); $endOfStatement < $phpcsFile->numTokens; $endOfStatement++) {
+            if ($tokens[$endOfStatement]['code'] === \T_CLOSE_TAG
+                || $tokens[$endOfStatement]['code'] === \T_SEMICOLON
+            ) {
+                break;
+            }
+
+            // Skip over anything within parenthesis.
+            if ($tokens[$endOfStatement]['code'] === \T_OPEN_PARENTHESIS
+                && isset($tokens[$endOfStatement]['parenthesis_closer'])
+            ) {
+                $endOfStatement = $tokens[$endOfStatement]['parenthesis_closer'];
+            }
+        }
+
+        if ($endOfStatement === $phpcsFile->numTokens
             || $tokens[$endOfStatement]['code'] === \T_CLOSE_TAG
         ) {
             return;

--- a/Universal/Tests/PHP/OneStatementInShortEchoTagUnitTest.1.inc
+++ b/Universal/Tests/PHP/OneStatementInShortEchoTagUnitTest.1.inc
@@ -13,6 +13,8 @@ echo 'b';
 ?></div>
 <div><?= $someText . $anotherText . ($x + 10); ?></div>
 <div><?= ($cond) ? $someText : $anotherText ?></div>
+<div><?= (function() use ($a) { return $a; })() ?></div>
+<div><?= (function() use ($a) { return $a; })(); ?></div>
 
 // Multiple statements in short open echo tags should be flagged.
 <div><?=$someText;
@@ -28,6 +30,8 @@ if ($cond) {
 <div><?= $someText;
 trigger_error('test', E_USER_NOTICE);
 ?></div>
+
+<div><?= $cl = function() use ($a) { return $a; }; echo $cl ?></div>
 
 // Unclosed tag. This must be the last test in the file.
 <div><?= $someText

--- a/Universal/Tests/PHP/OneStatementInShortEchoTagUnitTest.1.inc.fixed
+++ b/Universal/Tests/PHP/OneStatementInShortEchoTagUnitTest.1.inc.fixed
@@ -13,6 +13,8 @@ echo 'b';
 ?></div>
 <div><?= $someText . $anotherText . ($x + 10); ?></div>
 <div><?= ($cond) ? $someText : $anotherText ?></div>
+<div><?= (function() use ($a) { return $a; })() ?></div>
+<div><?= (function() use ($a) { return $a; })(); ?></div>
 
 // Multiple statements in short open echo tags should be flagged.
 <div><?php echo $someText;
@@ -28,6 +30,8 @@ if ($cond) {
 <div><?php echo $someText;
 trigger_error('test', E_USER_NOTICE);
 ?></div>
+
+<div><?php echo $cl = function() use ($a) { return $a; }; echo $cl ?></div>
 
 // Unclosed tag. This must be the last test in the file.
 <div><?= $someText

--- a/Universal/Tests/PHP/OneStatementInShortEchoTagUnitTest.php
+++ b/Universal/Tests/PHP/OneStatementInShortEchoTagUnitTest.php
@@ -34,9 +34,10 @@ final class OneStatementInShortEchoTagUnitTest extends AbstractSniffUnitTest
         switch ($testFile) {
             case 'OneStatementInShortEchoTagUnitTest.1.inc':
                 return [
-                    19 => 1,
-                    22 => 1,
-                    29 => 1,
+                    21 => 1,
+                    24 => 1,
+                    31 => 1,
+                    34 => 1,
                 ];
 
             case 'OneStatementInShortEchoTagUnitTest.2.inc':


### PR DESCRIPTION
In convoluted code, which I hope to never encounter in real life, it _could_ be possible to encounter a semi-colon, which is not the end of the statement, in the statement being executed for the `echo`.

This commit hardens the sniff to improve the handling of these.

Includes additional tests.