### PR TITLE
Universal/DisallowLonelyIf: bow out early for a specific situation (PHP close tag)

### DIFF
--- a/Universal/Sniffs/ControlStructures/DisallowLonelyIfSniff.php
+++ b/Universal/Sniffs/ControlStructures/DisallowLonelyIfSniff.php
@@ -89,16 +89,15 @@ final class DisallowLonelyIfSniff implements Sniff
         /*
          * Find the end of an if - else chain.
          */
+
         $innerIfPtr       = $nextNonEmpty;
         $innerIfToken     = $tokens[$innerIfPtr];
         $autoFixable      = true;
         $innerScopeCloser = $innerIfToken['scope_closer'];
 
-        /*
-         * For alternative syntax fixer only.
-         * Remember the individual inner scope opener and closers so the fixer doesn't need
-         * to do the same walking over the if/else chain again.
-         */
+        // For alternative syntax fixer only.
+        // Remember the individual inner scope opener and closers so the fixer doesn't need
+        // to do the same walking over the if/else chain again.
         $innerScopes = [
             $innerIfToken['scope_opener'] => $innerScopeCloser,
         ];
@@ -115,6 +114,11 @@ final class DisallowLonelyIfSniff implements Sniff
                         $outerScopeCloser,
                         true
                     );
+
+                    if ($tokens[$nextAfter]['code'] === \T_CLOSE_TAG) {
+                        // Not "lonely" as at the very least there must be a PHP open tag before the outer closer.
+                        return;
+                    }
 
                     if ($tokens[$nextAfter]['code'] === \T_SEMICOLON) {
                         $innerScopeCloser = $nextAfter;

--- a/Universal/Tests/ControlStructures/DisallowLonelyIfUnitTest.inc
+++ b/Universal/Tests/ControlStructures/DisallowLonelyIfUnitTest.inc
@@ -278,6 +278,21 @@ if ($condition) {
         doSomething();
 }
 
+/*
+ * Tests involving PHP close tags to close the inner control structure.
+ * Ignore as these will always need an open tag to reach the outer control structure again,
+ * so are never the "only" thing within the `else` (so not a lonely if).
+ */
+if ($condition):
+    doSomething();
+else:
+    if ($anotherCondition):
+        doSomething();
+    endif ?>
+    Inline HTML
+    <?php
+endif;
+
 // Live coding.
 // Intentional parse error. This test has to be the last in the file.
 if ($a) {

--- a/Universal/Tests/ControlStructures/DisallowLonelyIfUnitTest.inc.fixed
+++ b/Universal/Tests/ControlStructures/DisallowLonelyIfUnitTest.inc.fixed
@@ -253,6 +253,21 @@ if ($condition) {
         doSomething();
 }
 
+/*
+ * Tests involving PHP close tags to close the inner control structure.
+ * Ignore as these will always need an open tag to reach the outer control structure again,
+ * so are never the "only" thing within the `else` (so not a lonely if).
+ */
+if ($condition):
+    doSomething();
+else:
+    if ($anotherCondition):
+        doSomething();
+    endif ?>
+    Inline HTML
+    <?php
+endif;
+
 // Live coding.
 // Intentional parse error. This test has to be the last in the file.
 if ($a) {


### PR DESCRIPTION
If an inner "if/else" chain using alternative syntax has a PHP close tag after the `endif` instead of a semi-colon, we **know** there will need to be a PHP open tag before the closer for the "outer" `else` can be reached, so this means there will always be additional content within the outer `else` which doesn't belong with the inner `if`, i.e. it's not a lonely `if`.

This commit implements bowing out early for that situation.

Includes unit test.

Includes minor tweaks to the inline documentation to make it clearer that the `do-while` code is part of the "Find the end of an if - else chain." block.