### PR TITLE
Universal/SeparateFunctionsFromOO: update tests for arrow functions

### DIFF
--- a/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.1.inc
+++ b/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.1.inc
@@ -31,6 +31,8 @@ $closure = function($a, $b) {
     return $a + $b;
 };
 
+$arrow = fn($a, $b) => $a + $b;
+
 define('MY_CONSTANT', 'foo');
 
 const ANOTHER_CONSTANT = 'bar';

--- a/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.2.inc
+++ b/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.2.inc
@@ -31,6 +31,8 @@ namespace {
         return $a + $b;
     };
 
+    $arrow = fn($a, $b) => $a + $b;
+
     define('MY_CONSTANT', 'foo');
 
     const ANOTHER_CONSTANT = 'bar';

--- a/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.3.inc
+++ b/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.3.inc
@@ -45,6 +45,8 @@ $closure = function($a, $b) {
     return $a + $b;
 };
 
+$arrow = fn($a, $b) => $a + $b;
+
 define('MY_CONSTANT', 'foo');
 
 const ANOTHER_CONSTANT = 'bar';

--- a/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.4.inc
+++ b/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.4.inc
@@ -44,6 +44,8 @@ namespace {
         return $a + $b;
     };
 
+    $arrow = fn($a, $b) => $a + $b;
+
     define('MY_CONSTANT', 'foo');
 
     const ANOTHER_CONSTANT = 'bar';

--- a/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.5.inc
+++ b/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.5.inc
@@ -1,6 +1,6 @@
 <?php
 
-// Valid: File which doesn't declare functions nor OO structures.
+// Valid: File which doesn't declare named functions or OO structures.
 
 $globVar = new class() {
     public function thisIsAnAnonymousClass() {}
@@ -12,6 +12,8 @@ $globVar = new class() {
 $closure = function($a, $b) {
     return $a + $b;
 };
+
+$arrow = fn($a, $b) => $a + $b;
 
 define('MY_CONSTANT', 'foo');
 

--- a/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.6.inc
+++ b/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.6.inc
@@ -1,6 +1,6 @@
 <?php
 
-// Invalid: File which declares both function(s) as well as OO structure(s).
+// Invalid: File which declares both named function(s) as well as OO structure(s).
 
 function foo() {}
 

--- a/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.7.inc
+++ b/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.7.inc
@@ -1,6 +1,6 @@
 <?php
 
-// Invalid: File which declares both function(s) as well as OO structure(s).
+// Invalid: File which declares both named function(s) as well as OO structure(s).
 
 interface IBar {
     function bar();

--- a/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.8.inc
+++ b/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.8.inc
@@ -1,6 +1,6 @@
 <?php
 
-// Invalid: File which declares both function(s) as well as OO structure(s).
+// Invalid: File which declares both named function(s) as well as OO structure(s).
 
 enum Suit: string implements Colorful, CardGame {
     case Hearts = 'H';


### PR DESCRIPTION
As the sniff uses predefined token collections from PHPCSUtils, it automatically takes PHP 7.4 arrow functions into account since Utils-1.0.0-alpha4.

This commit adjusts pre-existing tests to safeguard this.

Includes minor test documentation updates.