### PR TITLE
Universal/DisallowStandalonePostIncrementDecrement: allow for statement ending with close tag

### DIFF
--- a/Universal/Sniffs/Operators/DisallowStandalonePostIncrementDecrementSniff.php
+++ b/Universal/Sniffs/Operators/DisallowStandalonePostIncrementDecrementSniff.php
@@ -98,7 +98,14 @@ final class DisallowStandalonePostIncrementDecrementSniff implements Sniff
         $start = BCFile::findStartOfStatement($phpcsFile, $stackPtr);
         $end   = BCFile::findEndOfStatement($phpcsFile, $stackPtr);
 
-        if ($tokens[$end]['code'] !== \T_SEMICOLON) {
+        if (isset(Collections::incrementDecrementOperators()[$tokens[$end]['code']])) {
+            // Statement ends on a PHP close tag, set the end pointer to the close tag.
+            $end = $phpcsFile->findNext(Tokens::$emptyTokens, ($end + 1), null, true);
+        }
+
+        if ($tokens[$end]['code'] !== \T_SEMICOLON
+            && $tokens[$end]['code'] !== \T_CLOSE_TAG
+        ) {
             // Not a stand-alone statement.
             return $end;
         }

--- a/Universal/Tests/Operators/DisallowStandalonePostIncrementDecrementUnitTest.inc
+++ b/Universal/Tests/Operators/DisallowStandalonePostIncrementDecrementUnitTest.inc
@@ -5,16 +5,16 @@
  */
 $i = 10;
 --$i;
--- $i;
+-- $i ?> <?php
 -- /*comment*/ $i;
     ++$i;
     ++
-    $i;
+    $i ?> <?php
     ++/*comment*/$i;
 
 if (true) {
     ++ClassName::$v;
---\Fully\Qualified\ClassName::$v;
+--\Fully\Qualified\ClassName::$v ?> <?php
     ++namespace\ClassName::$v;
 }
 
@@ -22,14 +22,14 @@ if (true) {
 
 --$a[0];
 
-++$obj->prop;
+++$obj->prop ?> <?php
 --$obj->prop;
 
 /*
  * These should throw errors.
  */
 $i--;
-$i        --;
+$i        -- ?> <?php
 $i /*comment*/ --;
     $i++;
     $i ++;
@@ -39,13 +39,13 @@ $a[0]--;
 
 if (true) {
     ClassName::$v++;
-\Fully\Qualified\ClassName::$v--;
+\Fully\Qualified\ClassName::$v-- ?> <?php
     namespace\ClassName::$v++;
 }
 
 self::$v++;self::$v--;
 
-           $obj->prop ++;
+           $obj->prop ++ ?> <?php
 /*comment*/ $obj-> /*comment*/ prop --;
 
 $obj->prop[$value[2]]++;
@@ -55,7 +55,7 @@ $var['key' . ($i + 10) . 'key']--;
  * Report on, but don't auto-fix, statements with multiple in/decrementers.
  */
 ++$i--;
-++ -- $i ++ ++;
+++ -- $i ++ ++ ?> <?php
 
 /*
  * Don't touch non-stand-alone statements.
@@ -64,7 +64,7 @@ while ($i++ && $i < 10);
 
 for ($i = 0; $i < 10; $i++) {}
 
-function_call($i--, $j++);
+function_call($i--, $j++) ?> <?php
 
 $a = 10 + $i++ - 5;
 

--- a/Universal/Tests/Operators/DisallowStandalonePostIncrementDecrementUnitTest.inc.fixed
+++ b/Universal/Tests/Operators/DisallowStandalonePostIncrementDecrementUnitTest.inc.fixed
@@ -5,16 +5,16 @@
  */
 $i = 10;
 --$i;
--- $i;
+-- $i ?> <?php
 -- /*comment*/ $i;
     ++$i;
     ++
-    $i;
+    $i ?> <?php
     ++/*comment*/$i;
 
 if (true) {
     ++ClassName::$v;
---\Fully\Qualified\ClassName::$v;
+--\Fully\Qualified\ClassName::$v ?> <?php
     ++namespace\ClassName::$v;
 }
 
@@ -22,14 +22,14 @@ if (true) {
 
 --$a[0];
 
-++$obj->prop;
+++$obj->prop ?> <?php
 --$obj->prop;
 
 /*
  * These should throw errors.
  */
 --$i;
---$i        ;
+--$i         ?> <?php
 --$i /*comment*/ ;
     ++$i;
     ++$i ;
@@ -39,13 +39,13 @@ if (true) {
 
 if (true) {
     ++ClassName::$v;
---\Fully\Qualified\ClassName::$v;
+--\Fully\Qualified\ClassName::$v ?> <?php
     ++namespace\ClassName::$v;
 }
 
 ++self::$v;--self::$v;
 
-           ++$obj->prop ;
+           ++$obj->prop  ?> <?php
 /*comment*/ --$obj-> /*comment*/ prop ;
 
 ++$obj->prop[$value[2]];
@@ -55,7 +55,7 @@ if (true) {
  * Report on, but don't auto-fix, statements with multiple in/decrementers.
  */
 ++$i--;
-++ -- $i ++ ++;
+++ -- $i ++ ++ ?> <?php
 
 /*
  * Don't touch non-stand-alone statements.
@@ -64,7 +64,7 @@ while ($i++ && $i < 10);
 
 for ($i = 0; $i < 10; $i++) {}
 
-function_call($i--, $j++);
+function_call($i--, $j++) ?> <?php
 
 $a = 10 + $i++ - 5;
 


### PR DESCRIPTION
A stand-alone statement doesn't necessarily have to end with a semi-colon. It can also end on a PHP close tag.

This commit adjusts the sniff to take this into account.

Includes adjusting some pre-existing tests to safeguard the change.