### PR TITLE
Universal/ForeachUniqueAssignment: improve analysis for foreach list assignments

### DIFF
--- a/Universal/Tests/CodeAnalysis/ForeachUniqueAssignmentUnitTest.inc
+++ b/Universal/Tests/CodeAnalysis/ForeachUniqueAssignmentUnitTest.inc
@@ -22,15 +22,23 @@ foreach ($array as $key => list($a) ) {}
 foreach ($array as $k => $k ) {}
 foreach ($array as /*comment*/ $k [ 'key' ] => $k['key'] ) {}
 foreach ($array as $k[$name /*comment*/] => $k[/*comment*/ $name] ) {}
-foreach ($array as [$a] => [$a] ) {}
-foreach ($array as list($a) => list($a) ) {}
+foreach ($array as $a => [$a] ) {}
+foreach ($array as $key => list($a, $key, $b) ) {}
 foreach ( $data as $this->prop['key'] => $this->prop['key'] ) {}
+foreach ( $array as $key['key'] => list( $a, $key['key'] ) ) {}
 
 // Also detect the same variable being used in combination with a reference assignment.
 foreach ($a as $k => &$k) {}
+
+// Ensure non-unique variables used in foreach list assignments are disregarded. Not the concern of this sniff.
+foreach ($data as $key => list(, ,)) {} // Invalid, empty list. Bow out.
+foreach ($data as [$id => $id]) {}
+foreach ($data as $key => list("id" => $id, "id" => $id)) {}
+foreach ($data as $key => ["id" => $id, "id" => $id]) {}
 
 /*
  * Parse errors, not our concern.
  */
 foreach ($array) {} // Missing "as".
 foreach ($array as $k => $k
+foreach ($array as $k => ) {}

--- a/Universal/Tests/CodeAnalysis/ForeachUniqueAssignmentUnitTest.inc
+++ b/Universal/Tests/CodeAnalysis/ForeachUniqueAssignmentUnitTest.inc
@@ -13,8 +13,8 @@ foreach ($array as $k => &$v ) {}
 foreach ($array as $k['key'] => $k['value'] ) {}
 foreach ($array as $k[$name] => $k[$value] ) {}
 foreach ($data as $key => [$id, [$name, $address]]) {}
-foreach ($data as list("id" => $id, "name" => $name)) {}
-foreach ($array as array($a) => list($a) ) {}
+foreach ($data as $key => list("id" => $id, "name" => $name)) {}
+foreach ($array as $key => list($a) ) {}
 
 /*
  * The issue.

--- a/Universal/Tests/CodeAnalysis/ForeachUniqueAssignmentUnitTest.inc.fixed
+++ b/Universal/Tests/CodeAnalysis/ForeachUniqueAssignmentUnitTest.inc.fixed
@@ -23,14 +23,22 @@ foreach ($array as $k ) {}
 foreach ($array as /*comment*/ $k['key'] ) {}
 foreach ($array as /*comment*/ $k[/*comment*/ $name] ) {}
 foreach ($array as [$a] ) {}
-foreach ($array as list($a) ) {}
+foreach ($array as list($a, $key, $b) ) {}
 foreach ( $data as $this->prop['key'] ) {}
+foreach ( $array as list( $a, $key['key'] ) ) {}
 
 // Also detect the same variable being used in combination with a reference assignment.
 foreach ($a as &$k) {}
+
+// Ensure non-unique variables used in foreach list assignments are disregarded. Not the concern of this sniff.
+foreach ($data as $key => list(, ,)) {} // Invalid, empty list. Bow out.
+foreach ($data as [$id => $id]) {}
+foreach ($data as $key => list("id" => $id, "id" => $id)) {}
+foreach ($data as $key => ["id" => $id, "id" => $id]) {}
 
 /*
  * Parse errors, not our concern.
  */
 foreach ($array) {} // Missing "as".
 foreach ($array as $k => $k
+foreach ($array as $k => ) {}

--- a/Universal/Tests/CodeAnalysis/ForeachUniqueAssignmentUnitTest.inc.fixed
+++ b/Universal/Tests/CodeAnalysis/ForeachUniqueAssignmentUnitTest.inc.fixed
@@ -13,8 +13,8 @@ foreach ($array as $k => &$v ) {}
 foreach ($array as $k['key'] => $k['value'] ) {}
 foreach ($array as $k[$name] => $k[$value] ) {}
 foreach ($data as $key => [$id, [$name, $address]]) {}
-foreach ($data as list("id" => $id, "name" => $name)) {}
-foreach ($array as array($a) => list($a) ) {}
+foreach ($data as $key => list("id" => $id, "name" => $name)) {}
+foreach ($array as $key => list($a) ) {}
 
 /*
  * The issue.

--- a/Universal/Tests/CodeAnalysis/ForeachUniqueAssignmentUnitTest.php
+++ b/Universal/Tests/CodeAnalysis/ForeachUniqueAssignmentUnitTest.php
@@ -36,7 +36,8 @@ final class ForeachUniqueAssignmentUnitTest extends AbstractSniffUnitTest
             25 => 1,
             26 => 1,
             27 => 1,
-            30 => 1,
+            28 => 1,
+            31 => 1,
         ];
     }
 


### PR DESCRIPTION
### Universal/ForeachUniqueAssignment: fix some tests

These tests weren't testing the sniff well enough.

### Universal/ForeachUniqueAssignment: improve analysis for foreach list assignments

This commit:
* Prevents _"accidentally correct"_ handling of code like `foreach ($data as [$id => $id])`, where the first `$id` is not the key for the foreach assignment, so is not the concern of this sniff.
* Improves analysis for key vs value when the value is a list assignment.
    Previously, the key and the value would just be compared as found. Now, each individual assignment in the list will be compared against the key.
    Notes: nested list assignment are not (yet) taken into account.

Includes improved and additional tests.