### PR TITLE
Universal/DuplicateArrayKey: add support for detecting duplicate key PHP cross-version

### DIFF
--- a/Universal/Sniffs/Arrays/DuplicateArrayKeySniff.php
+++ b/Universal/Sniffs/Arrays/DuplicateArrayKeySniff.php
@@ -13,6 +13,7 @@ namespace PHPCSExtra\Universal\Sniffs\Arrays;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff;
+use PHPCSUtils\BackCompat\Helper;
 
 /**
  * Detect duplicate array keys in array declarations.
@@ -20,29 +21,61 @@ use PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff;
  * This sniff will detect duplicate keys with high precision, though any array key
  * set via a variable/constant/function call is excluded from the examination.
  *
+ * The sniff will handle the change in how numeric array keys are set
+ * since PHP 8.0 and will flag keys which would be duplicates cross-version.
+ * {@link https://wiki.php.net/rfc/negative_array_index}
+ *
  * @since 1.0.0
  */
 final class DuplicateArrayKeySniff extends AbstractArrayDeclarationSniff
 {
 
     /**
-     * Keep track of which array keys have been seen already.
+     * Keep track of which array keys have been seen already on PHP < 8.0.
      *
      * @since 1.0.0
      *
      * @var array
      */
-    private $keysSeen = [];
+    private $keysSeenLt8 = [];
+
+    /**
+     * Keep track of which array keys have been seen already on PHP >= 8.0.
+     *
+     * @since 1.0.0
+     *
+     * @var array
+     */
+    private $keysSeenGt8 = [];
 
     /**
      * Keep track of the maximum seen integer key to know what the next value will be for
-     * array items without a key.
+     * array items without a key on PHP < 8.0.
      *
      * @since 1.0.0
      *
      * @var int
      */
-    private $currentMaxIntKey = -1;
+    private $currentMaxIntKeyLt8;
+
+    /**
+     * Keep track of the maximum seen integer key to know what the next value will be for
+     * array items without a key on PHP >= 8.0.
+     *
+     * @since 1.0.0
+     *
+     * @var int
+     */
+    private $currentMaxIntKeyGt8;
+
+    /**
+     * The current PHP version.
+     *
+     * @since 1.0.0
+     *
+     * @var int
+     */
+    private $phpVersion;
 
     /**
      * Process every part of the array declaration.
@@ -60,8 +93,17 @@ final class DuplicateArrayKeySniff extends AbstractArrayDeclarationSniff
     public function processArray(File $phpcsFile)
     {
         // Reset properties before processing this array.
-        $this->keysSeen         = [];
-        $this->currentMaxIntKey = -1;
+        $this->keysSeenLt8 = [];
+        $this->keysSeenGt8 = [];
+
+        if (isset($this->phpVersion) === false) {
+            $phpVersion = Helper::getConfigData('php_version');
+            if ($phpVersion !== null) {
+                $this->phpVersion = (int) $phpVersion;
+            }
+        }
+
+        unset($this->currentMaxIntKeyLt8, $this->currentMaxIntKeyGt8);
 
         parent::processArray($phpcsFile);
     }
@@ -92,41 +134,131 @@ final class DuplicateArrayKeySniff extends AbstractArrayDeclarationSniff
 
         $integerKey = \is_int($key);
 
+        $errorMsg  = 'Duplicate array key found. The value will be overwritten%s.'
+            . ' The %s array key "%s" was first seen on line %d';
+        $errorCode = 'Found';
+        $errors    = [];
+        $baseData  = [
+            ($integerKey === true) ? 'integer' : 'string',
+            $key,
+        ];
+
         /*
-         * Check if we've seen it before.
+         * Check if we've seen the key before.
+         *
+         * If no PHP version was passed, throw errors both for PHP < 8.0 and PHP >= 8.0.
+         * If a PHP version was set, only throw the error appropriate for the selected PHP version.
+         * If both errors would effectively be the same, only throw one.
          */
-        if (isset($this->keysSeen[$key]) === true) {
-            $firstSeen              = $this->keysSeen[$key];
-            $firstNonEmptyFirstSeen = $phpcsFile->findNext(Tokens::$emptyTokens, $firstSeen['ptr'], null, true);
-            $firstNonEmpty          = $phpcsFile->findNext(Tokens::$emptyTokens, $startPtr, null, true);
+        if (isset($this->phpVersion) === false || $this->phpVersion < 80000) {
+            if (isset($this->keysSeenLt8[$key]) === true) {
+                $errorSuffix     = '';
+                $errorCodeSuffix = '';
+                if ($integerKey === true) {
+                    $errorSuffix     = ' when using PHP < 8.0';
+                    $errorCodeSuffix = 'ForPHPlt80';
+                }
 
-            $data = [
-                ($integerKey === true) ? 'integer' : 'string',
-                $key,
-                $this->tokens[$firstNonEmptyFirstSeen]['line'],
-            ];
+                $firstSeen              = $this->keysSeenLt8[$key];
+                $firstNonEmptyFirstSeen = $phpcsFile->findNext(Tokens::$emptyTokens, $firstSeen['ptr'], null, true);
+                $dataLt8                = $baseData;
+                $dataLt8[]              = $this->tokens[$firstNonEmptyFirstSeen]['line'];
 
-            $phpcsFile->addError(
-                'Duplicate array key found. The value will be overwritten.'
-                    . ' The %s array key "%s" was first seen on line %d',
-                $firstNonEmpty,
-                'Found',
-                $data
-            );
+                $errors['phplt8'] = [
+                    'data_subset'  => $dataLt8,
+                    'error_suffix' => $errorSuffix,
+                    'code_suffix'  => $errorCodeSuffix,
+                ];
+            }
+        }
+
+        if (isset($this->phpVersion) === false || $this->phpVersion >= 80000) {
+            if (isset($this->keysSeenGt8[$key]) === true) {
+                $errorSuffix     = '';
+                $errorCodeSuffix = '';
+                if ($integerKey === true) {
+                    $errorSuffix     = ' when using PHP >= 8.0';
+                    $errorCodeSuffix = 'ForPHPgte80';
+                }
+
+                $firstSeen              = $this->keysSeenGt8[$key];
+                $firstNonEmptyFirstSeen = $phpcsFile->findNext(Tokens::$emptyTokens, $firstSeen['ptr'], null, true);
+                $dataGt8                = $baseData;
+                $dataGt8[]              = $this->tokens[$firstNonEmptyFirstSeen]['line'];
+
+                $errors['phpgt8'] = [
+                    'data_subset'  => $dataGt8,
+                    'error_suffix' => $errorSuffix,
+                    'code_suffix'  => $errorCodeSuffix,
+                ];
+            }
+        }
+
+        if ($errors !== []) {
+            $firstNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $startPtr, null, true);
+
+            if (isset($errors['phplt8'], $errors['phpgt8'])) {
+                if ($errors['phplt8']['data_subset'] === $errors['phpgt8']['data_subset']) {
+                    // Only throw the error once if it would be the same for PHP < 8.0 and PHP >= 8.0.
+                    $data = $errors['phplt8']['data_subset'];
+                    \array_unshift($data, '');
+
+                    $phpcsFile->addError($errorMsg, $firstNonEmpty, $errorCode, $data);
+                } else {
+                    // Throw both errors.
+                    $codeLt8 = $errorCode . $errors['phplt8']['code_suffix'];
+                    $dataLt8 = $errors['phplt8']['data_subset'];
+                    \array_unshift($dataLt8, $errors['phplt8']['error_suffix']);
+
+                    $phpcsFile->addError($errorMsg, $firstNonEmpty, $codeLt8, $dataLt8);
+
+                    $codeGt8 = $errorCode . $errors['phpgt8']['code_suffix'];
+                    $dataGt8 = $errors['phpgt8']['data_subset'];
+                    \array_unshift($dataGt8, $errors['phpgt8']['error_suffix']);
+
+                    $phpcsFile->addError($errorMsg, $firstNonEmpty, $codeGt8, $dataGt8);
+                }
+            } elseif (isset($errors['phplt8'])) {
+                $errorCode .= $errors['phplt8']['code_suffix'];
+                $data       = $errors['phplt8']['data_subset'];
+                \array_unshift($data, $errors['phplt8']['error_suffix']);
+
+                $phpcsFile->addError($errorMsg, $firstNonEmpty, $errorCode, $data);
+            } elseif (isset($errors['phpgt8'])) {
+                $errorCode .= $errors['phpgt8']['code_suffix'];
+                $data       = $errors['phpgt8']['data_subset'];
+                \array_unshift($data, $errors['phpgt8']['error_suffix']);
+
+                $phpcsFile->addError($errorMsg, $firstNonEmpty, $errorCode, $data);
+            }
 
             return;
         }
 
         /*
-         * Key not seen before. Add to array.
+         * Key not seen before. Add to arrays.
          */
-        $this->keysSeen[$key] = [
+        $this->keysSeenLt8[$key] = [
+            'item' => $itemNr,
+            'ptr'  => $startPtr,
+        ];
+        $this->keysSeenGt8[$key] = [
             'item' => $itemNr,
             'ptr'  => $startPtr,
         ];
 
-        if ($integerKey === true && $key > $this->currentMaxIntKey) {
-            $this->currentMaxIntKey = $key;
+        if ($integerKey === true) {
+            if ((isset($this->currentMaxIntKeyLt8) === false && $key > -1)
+                || (isset($this->currentMaxIntKeyLt8) === true && $key > $this->currentMaxIntKeyLt8)
+            ) {
+                $this->currentMaxIntKeyLt8 = $key;
+            }
+
+            if (isset($this->currentMaxIntKeyGt8) === false
+                || $key > $this->currentMaxIntKeyGt8
+            ) {
+                $this->currentMaxIntKeyGt8 = $key;
+            }
         }
     }
 
@@ -146,8 +278,24 @@ final class DuplicateArrayKeySniff extends AbstractArrayDeclarationSniff
      */
     public function processNoKey(File $phpcsFile, $startPtr, $itemNr)
     {
-        ++$this->currentMaxIntKey;
-        $this->keysSeen[$this->currentMaxIntKey] = [
+        // Track the key for PHP < 8.0.
+        if (isset($this->currentMaxIntKeyLt8) === false) {
+            $this->currentMaxIntKeyLt8 = -1;
+        }
+
+        ++$this->currentMaxIntKeyLt8;
+        $this->keysSeenLt8[$this->currentMaxIntKeyLt8] = [
+            'item' => $itemNr,
+            'ptr'  => $startPtr,
+        ];
+
+        // Track the key for PHP 8.0+.
+        if (isset($this->currentMaxIntKeyGt8) === false) {
+            $this->currentMaxIntKeyGt8 = -1;
+        }
+
+        ++$this->currentMaxIntKeyGt8;
+        $this->keysSeenGt8[$this->currentMaxIntKeyGt8] = [
             'item' => $itemNr,
             'ptr'  => $startPtr,
         ];

--- a/Universal/Tests/Arrays/DuplicateArrayKeyUnitTest.inc
+++ b/Universal/Tests/Arrays/DuplicateArrayKeyUnitTest.inc
@@ -151,3 +151,17 @@ $testKeepingTrackOfHighestIntKey = array(
     '9' . '6'  => 'y',    // Int 96 - Error.
     '1.'       => 'z',    // String '1.'
 );
+
+$testPHPLt8VsPHP8 = array(
+    -10 => 'a',
+    'b',        // PHP < 8: int 0; PHP 8+: -9.
+    'c',        // PHP < 8: int 1; PHP 8+: -8.
+    -4  => 'd',
+    'e',        // PHP < 8: int 2; PHP 8+: -3.
+    -9  => 'f', // Duplicate in PHP 8, not in PHP < 8.
+    -8  => 'g', // Duplicate in PHP 8, not in PHP < 8.
+    -3  => 'h', // Duplicate in PHP 8, not in PHP < 8.
+    0   => 'i', // Duplicate in PHP < 8, not in PHP 8.
+    1   => 'j', // Duplicate in PHP < 8, not in PHP 8.
+    2   => 'k', // Duplicate in PHP < 8, not in PHP 8.
+);

--- a/Universal/Tests/Arrays/DuplicateArrayKeyUnitTest.php
+++ b/Universal/Tests/Arrays/DuplicateArrayKeyUnitTest.php
@@ -11,6 +11,7 @@
 namespace PHPCSExtra\Universal\Tests\Arrays;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHPCSUtils\BackCompat\Helper;
 
 /**
  * Unit test class for the DuplicateArrayKey sniff.
@@ -109,6 +110,12 @@ final class DuplicateArrayKeyUnitTest extends AbstractSniffUnitTest
             147 => 1,
             148 => 1,
             151 => 1,
+            161 => 1,
+            162 => 1,
+            163 => 1,
+            164 => 1,
+            165 => 1,
+            166 => 1,
         ];
     }
 


### PR DESCRIPTION
How array keys for array items without keys are being determined, has changed in PHP 8.0.

Previously, the key would be the highest previously seen numeric key + 1, providing the highest previously seen numeric key was 0 or higher. Otherwise, it would be 0.

As of PHP 8.0, the key will be the highest previously seen numeric key + 1, independently of whether the previously seen numeric key was negative.

The sniff will now calculate and track the keys for unkeyed array items using both the PHP < 8.0 logic as well as the PHP >= 8.0 logic.

If a duplicate key would yield the same error in both PHP < 8.0 as well as PHP >= 8.0, the `Found` error code will be used. If a duplicate key would only be a duplicate on PHP < 8.0, the `FoundForPHPlt80` error code will be used and the error message will indicate the error only applies to PHP < 8.0. If a duplicate key would only be a duplicate on PHP > 8.0, the `FoundForPHPgte80` and the error message will indicate the error only applies to PHP >= 8.0.

If the end-user has set the `php_version` configuration option, the sniff will respect that and only report duplicate keys for the PHP version indicated.

Includes additional unit tests.

P.S.: the code could possible be made smarter, but for now, this is fine as the goal of accounting for this change in PHP has been achieved.

Refs:
* https://3v4l.org/liBXD
* https://wiki.php.net/rfc/negative_array_index
* https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-php-version