### PR TITLE
✨ New Modernize.FunctionCalls.Dirname sniff

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,7 @@
 /phpcs.xml.dist export-ignore
 /phpunit.xml.dist export-ignore
 /phpunit-bootstrap.php export-ignore
+/Modernize/Tests/ export-ignore
 /NormalizedArrays/Tests/ export-ignore
 /Universal/Tests/ export-ignore
 

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -72,6 +72,7 @@ jobs:
       # Check the code-style consistency of the XML ruleset files.
       - name: Check XML code style
         run: |
+          diff -B ./Modernize/ruleset.xml <(xmllint --format "./Modernize/ruleset.xml")
           diff -B ./NormalizedArrays/ruleset.xml <(xmllint --format "./NormalizedArrays/ruleset.xml")
           diff -B ./Universal/ruleset.xml <(xmllint --format "./Universal/ruleset.xml")
 

--- a/Modernize/Docs/FunctionCalls/DirnameStandard.xml
+++ b/Modernize/Docs/FunctionCalls/DirnameStandard.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Function Calls to Dirname"
+    >
+    <standard>
+    <![CDATA[
+    PHP >= 5.3: Usage of dirname(__FILE__) can be replaced with __DIR__.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Using __DIR__.">
+        <![CDATA[
+$path = <em>__DIR__</em>;
+        ]]>
+        </code>
+        <code title="Invalid: dirname(__FILE__).">
+        <![CDATA[
+$path = <em>dirname(__FILE__)</em>;
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    PHP >= 7.0: Nested calls to dirname() can be replaced by using dirname() with the $levels parameter.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Using dirname() with the $levels parameter.">
+        <![CDATA[
+$path = <em>dirname($file, 3)</em>;
+        ]]>
+        </code>
+        <code title="Invalid: Nested function calls to dirname().">
+        <![CDATA[
+$path = <em>dirname(dirname(dirname($file)))</em>;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Modernize/Sniffs/FunctionCalls/DirnameSniff.php
+++ b/Modernize/Sniffs/FunctionCalls/DirnameSniff.php
@@ -1,0 +1,339 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Modernize\Sniffs\FunctionCalls;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\PassedParameters;
+
+/**
+ * Detect `dirname(__FILE__)` and nested uses of `dirname()`.
+ *
+ * @since 1.0.0
+ */
+final class DirnameSniff implements Sniff
+{
+
+    /**
+     * Registers the tokens that this sniff wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return int|string[]
+     */
+    public function register()
+    {
+        return [\T_STRING];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (\strtolower($tokens[$stackPtr]['content']) !== 'dirname') {
+            // Not our target.
+            return;
+        }
+
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($nextNonEmpty === false
+            || $tokens[$nextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS
+            || isset($tokens[$nextNonEmpty]['parenthesis_owner']) === true
+        ) {
+            // Not our target.
+            return;
+        }
+
+        if (isset($tokens[$nextNonEmpty]['parenthesis_closer']) === false) {
+            // Live coding or parse error, ignore.
+            return;
+        }
+
+        // Check if it is really a function call to the global function.
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+
+        if (isset(Collections::objectOperators()[$tokens[$prevNonEmpty]['code']]) === true
+            || $tokens[$prevNonEmpty]['code'] === \T_NEW
+        ) {
+            // Method call, class instantiation or other "not our target".
+            return;
+        }
+
+        if ($tokens[$prevNonEmpty]['code'] === \T_NS_SEPARATOR) {
+            $prevPrevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
+            if ($tokens[$prevPrevToken]['code'] === \T_STRING
+                || $tokens[$prevPrevToken]['code'] === \T_NAMESPACE
+            ) {
+                // Namespaced function.
+                return;
+            }
+        }
+
+        /*
+         * As of here, we can be pretty sure this is a function call to the global function.
+         */
+        $opener = $nextNonEmpty;
+        $closer = $tokens[$nextNonEmpty]['parenthesis_closer'];
+
+        $parameters = PassedParameters::getParameters($phpcsFile, $stackPtr);
+        $paramCount = \count($parameters);
+        if (empty($parameters) || $paramCount > 2) {
+            // No parameters or too many parameter.
+            return;
+        }
+
+        $pathParam = PassedParameters::getParameterFromStack($parameters, 1, 'path');
+        if ($pathParam === false) {
+            // If the path parameter doesn't exist, there's nothing to do.
+            return;
+        }
+
+        $levelsParam = PassedParameters::getParameterFromStack($parameters, 2, 'levels');
+        if ($levelsParam === false && $paramCount === 2) {
+            // There must be a typo in the param name or an otherwise stray parameter. Ignore.
+            return;
+        }
+
+        /*
+         * PHP 5.3+: Detect use of dirname(__FILE__).
+         */
+        if ($pathParam['clean'] === '__FILE__') {
+            // Determine if the issue is auto-fixable.
+            $hasComment = $phpcsFile->findNext(Tokens::$commentTokens, ($opener + 1), $closer);
+            $fixable    = ($hasComment === false);
+
+            if ($fixable === true) {
+                $levelsValue = $this->getLevelsValue($phpcsFile, $levelsParam);
+                if ($levelsParam !== false && $levelsValue === false) {
+                    // Can't autofix if we don't know the value of the $levels parameter.
+                    $fixable = false;
+                }
+            }
+
+            $error = 'Use the __DIR__ constant instead of calling dirname(__FILE__) (PHP >= 5.3)';
+            $code  = 'FileConstant';
+
+            // Throw the error.
+            if ($fixable === false) {
+                $phpcsFile->addError($error, $stackPtr, $code);
+                return;
+            }
+
+            $fix = $phpcsFile->addFixableError($error, $stackPtr, $code);
+            if ($fix === true) {
+                if ($levelsParam === false || $levelsValue === 1) {
+                    // No $levels or $levels set to 1: we can replace the complete function call.
+                    $phpcsFile->fixer->beginChangeset();
+
+                    $phpcsFile->fixer->replaceToken($stackPtr, '__DIR__');
+
+                    for ($i = ($stackPtr + 1); $i <= $closer; $i++) {
+                        $phpcsFile->fixer->replaceToken($i, '');
+                    }
+
+                    // Remove potential leading \.
+                    if ($tokens[$prevNonEmpty]['code'] === \T_NS_SEPARATOR) {
+                        $phpcsFile->fixer->replaceToken($prevNonEmpty, '');
+                    }
+
+                    $phpcsFile->fixer->endChangeset();
+                } else {
+                    // We can replace the $path parameter and will need to adjust the $levels parameter.
+                    $filePtr   = $phpcsFile->findNext(\T_FILE, $pathParam['start'], ($pathParam['end'] + 1));
+                    $levelsPtr = $phpcsFile->findNext(\T_LNUMBER, $levelsParam['start'], ($levelsParam['end'] + 1));
+
+                    $phpcsFile->fixer->beginChangeset();
+                    $phpcsFile->fixer->replaceToken($filePtr, '__DIR__');
+                    $phpcsFile->fixer->replaceToken($levelsPtr, ($levelsValue - 1));
+                    $phpcsFile->fixer->endChangeset();
+                }
+            }
+
+            return;
+        }
+
+        /*
+         * PHP 7.0+: Detect use of nested calls to dirname().
+         */
+        if (\preg_match('`^\s*\\\\?dirname\s*\(`i', $pathParam['clean']) !== 1) {
+            return;
+        }
+
+        /*
+         * Check if there is something _behind_ the nested dirname() call within the same parameter.
+         *
+         * Note: the findNext() calls are safe and will always match the dirname() function call
+         * as otherwise the above regex wouldn't have matched.
+         */
+        $innerDirnamePtr = $phpcsFile->findNext(\T_STRING, $pathParam['start'], ($pathParam['end'] + 1));
+        $innerOpener     = $phpcsFile->findNext(\T_OPEN_PARENTHESIS, ($innerDirnamePtr + 1), ($pathParam['end'] + 1));
+        if (isset($tokens[$innerOpener]['parenthesis_closer']) === false) {
+            // Shouldn't be possible.
+            return; // @codeCoverageIgnore
+        }
+
+        $innerCloser = $tokens[$innerOpener]['parenthesis_closer'];
+        if ($innerCloser !== $pathParam['end']) {
+            $hasContentAfter = $phpcsFile->findNext(
+                Tokens::$emptyTokens,
+                ($innerCloser + 1),
+                ($pathParam['end'] + 1),
+                true
+            );
+            if ($hasContentAfter !== false) {
+                // Matched code like: `dirname(dirname($file) . 'something')`. Ignore.
+                return;
+            }
+        }
+
+        /*
+         * Determine if this is an auto-fixable error.
+         */
+
+        // Step 1: Are there comments ? If so, not auto-fixable as we don't want to remove comments.
+        $fixable = true;
+        for ($i = ($opener + 1); $i < $closer; $i++) {
+            if (isset(Tokens::$commentTokens[$tokens[$i]['code']])) {
+                $fixable = false;
+                break;
+            }
+
+            if ($tokens[$i]['code'] === \T_OPEN_PARENTHESIS
+                && isset($tokens[$i]['parenthesis_closer'])
+            ) {
+                // Skip over everything within the nested dirname() function call.
+                $i = $tokens[$i]['parenthesis_closer'];
+            }
+        }
+
+        // Step 2: Does the `$levels` parameter exist for the outer dirname() call and if so, is it usable ?
+        if ($fixable === true) {
+            $outerLevelsValue = $this->getLevelsValue($phpcsFile, $levelsParam);
+            if ($levelsParam !== false && $outerLevelsValue === false) {
+                // Can't autofix if we don't know the value of the $levels parameter.
+                $fixable = false;
+            }
+        }
+
+        // Step 3: Does the `$levels` parameter exist for the inner dirname() call and if so, is it usable ?
+        if ($fixable === true) {
+            $innerParameters  = PassedParameters::getParameters($phpcsFile, $innerDirnamePtr);
+            $innerLevelsParam = PassedParameters::getParameterFromStack($innerParameters, 2, 'levels');
+            $innerLevelsValue = $this->getLevelsValue($phpcsFile, $innerLevelsParam);
+            if ($innerLevelsParam !== false && $innerLevelsValue === false) {
+                // Can't autofix if we don't know the value of the $levels parameter.
+                $fixable = false;
+            }
+        }
+
+        /*
+         * Throw the error.
+         */
+        $error  = 'Pass the $levels parameter to the dirname() call instead of using nested dirname() calls';
+        $error .= ' (PHP >= 7.0)';
+        $code   = 'Nested';
+
+        if ($fixable === false) {
+            $phpcsFile->addError($error, $stackPtr, $code);
+            return;
+        }
+
+        $fix = $phpcsFile->addFixableError($error, $stackPtr, $code);
+        if ($fix === false) {
+            return;
+        }
+
+        /*
+         * Fix the error.
+         */
+        $phpcsFile->fixer->beginChangeset();
+
+        // Remove the info in the _outer_ param call.
+        for ($i = $opener; $i < $innerOpener; $i++) {
+            $phpcsFile->fixer->replaceToken($i, '');
+        }
+
+        for ($i = ($innerCloser + 1); $i <= $closer; $i++) {
+            $phpcsFile->fixer->replaceToken($i, '');
+        }
+
+        if ($innerLevelsParam !== false) {
+            // Inner $levels parameter already exists, just adjust the value.
+            $innerLevelsPtr = $phpcsFile->findNext(
+                \T_LNUMBER,
+                $innerLevelsParam['start'],
+                ($innerLevelsParam['end'] + 1)
+            );
+            $phpcsFile->fixer->replaceToken($innerLevelsPtr, ($innerLevelsValue + $outerLevelsValue));
+        } else {
+            // Inner $levels parameter does not exist yet. We need to add it.
+            $content = ', ';
+
+            $prevBeforeCloser = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($innerCloser - 1), null, true);
+            if ($tokens[$prevBeforeCloser]['code'] === \T_COMMA) {
+                // Trailing comma found, no need to add the comma.
+                $content = ' ';
+            }
+
+            $innerPathParam = PassedParameters::getParameterFromStack($innerParameters, 1, 'path');
+            if (isset($innerPathParam['name_token']) === true) {
+                // Non-named param cannot follow named param, so add param name.
+                $content .= 'levels: ';
+            }
+
+            $content .= ($innerLevelsValue + $outerLevelsValue);
+            $phpcsFile->fixer->addContentBefore($innerCloser, $content);
+        }
+
+        $phpcsFile->fixer->endChangeset();
+    }
+
+    /**
+     * Determine the value of the $levels parameter passed to dirname().
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being scanned.
+     * @param array|false                 $levelsParam The information about the parameter as retrieved
+     *                                                 via PassedParameters::getParameterFromStack().
+     *
+     * @return int|false Integer levels value or FALSE if the levels value couldn't be determined.
+     */
+    private function getLevelsValue($phpcsFile, $levelsParam)
+    {
+        if ($levelsParam === false) {
+            return 1;
+        }
+
+        $ignore   = Tokens::$emptyTokens;
+        $ignore[] = \T_LNUMBER;
+
+        $hasNonNumber = $phpcsFile->findNext($ignore, $levelsParam['start'], ($levelsParam['end'] + 1), true);
+        if ($hasNonNumber !== false) {
+            return false;
+        }
+
+        return (int) $levelsParam['clean'];
+    }
+}

--- a/Modernize/Tests/FunctionCalls/DirnameUnitTest.inc
+++ b/Modernize/Tests/FunctionCalls/DirnameUnitTest.inc
@@ -1,0 +1,142 @@
+<?php
+
+/*
+ * Not our target.
+ */
+use dirname;
+
+class Foo {
+    function dirname( $a = __FILE__) {}
+    function &dirname( $a = __FILE__) {}
+}
+
+$path = Foo::dirname(__FILE__);
+$path = $obj->dirname(__FILE__);
+$path = $obj?->dirname(__FILE__);
+$path = Package\dirname(__FILE__);
+$path = \My\Package\dirname(__FILE__);
+echo Foo::DIRNAME;
+$obj = new dirname(__FILE__);
+
+echo DIRNAME . '/file.php';
+
+
+/*
+ * These should not be flagged.
+ */
+echo foo(__FILE__);
+$path = dirname();
+$path = dirname( $file );
+$path = dirname( __DIR__ );
+$path = dirname( '.' );
+$path = dirname( get_path(__FILE__) );
+$path = dirname(__FILE__ . '/..');
+
+$path = dirname( ABSPATH . '/path/to/file.php', 3 );
+$path = dirname( __DIR__, 3 );
+
+$path = dirname(levels: 2); // ArgumentCountError, require param dirname missing. Ignore as not the concern of this sniff.
+$path = dirname( __FILE__, 3, $extra ); // ArgumentCountError, too many args. Ignore as not the concern of this sniff.
+
+$path = dirname( paths: __FILE__ ); // Error: unknown named parameter. Ignore as not the concern of this sniff.
+$path = dirname( __FILE__, level: 2); // Error: unknown named parameter. Ignore as not the concern of this sniff.
+
+$path = dirname(\dirname(__DIR__) . '/file.php'); // Nested dirname() call not stand-alone. Silly code, but should not be flagged.
+
+
+/*
+ * These should be flagged for use of dirname(__FILE__).
+ */
+$path = dirname(__FILE__);
+$path = \dirname (   __FILE__  ,  ) ; // Includes trailing comma.
+
+$path = DirName(__FILE__ /* todo: replace with __DIR__ */); // Not auto-fixable.
+
+// Handling of multi-line function calls.
+$path = dirname(
+    __FILE__
+);
+
+// Uses __FILE__, but also has $levels parameter.
+$path = dirname(__FILE__, 1);
+$path = dirname(__FILE__, 2);
+$path = dirname(__FILE__, 03); // Octal 3.
+
+$path = dirname(__FILE__, $levels); // Not auto-fixable.
+$path = dirname(__FILE__, get_levels(2)); // Not auto-fixable.
+
+// With named parameters.
+$path = dirname(path: __FILE__, levels: 1);
+$path = dirname(levels: 3, path: __FILE__);
+
+// phpcs:ignore Modernize.FunctionCalls.Dirname.Nested -- Only apply __DIR__ fix, not $levels.
+$path = dirname(dirname(dirname(dirname(__FILE__))));
+
+
+/*
+ * These should be flagged for use of nested dirname().
+ */
+$path = dirname(dirname(dirname(dirname(__DIR__))));
+$path = dirname(dirname(DIRNAME(dirname(__DIR__, 2,)))); // Includes trailing comma.
+
+$path = dirname(\dirname($file,), 2); // Includes trailing comma in inner dirname() call.
+$path = dirname(dirname(dirname($file), 2), 2);
+
+// Handling of multi-line function calls.
+$path = dirname(
+    dirname(
+        __DIR__,
+        2
+    ),
+    2
+);
+
+$path = dirname(
+    \dirname(__DIR__, 1), // Comment within the outer dirname() scope.
+    2
+); // Not auto-fixable.
+
+$path = dirname(
+    dirname(
+        __DIR__, // Comment within the inner dirname() scope.
+        3
+    ),
+    2
+); // Auto-fixable.
+
+$path = dirname(dirname(__DIR__, $levels), 2); // Not auto-fixable.
+$path = dirname(dirname(__DIR__, 2), get_levels()); // Not auto-fixable.
+
+$path = dirname(dirname(dirname($file, 2), 2), FOO::LEVELS); // Partially auto-fixable.
+
+// With named parameters.
+$path = dirname(levels: 2, path: \dirname(levels: 2, path: DIRNAME(path: dirname(path: __DIR__), levels: 2)));
+$path = dirname(levels: 1, path: dirname(levels: 3, path: \DIRNAME(levels: 1, path: dirname(levels: 2, path: __DIR__,)))); // Includes trailing comma.
+
+
+/*
+ * These should be flagged for both.
+ */
+$path = dirname(dirname(dirname(dirname(__FILE__))));
+$path = dirname(DirName(dirname(dirname(__FILE__, 2))));
+
+// With named parameters.
+$path = dirname(path: DirName(path: dirname(path: dirname(path: __FILE__))));
+
+// With named parameters, multi-line function call, trailing comma, non-lowercase function call.
+$path = dirname(
+    path: DirName(
+        levels: 2,
+        path: dirname(
+            path: dirname(
+                path: __FILE__
+            ),
+            levels: 3,
+        )
+    )
+);
+
+
+// Parse error.
+// This must be the last test in the file.
+echo dirname(__FILE__

--- a/Modernize/Tests/FunctionCalls/DirnameUnitTest.inc.fixed
+++ b/Modernize/Tests/FunctionCalls/DirnameUnitTest.inc.fixed
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * Not our target.
+ */
+use dirname;
+
+class Foo {
+    function dirname( $a = __FILE__) {}
+    function &dirname( $a = __FILE__) {}
+}
+
+$path = Foo::dirname(__FILE__);
+$path = $obj->dirname(__FILE__);
+$path = $obj?->dirname(__FILE__);
+$path = Package\dirname(__FILE__);
+$path = \My\Package\dirname(__FILE__);
+echo Foo::DIRNAME;
+$obj = new dirname(__FILE__);
+
+echo DIRNAME . '/file.php';
+
+
+/*
+ * These should not be flagged.
+ */
+echo foo(__FILE__);
+$path = dirname();
+$path = dirname( $file );
+$path = dirname( __DIR__ );
+$path = dirname( '.' );
+$path = dirname( get_path(__FILE__) );
+$path = dirname(__FILE__ . '/..');
+
+$path = dirname( ABSPATH . '/path/to/file.php', 3 );
+$path = dirname( __DIR__, 3 );
+
+$path = dirname(levels: 2); // ArgumentCountError, require param dirname missing. Ignore as not the concern of this sniff.
+$path = dirname( __FILE__, 3, $extra ); // ArgumentCountError, too many args. Ignore as not the concern of this sniff.
+
+$path = dirname( paths: __FILE__ ); // Error: unknown named parameter. Ignore as not the concern of this sniff.
+$path = dirname( __FILE__, level: 2); // Error: unknown named parameter. Ignore as not the concern of this sniff.
+
+$path = dirname(\dirname(__DIR__) . '/file.php'); // Nested dirname() call not stand-alone. Silly code, but should not be flagged.
+
+
+/*
+ * These should be flagged for use of dirname(__FILE__).
+ */
+$path = __DIR__;
+$path = __DIR__ ; // Includes trailing comma.
+
+$path = DirName(__FILE__ /* todo: replace with __DIR__ */); // Not auto-fixable.
+
+// Handling of multi-line function calls.
+$path = __DIR__;
+
+// Uses __FILE__, but also has $levels parameter.
+$path = __DIR__;
+$path = dirname(__DIR__, 1);
+$path = dirname(__DIR__, 2); // Octal 3.
+
+$path = dirname(__FILE__, $levels); // Not auto-fixable.
+$path = dirname(__FILE__, get_levels(2)); // Not auto-fixable.
+
+// With named parameters.
+$path = __DIR__;
+$path = dirname(levels: 2, path: __DIR__);
+
+// phpcs:ignore Modernize.FunctionCalls.Dirname.Nested -- Only apply __DIR__ fix, not $levels.
+$path = dirname(dirname(dirname(__DIR__)));
+
+
+/*
+ * These should be flagged for use of nested dirname().
+ */
+$path = dirname(__DIR__, 4);
+$path = dirname(__DIR__, 5,); // Includes trailing comma.
+
+$path = dirname($file, 3); // Includes trailing comma in inner dirname() call.
+$path = dirname($file, 5);
+
+// Handling of multi-line function calls.
+$path = dirname(
+        __DIR__,
+        4
+    );
+
+$path = dirname(
+    \dirname(__DIR__, 1), // Comment within the outer dirname() scope.
+    2
+); // Not auto-fixable.
+
+$path = dirname(
+        __DIR__, // Comment within the inner dirname() scope.
+        5
+    ); // Auto-fixable.
+
+$path = dirname(dirname(__DIR__, $levels), 2); // Not auto-fixable.
+$path = dirname(dirname(__DIR__, 2), get_levels()); // Not auto-fixable.
+
+$path = dirname(dirname($file, 4), FOO::LEVELS); // Partially auto-fixable.
+
+// With named parameters.
+$path = dirname(path: __DIR__, levels: 7);
+$path = dirname(levels: 7, path: __DIR__,); // Includes trailing comma.
+
+
+/*
+ * These should be flagged for both.
+ */
+$path = dirname(__DIR__, 3);
+$path = dirname(__DIR__, 4);
+
+// With named parameters.
+$path = dirname(path: __DIR__, levels: 3);
+
+// With named parameters, multi-line function call, trailing comma, non-lowercase function call.
+$path = dirname(
+                path: __DIR__
+            , levels: 6);
+
+
+// Parse error.
+// This must be the last test in the file.
+echo dirname(__FILE__

--- a/Modernize/Tests/FunctionCalls/DirnameUnitTest.php
+++ b/Modernize/Tests/FunctionCalls/DirnameUnitTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Modernize\Tests\FunctionCalls;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the Dirname sniff.
+ *
+ * @covers PHPCSExtra\Modernize\Sniffs\FunctionCalls\DirnameSniff
+ *
+ * @since 1.0.0
+ */
+final class DirnameUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [
+            50  => 1,
+            51  => 1,
+            53  => 1,
+            56  => 1,
+            61  => 1,
+            62  => 1,
+            63  => 1,
+            65  => 1,
+            66  => 1,
+            69  => 1,
+            70  => 1,
+            73  => 1,
+            79  => 3,
+            80  => 3,
+            82  => 1,
+            83  => 2,
+            86  => 1,
+            94  => 1,
+            99  => 1,
+            107 => 1,
+            108 => 1,
+            110 => 2,
+            113 => 3,
+            114 => 3,
+            120 => 4,
+            121 => 4,
+            124 => 4,
+            127 => 1,
+            128 => 1,
+            130 => 1,
+            131 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}

--- a/Modernize/ruleset.xml
+++ b/Modernize/ruleset.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Modernize" namespace="PHPCSExtra\Modernize" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <description>A collection of sniffs to detect code modernization opportunties.</description>
+</ruleset>

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
             "@remove-devcs"
         ],
         "check-complete": [
-            "@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./NormalizedArrays ./Universal"
+            "@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./Modernize ./NormalizedArrays ./Universal"
         ],
         "test": [
             "@php ./vendor/phpunit/phpunit/phpunit --filter PHPCSExtra --no-coverage ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"

--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -67,6 +67,7 @@ for that PHPCS install.
  * Ref: https://github.com/squizlabs/PHP_CodeSniffer/pull/1146
  */
 $phpcsExtraStandards = [
+    'Modernize'        => true,
     'NormalizedArrays' => true,
     'Universal'        => true,
 ];

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,6 +14,7 @@
 
     <testsuites>
         <testsuite name="PHPCSExtra">
+            <directory suffix="UnitTest.php">./Modernize/Tests/</directory>
             <directory suffix="UnitTest.php">./NormalizedArrays/Tests/</directory>
             <directory suffix="UnitTest.php">./Universal/Tests/</directory>
         </testsuite>
@@ -21,6 +22,7 @@
 
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./Modernize/Sniffs/</directory>
             <directory suffix=".php">./NormalizedArrays/Sniffs/</directory>
             <directory suffix=".php">./Universal/Sniffs/</directory>
         </whitelist>


### PR DESCRIPTION
### Introduce new Modernize standard

Includes updating CI and other dev related files to take the new standard into account.

**_P.S.: By rights, this should be a separate standard in the PHPCompatibility organisation, but that's for later. For now, I just want to make sure this sniff becomes available._**

### ✨ New Modernize.FunctionCalls.Dirname sniff

This new sniff will detect and, when possible, auto-fix two typical code modernizations which can be made related to the `dirname()` function:
1. Since PHP 5.3, calls to `dirname(__FILE__)` can be replaced by `__DIR__`.
    Errorcode: `Modernize.FunctionCalls.Dirname.FileConstant`.
2. Since PHP 7.0, nested function calls to `dirname()` can be changed to use the new `$levels` parameter.
    Errorcode: `Modernize.FunctionCalls.Dirname.Nested`.

Depending on supported PHP versions of an application, the complete sniff can be enabled and/or just one of the error codes could be enabled.

**Regarding the fixers:**

The sniff - and more importantly, the fixer - take fully qualified function calls, named parameters, as well as trailing comma's in function calls into account.

* If a comment is found in any of the code which would be removed by the fixer, the issues will still be flagged, but not be marked as fixable.
* If the value of a pre-existing `$levels` parameter cannot be determined, the issues will still be flagged, but not be marked as fixable.

Also take note that the fixer does not make any presumptions about the code style of the project. It is recommended to run the code style fixers together with or after this fixer, so those can adjust the code style to the style applicable in the project.

Includes fixer.
Includes unit tests.
Includes documentation.

#### Notes/Future scope:
* The sniff is not yet compatible with PHPCS 4.x.
* When PHPCSUtils releases its own abstract for sniffing function calls, this sniff should switch to it.

Refs:
* https://www.php.net/manual/en/function.dirname.php
* PHP 5.3: https://php-legacy-docs.zend.com/manual/php5/en/migration53.global-constants
* PHp 7.0: https://www.php.net/manual/en/migration70.changed-functions.php#migration70.changed-functions.core
    Note: the parameter was originally called `$depth`, but has since been renamed to `$levels`.