### PR TITLE
Universal/NoLeadingBackslash: examine imports within a group use statement

### DIFF
--- a/Universal/Sniffs/UseStatements/NoLeadingBackslashSniff.php
+++ b/Universal/Sniffs/UseStatements/NoLeadingBackslashSniff.php
@@ -84,6 +84,28 @@ final class NoLeadingBackslashSniff implements Sniff
             // Move the stackPtr forward to the next part of the use statement, if any.
             $current = $phpcsFile->findNext(\T_COMMA, ($current + 1), $endOfStatement);
         } while ($current !== false);
+
+        if ($tokens[$endOfStatement]['code'] !== \T_OPEN_USE_GROUP) {
+            // Finished the statement.
+            return;
+        }
+
+        $current        = $endOfStatement; // Group open brace.
+        $endOfStatement = $phpcsFile->findNext([\T_CLOSE_USE_GROUP], ($endOfStatement + 1));
+        if ($endOfStatement === false) {
+            // Live coding or parse error.
+            return;
+        }
+
+        do {
+            $continue = $this->processImport($phpcsFile, $current, $endOfStatement, true);
+            if ($continue === false) {
+                break;
+            }
+
+            // Move the stackPtr forward to the next part of the use statement, if any.
+            $current = $phpcsFile->findNext(\T_COMMA, ($current + 1), $endOfStatement);
+        } while ($current !== false);
     }
 
     /**
@@ -92,10 +114,12 @@ final class NoLeadingBackslashSniff implements Sniff
      * @param \PHP_CodeSniffer\Files\File $phpcsFile      The file being scanned.
      * @param int                         $stackPtr       The position of the current token.
      * @param int                         $endOfStatement End token for the current import statement.
+     * @param bool                        $groupUse       Whether the current statement is a partial one
+     *                                                    within a group use statement.
      *
      * @return bool Whether or not to continue examining this import use statement.
      */
-    private function processImport(File $phpcsFile, $stackPtr, $endOfStatement)
+    private function processImport(File $phpcsFile, $stackPtr, $endOfStatement, $groupUse = false)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -121,7 +145,14 @@ final class NoLeadingBackslashSniff implements Sniff
             $phpcsFile->recordMetric($nextNonEmpty, self::METRIC_NAME, 'yes');
 
             $error = 'An import use statement should never start with a leading backslash';
-            $fix   = $phpcsFile->addFixableError($error, $nextNonEmpty, 'LeadingBackslashFound');
+            $code  = 'LeadingBackslashFound';
+
+            if ($groupUse === true) {
+                $error = 'Parse error: partial import use statement in a use group starting with a leading backslash';
+                $code  = 'LeadingBackslashFoundInGroup';
+            }
+
+            $fix = $phpcsFile->addFixableError($error, $nextNonEmpty, $code);
 
             if ($fix === true) {
                 if ($tokens[$nextNonEmpty - 1]['code'] !== \T_WHITESPACE) {

--- a/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.1.inc
+++ b/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.1.inc
@@ -17,10 +17,16 @@ use Vendor\Foo\ClassA as ClassABC,
 
 <?php
 
+use other\namespacing\{
+    SomeClassB,
+    function another\level\function_foo as bar,
+    const another\level\NAMED_CONSTANT,
+};
+
 use \some\namespacing\{
-    \SomeClassA, // Intentional parse error. Should be ignored.
-    function \another\level\function_name as my_function, // Intentional parse error. Should be ignored.
-    const \another\level\CONSTANT_NAME, // Intentional parse error. Should be ignored.
+    \SomeClassA, // Intentional parse error.
+    function \another\level\function_name as my_function, // Intentional parse error.
+    const \another\level\CONSTANT_NAME, // Intentional parse error.
 };
 
 // Not the use statements we're looking for.

--- a/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.1.inc.fixed
+++ b/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.1.inc.fixed
@@ -17,10 +17,16 @@ use Vendor\Foo\ClassA as ClassABC,
 
 <?php
 
+use other\namespacing\{
+    SomeClassB,
+    function another\level\function_foo as bar,
+    const another\level\NAMED_CONSTANT,
+};
+
 use some\namespacing\{
-    \SomeClassA, // Intentional parse error. Should be ignored.
-    function \another\level\function_name as my_function, // Intentional parse error. Should be ignored.
-    const \another\level\CONSTANT_NAME, // Intentional parse error. Should be ignored.
+    SomeClassA, // Intentional parse error.
+    function another\level\function_name as my_function, // Intentional parse error.
+    const another\level\CONSTANT_NAME, // Intentional parse error.
 };
 
 // Not the use statements we're looking for.

--- a/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.5.inc
+++ b/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.5.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Live coding/parse error test.
+use some\namespacing\{
+    \SomeClassA,

--- a/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.php
+++ b/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.php
@@ -39,7 +39,10 @@ final class NoLeadingBackslashUnitTest extends AbstractSniffUnitTest
                     11 => 1,
                     14 => 1,
                     16 => 1,
-                    20 => 1,
+                    26 => 1,
+                    27 => 1,
+                    28 => 1,
+                    29 => 1,
                 ];
 
             default:


### PR DESCRIPTION
### Universal/NoLeadingBackslash: minor code reorganization

### Universal/NoLeadingBackslash: examine imports within a group use statement

Previously the sniff would only examine the start of a complete import statement, now it will also examine the partial imports within a group `use` statement.

A partial import statement within a group use starting with a leading backslash is actually a parse error, which normally gets ignored by PHPCS, but this is a very specific one, which is also auto-fixable, so may as well report it.

This new error for leading backslashes for partial import statements within a group use statement will be reported using a separate error code `LeadingBackslashFoundInGroup`.

Includes updated and extra unit tests.