### PR TITLE
Universal/SeparateFunctionsFromOO: update tests for enums

### DIFF
--- a/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.3.inc
+++ b/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.3.inc
@@ -12,11 +12,15 @@ interface fooB() {}
 
 trait fooC() {}
 
+enum fooD: string {}
+
 namespace First;
 
 class firstFooA() {}
 
 trait firstFooB() {}
+
+enum firstFooD: string {}
 
 namespace Second;
 
@@ -29,6 +33,8 @@ interface secondFooA() {
 if (!class_exists('secondFooB')) {
     class secondFooB() {}
 }
+
+enum secondFooD: string {}
 
 // This sniff has no rules about side-effects.
 $globVar = new class() {

--- a/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.4.inc
+++ b/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.4.inc
@@ -11,11 +11,13 @@ namespace {
 
     interface fooB() {}
     trait fooC() {}
+    enum fooD {}
 }
 
 namespace First {
     class firstFooA() {}
     trait firstFooB() {}
+    enum firstFooD {}
 }
 
 namespace Second {
@@ -28,6 +30,8 @@ namespace Second {
     if (!class_exists('secondFooB')) {
         class secondFooB() {}
     }
+
+    enum secondFooD {}
 }
 
 namespace {

--- a/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.8.inc
+++ b/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.8.inc
@@ -1,0 +1,12 @@
+<?php
+
+// Invalid: File which declares both function(s) as well as OO structure(s).
+
+enum Suit: string implements Colorful, CardGame {
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+}
+
+function foo() {}

--- a/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.php
+++ b/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.php
@@ -42,6 +42,11 @@ final class SeparateFunctionsFromOOUnitTest extends AbstractSniffUnitTest
                     11 => 1,
                 ];
 
+            case 'SeparateFunctionsFromOOUnitTest.8.inc':
+                return [
+                    12 => 1,
+                ];
+
             default:
                 return [];
         }


### PR DESCRIPTION
As the sniff uses predefined token collections from PHPCSUtils, it automatically takes PHP 8.1 `enum`s into account since Utils-1.0.0-alpha4.

This commit adjusts pre-existing tests and adds an extra test to safeguard this.