### PR TITLE
Universal/NoReservedKeywordParameterNames: various improvements

### DIFF
--- a/Universal/Sniffs/NamingConventions/NoReservedKeywordParameterNamesSniff.php
+++ b/Universal/Sniffs/NamingConventions/NoReservedKeywordParameterNamesSniff.php
@@ -10,7 +10,6 @@
 
 namespace PHPCSExtra\Universal\Sniffs\NamingConventions;
 
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHPCSUtils\Tokens\Collections;
@@ -161,16 +160,11 @@ final class NoReservedKeywordParameterNamesSniff implements Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         // Get all parameters from method signature.
-        try {
-            $parameters = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
-            if (empty($parameters)) {
-                return;
-            }
-        } catch (RuntimeException $e) {
+        $parameters = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
+        if (empty($parameters)) {
             return;
         }
 
-        $paramNames = [];
         foreach ($parameters as $param) {
             $name = \ltrim($param['name'], '$');
             if (isset($this->reservedNames[$name]) === true) {

--- a/Universal/Sniffs/NamingConventions/NoReservedKeywordParameterNamesSniff.php
+++ b/Universal/Sniffs/NamingConventions/NoReservedKeywordParameterNamesSniff.php
@@ -16,7 +16,13 @@ use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
 
 /**
- * Verifies that parameters in function declarations do not use PHP reserved keywords.
+ * Verifies that parameters in function declarations do not use PHP reserved keywords
+ * as this can lead to confusing code when using PHP 8.0+ named parameters in function calls.
+ *
+ * Note: while parameters (variables) are case-sensitive in PHP, keywords are not,
+ * so this sniff checks for the keywords used in parameter names in a
+ * case-insensitive manner to make this sniff independent of code style rules
+ * regarding the case for parameter names.
  *
  * @link https://www.php.net/manual/en/reserved.keywords.php
  *
@@ -30,108 +36,108 @@ final class NoReservedKeywordParameterNamesSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @var array(string => string)
+     * @var array<string => string> Key is the lowercased keyword, value the "proper" cased keyword.
      */
-    protected $reservedNames = [
-        'abstract'      => true,
-        'and'           => true,
-        'array'         => true,
-        'as'            => true,
-        'break'         => true,
-        'callable'      => true,
-        'case'          => true,
-        'catch'         => true,
-        'class'         => true,
-        'clone'         => true,
-        'const'         => true,
-        'continue'      => true,
-        'declare'       => true,
-        'default'       => true,
-        'die'           => true,
-        'do'            => true,
-        'echo'          => true,
-        'else'          => true,
-        'elseif'        => true,
-        'empty'         => true,
-        'enddeclare'    => true,
-        'endfor'        => true,
-        'endforeach'    => true,
-        'endif'         => true,
-        'endswitch'     => true,
-        'endwhile'      => true,
-        'enum'          => true,
-        'eval'          => true,
-        'exit'          => true,
-        'extends'       => true,
-        'final'         => true,
-        'finally'       => true,
-        'fn'            => true,
-        'for'           => true,
-        'foreach'       => true,
-        'function'      => true,
-        'global'        => true,
-        'goto'          => true,
-        'if'            => true,
-        'implements'    => true,
-        'include'       => true,
-        'include_once'  => true,
-        'instanceof'    => true,
-        'insteadof'     => true,
-        'interface'     => true,
-        'isset'         => true,
-        'list'          => true,
-        'match'         => true,
-        'namespace'     => true,
-        'new'           => true,
-        'or'            => true,
-        'print'         => true,
-        'private'       => true,
-        'protected'     => true,
-        'public'        => true,
-        'readonly'      => true,
-        'require'       => true,
-        'require_once'  => true,
-        'return'        => true,
-        'static'        => true,
-        'switch'        => true,
-        'throw'         => true,
-        'trait'         => true,
-        'try'           => true,
-        'unset'         => true,
-        'use'           => true,
-        'var'           => true,
-        'while'         => true,
-        'xor'           => true,
-        'yield'         => true,
-        '__CLASS__'     => true,
-        '__DIR__'       => true,
-        '__FILE__'      => true,
-        '__FUNCTION__'  => true,
-        '__LINE__'      => true,
-        '__METHOD__'    => true,
-        '__NAMESPACE__' => true,
-        '__TRAIT__'     => true,
-        'int'           => true,
-        'float'         => true,
-        'bool'          => true,
-        'string'        => true,
-        'true'          => true,
-        'false'         => true,
-        'null'          => true,
-        'void'          => true,
-        'iterable'      => true,
-        'object'        => true,
-        'resource'      => true,
-        'mixed'         => true,
-        'numeric'       => true,
-        'never'         => true,
+    private $reservedNames = [
+        'abstract'      => 'abstract',
+        'and'           => 'and',
+        'array'         => 'array',
+        'as'            => 'as',
+        'break'         => 'break',
+        'callable'      => 'callable',
+        'case'          => 'case',
+        'catch'         => 'catch',
+        'class'         => 'class',
+        'clone'         => 'clone',
+        'const'         => 'const',
+        'continue'      => 'continue',
+        'declare'       => 'declare',
+        'default'       => 'default',
+        'die'           => 'die',
+        'do'            => 'do',
+        'echo'          => 'echo',
+        'else'          => 'else',
+        'elseif'        => 'elseif',
+        'empty'         => 'empty',
+        'enddeclare'    => 'enddeclare',
+        'endfor'        => 'endfor',
+        'endforeach'    => 'endforeach',
+        'endif'         => 'endif',
+        'endswitch'     => 'endswitch',
+        'endwhile'      => 'endwhile',
+        'enum'          => 'enum',
+        'eval'          => 'eval',
+        'exit'          => 'exit',
+        'extends'       => 'extends',
+        'final'         => 'final',
+        'finally'       => 'finally',
+        'fn'            => 'fn',
+        'for'           => 'for',
+        'foreach'       => 'foreach',
+        'function'      => 'function',
+        'global'        => 'global',
+        'goto'          => 'goto',
+        'if'            => 'if',
+        'implements'    => 'implements',
+        'include'       => 'include',
+        'include_once'  => 'include_once',
+        'instanceof'    => 'instanceof',
+        'insteadof'     => 'insteadof',
+        'interface'     => 'interface',
+        'isset'         => 'isset',
+        'list'          => 'list',
+        'match'         => 'match',
+        'namespace'     => 'namespace',
+        'new'           => 'new',
+        'or'            => 'or',
+        'print'         => 'print',
+        'private'       => 'private',
+        'protected'     => 'protected',
+        'public'        => 'public',
+        'readonly'      => 'readonly',
+        'require'       => 'require',
+        'require_once'  => 'require_once',
+        'return'        => 'return',
+        'static'        => 'static',
+        'switch'        => 'switch',
+        'throw'         => 'throw',
+        'trait'         => 'trait',
+        'try'           => 'try',
+        'unset'         => 'unset',
+        'use'           => 'use',
+        'var'           => 'var',
+        'while'         => 'while',
+        'xor'           => 'xor',
+        'yield'         => 'yield',
+        '__class__'     => '__CLASS__',
+        '__dir__'       => '__DIR__',
+        '__file__'      => '__FILE__',
+        '__function__'  => '__FUNCTION__',
+        '__line__'      => '__LINE__',
+        '__method__'    => '__METHOD__',
+        '__namespace__' => '__NAMESPACE__',
+        '__trait__'     => '__TRAIT__',
+        'int'           => 'int',
+        'float'         => 'float',
+        'bool'          => 'bool',
+        'string'        => 'string',
+        'true'          => 'true',
+        'false'         => 'false',
+        'null'          => 'null',
+        'void'          => 'void',
+        'iterable'      => 'iterable',
+        'object'        => 'object',
+        'resource'      => 'resource',
+        'mixed'         => 'mixed',
+        'numeric'       => 'numeric',
+        'never'         => 'never',
 
         /*
          * Not reserved keywords, but equally confusing when used in the context of function calls
          * with named parameters.
          */
-        'parent'        => true,
-        'self'          => true,
+        'parent'        => 'parent',
+        'self'          => 'self',
     ];
 
     /**
@@ -165,15 +171,19 @@ final class NoReservedKeywordParameterNamesSniff implements Sniff
             return;
         }
 
+        $message = 'It is recommended not to use reserved keyword "%s" as function parameter name. Found: %s';
+
         foreach ($parameters as $param) {
-            $name = \ltrim($param['name'], '$');
-            if (isset($this->reservedNames[$name]) === true) {
-                $phpcsFile->addWarning(
-                    'It is recommended not to use reserved keywords as function parameter names. Found: %s',
-                    $param['token'],
-                    $name . 'Found',
-                    [$param['name']]
-                );
+            $name   = \ltrim($param['name'], '$');
+            $nameLC = \strtolower($name);
+            if (isset($this->reservedNames[$nameLC]) === true) {
+                $errorCode = $nameLC . 'Found';
+                $data      = [
+                    $this->reservedNames[$nameLC],
+                    $param['name'],
+                ];
+
+                $phpcsFile->addWarning($message, $param['token'], $errorCode, $data);
             }
         }
     }

--- a/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.inc
+++ b/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.inc
@@ -1,13 +1,13 @@
 <?php
 
-function foo( $parameter, $descriptive_name ) {} // OK.
+function noReservedKeywords( $parameter, $descriptive_name ) {} // OK.
 
-function foo( $string, $echo = true ) {} // Bad x 2.
+function hasReservedKeywords( $string, $echo = true ) {} // Bad x 2.
 $closure = function ( $foreach, $array, $require ) {}; // Bad x 3.
 $fn = fn($callable, $list) => $callable($list); // Bad x 2.
 
 abstract class Foo {
-    abstract public function bar(
+    abstract public function abstractMethod(
         string &$string,
         Foo|false $exit,
         ?int $parent

--- a/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.inc
+++ b/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.inc
@@ -13,3 +13,9 @@ abstract class Foo {
         ?int $parent
     ); // Bad x 3.
 }
+
+// No parameters, nothing to do.
+function noParam() {}
+
+// Live coding/parse error. This has to be the last test in the file.
+function liveCoding($echo

--- a/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.inc
+++ b/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.inc
@@ -4,13 +4,30 @@ function noReservedKeywords( $parameter, $descriptive_name ) {} // OK.
 
 function hasReservedKeywords( $string, $echo = true ) {} // Bad x 2.
 $closure = function ( $foreach, $array, $require ) {}; // Bad x 3.
-$fn = fn($callable, $list) => $callable($list); // Bad x 2.
+$fn = fn($callable, $__FILE__) => $callable($__FILE__); // Bad x 2.
 
 abstract class Foo {
     abstract public function abstractMethod(
         string &$string,
         Foo|false $exit,
         ?int $parent
+    ); // Bad x 3.
+}
+
+/*
+ * Tests using less conventional param name casing.
+ */
+function noReservedKeywordsCasedParams( $Parameter, $DescriptiveName ) {} // OK.
+
+function hasReservedKeywordsCasedParams( $String, $ECHO = true ) {} // Bad x 2.
+$closure = function ( $forEach, $Array, $REQUIRE ) {}; // Bad x 3.
+$fn = fn($Callable, $__file__) => $Callable($__file__); // Bad x 2.
+
+abstract class Bar {
+    abstract public function abstractMethodCasedParams(
+        string &$STRING,
+        Foo|false $Exit,
+        ?int $PaReNt
     ); // Bad x 3.
 }
 

--- a/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.inc
+++ b/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.inc
@@ -31,6 +31,22 @@ abstract class Bar {
     ); // Bad x 3.
 }
 
+/*
+ * Also flag properties declared via constructor property promotion as those can also be
+ * passed to the class constructor as named parameters.
+ */
+class ConstructorPropertyPromotionNoTypes {
+    public function __construct(
+        public $const = 0.0,
+        protected $do = '',
+        private $eval = null,
+    ) {}
+}
+
+class ConstructorPropertyPromotionWithTypes {
+    public function __construct(protected float|int $Function, public ?string &$GLOBAL = 'test', private mixed $match) {}
+}
+
 // No parameters, nothing to do.
 function noParam() {}
 

--- a/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.php
+++ b/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.php
@@ -52,6 +52,10 @@ final class NoReservedKeywordParameterNamesUnitTest extends AbstractSniffUnitTes
             28 => 1,
             29 => 1,
             30 => 1,
+            40 => 1,
+            41 => 1,
+            42 => 1,
+            47 => 3,
         ];
     }
 }

--- a/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.php
+++ b/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.php
@@ -46,6 +46,12 @@ final class NoReservedKeywordParameterNamesUnitTest extends AbstractSniffUnitTes
             11 => 1,
             12 => 1,
             13 => 1,
+            22 => 2,
+            23 => 3,
+            24 => 2,
+            28 => 1,
+            29 => 1,
+            30 => 1,
         ];
     }
 }


### PR DESCRIPTION
### Universal/NoReservedKeywordParameterNames: minor code simplification

... which can be made now support for PHPCS < 3.7.1 has been dropped.

The sniff now only listens to tokens which are accepted by the `FunctionDeclarations::getParameters()` method, so checking for an exception should be unnecessary.

Includes removing a stray `$paramNames` variable setting, which is never used.

### Universal/NoReservedKeywordParameterNames: make tests more descriptive

### Universal/NoReservedKeywordParameterNames: add extra tests

... to safeguard bowing out for function declarations without parameters and that the sniff stays silent for unfinished function declarations.

### Universal/NoReservedKeywordParameterNames: make the check case-insensitive

While parameters (variables) are case-sensitive in PHP, keywords are not.

This commit improves the sniff to check for the keyword used in parameter names in a case-insensitive manner to make this sniff independent of code style rules regarding the case for parameter names.

Includes additional tests.

### Universal/NoReservedKeywordParameterNames: add tests with PHP 8.0 constructor property promotion

... to confirm that properties set via the constructor are also checked.

Properties set via the constructor can be _passed_ to the constructor using named parameters, so this check should also apply to those properties.