### PR TITLE
CS/QA: various minor fixes

### DIFF
--- a/NormalizedArrays/Sniffs/Arrays/CommaAfterLastSniff.php
+++ b/NormalizedArrays/Sniffs/Arrays/CommaAfterLastSniff.php
@@ -205,6 +205,7 @@ final class CommaAfterLastSniff implements Sniff
                     }
 
                     $phpcsFile->fixer->beginChangeset();
+
                     for ($i = $start; $i <= $end; $i++) {
                         $phpcsFile->fixer->replaceToken($i, '');
                     }

--- a/Universal/Sniffs/Classes/DisallowAnonClassParenthesesSniff.php
+++ b/Universal/Sniffs/Classes/DisallowAnonClassParenthesesSniff.php
@@ -78,8 +78,9 @@ final class DisallowAnonClassParenthesesSniff implements Sniff
             // @codeCoverageIgnoreEnd
         }
 
-        $closer    = $tokens[$nextNonEmpty]['parenthesis_closer'];
-        $hasParams = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonEmpty + 1), $closer, true);
+        $opener    = $nextNonEmpty;
+        $closer    = $tokens[$opener]['parenthesis_closer'];
+        $hasParams = $phpcsFile->findNext(Tokens::$emptyTokens, ($opener + 1), $closer, true);
         if ($hasParams !== false) {
             // There is something between the parentheses. Ignore.
             $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'yes, with parameter(s)');
@@ -97,7 +98,7 @@ final class DisallowAnonClassParenthesesSniff implements Sniff
         if ($fix === true) {
             $phpcsFile->fixer->beginChangeset();
 
-            for ($i = $nextNonEmpty; $i <= $closer; $i++) {
+            for ($i = $opener; $i <= $closer; $i++) {
                 if (isset(Tokens::$commentTokens[$tokens[$i]['code']]) === true) {
                     continue;
                 }

--- a/Universal/Sniffs/Classes/DisallowAnonClassParenthesesSniff.php
+++ b/Universal/Sniffs/Classes/DisallowAnonClassParenthesesSniff.php
@@ -41,9 +41,7 @@ final class DisallowAnonClassParenthesesSniff implements Sniff
      */
     public function register()
     {
-        return [
-            \T_ANON_CLASS,
-        ];
+        return [\T_ANON_CLASS];
     }
 
     /**
@@ -98,6 +96,7 @@ final class DisallowAnonClassParenthesesSniff implements Sniff
 
         if ($fix === true) {
             $phpcsFile->fixer->beginChangeset();
+
             for ($i = $nextNonEmpty; $i <= $closer; $i++) {
                 if (isset(Tokens::$commentTokens[$tokens[$i]['code']]) === true) {
                     continue;
@@ -105,6 +104,7 @@ final class DisallowAnonClassParenthesesSniff implements Sniff
 
                 $phpcsFile->fixer->replaceToken($i, '');
             }
+
             $phpcsFile->fixer->endChangeset();
         }
     }

--- a/Universal/Sniffs/Classes/DisallowFinalClassSniff.php
+++ b/Universal/Sniffs/Classes/DisallowFinalClassSniff.php
@@ -42,9 +42,7 @@ final class DisallowFinalClassSniff implements Sniff
      */
     public function register()
     {
-        return [
-            \T_CLASS,
-        ];
+        return [\T_CLASS];
     }
 
     /**

--- a/Universal/Sniffs/Classes/ModifierKeywordOrderSniff.php
+++ b/Universal/Sniffs/Classes/ModifierKeywordOrderSniff.php
@@ -18,7 +18,7 @@ use PHPCSUtils\Tokens\Collections;
 /**
  * Standardize the modifier keyword order for class declarations.
  *
- * @since 1.0.0-alpha4
+ * @since 1.0.0
  */
 final class ModifierKeywordOrderSniff implements Sniff
 {
@@ -26,7 +26,7 @@ final class ModifierKeywordOrderSniff implements Sniff
     /**
      * Name of the metric.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var string
      */
@@ -35,7 +35,7 @@ final class ModifierKeywordOrderSniff implements Sniff
     /**
      * Order preference: abstract/final readonly.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var string
      */
@@ -44,7 +44,7 @@ final class ModifierKeywordOrderSniff implements Sniff
     /**
      * Order preference: readonly abstract/final.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var string
      */
@@ -59,7 +59,7 @@ final class ModifierKeywordOrderSniff implements Sniff
      *
      * Defaults to "extendability readonly".
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var string
      */
@@ -68,7 +68,7 @@ final class ModifierKeywordOrderSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @return array
      */
@@ -80,7 +80,7 @@ final class ModifierKeywordOrderSniff implements Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the current token
@@ -178,7 +178,7 @@ final class ModifierKeywordOrderSniff implements Sniff
     /**
      * Throw the error and potentially fix it.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile     The file being scanned.
      * @param int                         $firstKeyword  The position of the first keyword found.

--- a/Universal/Sniffs/Classes/RequireAnonClassParenthesesSniff.php
+++ b/Universal/Sniffs/Classes/RequireAnonClassParenthesesSniff.php
@@ -40,9 +40,7 @@ final class RequireAnonClassParenthesesSniff implements Sniff
      */
     public function register()
     {
-        return [
-            \T_ANON_CLASS,
-        ];
+        return [\T_ANON_CLASS];
     }
 
     /**

--- a/Universal/Sniffs/Classes/RequireFinalClassSniff.php
+++ b/Universal/Sniffs/Classes/RequireFinalClassSniff.php
@@ -42,9 +42,7 @@ final class RequireFinalClassSniff implements Sniff
      */
     public function register()
     {
-        return [
-            \T_CLASS,
-        ];
+        return [\T_CLASS];
     }
 
     /**

--- a/Universal/Sniffs/Constants/LowercaseClassResolutionKeywordSniff.php
+++ b/Universal/Sniffs/Constants/LowercaseClassResolutionKeywordSniff.php
@@ -43,9 +43,7 @@ final class LowercaseClassResolutionKeywordSniff implements Sniff
      */
     public function register()
     {
-        return [
-            \T_STRING,
-        ];
+        return [\T_STRING];
     }
 
     /**

--- a/Universal/Sniffs/Constants/ModifierKeywordOrderSniff.php
+++ b/Universal/Sniffs/Constants/ModifierKeywordOrderSniff.php
@@ -18,7 +18,7 @@ use PHPCSUtils\Utils\Scopes;
 /**
  * Standardize the modifier keyword order for OO constant declarations.
  *
- * @since 1.0.0-alpha4
+ * @since 1.0.0
  */
 final class ModifierKeywordOrderSniff implements Sniff
 {
@@ -26,7 +26,7 @@ final class ModifierKeywordOrderSniff implements Sniff
     /**
      * Name of the metric.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var string
      */
@@ -35,7 +35,7 @@ final class ModifierKeywordOrderSniff implements Sniff
     /**
      * Order preference: final visibility.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var string
      */
@@ -44,7 +44,7 @@ final class ModifierKeywordOrderSniff implements Sniff
     /**
      * Order preference: visibility final.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var string
      */
@@ -59,7 +59,7 @@ final class ModifierKeywordOrderSniff implements Sniff
      *
      * Defaults to "final visibility".
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var string
      */
@@ -68,7 +68,7 @@ final class ModifierKeywordOrderSniff implements Sniff
     /**
      * Tokens which can be constant modifier keywords.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var array
      */
@@ -79,7 +79,7 @@ final class ModifierKeywordOrderSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @return array
      */
@@ -94,7 +94,7 @@ final class ModifierKeywordOrderSniff implements Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the current token
@@ -175,7 +175,7 @@ final class ModifierKeywordOrderSniff implements Sniff
     /**
      * Throw the error and potentially fix it.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile     The file being scanned.
      * @param int                         $firstKeyword  The position of the first keyword found.

--- a/Universal/Sniffs/ControlStructures/DisallowLonelyIfSniff.php
+++ b/Universal/Sniffs/ControlStructures/DisallowLonelyIfSniff.php
@@ -39,9 +39,7 @@ final class DisallowLonelyIfSniff implements Sniff
      */
     public function register()
     {
-        return [
-            \T_ELSE,
-        ];
+        return [\T_ELSE];
     }
 
     /**
@@ -274,7 +272,7 @@ final class DisallowLonelyIfSniff implements Sniff
         }
 
         // Remove the inner scope closer.
-            $phpcsFile->fixer->replaceToken($innerScopeCloser, '');
+        $phpcsFile->fixer->replaceToken($innerScopeCloser, '');
         $i = ($innerScopeCloser - 1);
 
         // Handle alternative syntax for the closer.

--- a/Universal/Sniffs/ControlStructures/IfElseDeclarationSniff.php
+++ b/Universal/Sniffs/ControlStructures/IfElseDeclarationSniff.php
@@ -94,7 +94,7 @@ final class IfElseDeclarationSniff implements Sniff
          */
         $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if ($prevNonEmpty === false || $tokens[$prevNonEmpty]['code'] !== \T_CLOSE_CURLY_BRACKET) {
-            // Parse error. Not our concern.
+            // Parse error or mixing braced and non-braced. Not our concern.
             return;
         }
 

--- a/Universal/Sniffs/Namespaces/DisallowDeclarationWithoutNameSniff.php
+++ b/Universal/Sniffs/Namespaces/DisallowDeclarationWithoutNameSniff.php
@@ -65,7 +65,6 @@ final class DisallowDeclarationWithoutNameSniff implements Sniff
         if ($name !== '') {
             // Named namespace.
             $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'yes');
-
             return;
         }
 

--- a/Universal/Sniffs/Operators/DisallowStandalonePostIncrementDecrementSniff.php
+++ b/Universal/Sniffs/Operators/DisallowStandalonePostIncrementDecrementSniff.php
@@ -184,14 +184,12 @@ final class DisallowStandalonePostIncrementDecrementSniff implements Sniff
 
         $fix = $phpcsFile->addFixableError($error, $stackPtr, $errorCode, $data);
 
-        if ($fix === false) {
-            return $end;
+        if ($fix === true) {
+            $phpcsFile->fixer->beginChangeset();
+            $phpcsFile->fixer->replaceToken($stackPtr, '');
+            $phpcsFile->fixer->addContentBefore($start, $tokens[$stackPtr]['content']);
+            $phpcsFile->fixer->endChangeset();
         }
-
-        $phpcsFile->fixer->beginChangeset();
-        $phpcsFile->fixer->replaceToken($stackPtr, '');
-        $phpcsFile->fixer->addContentBefore($start, $tokens[$stackPtr]['content']);
-        $phpcsFile->fixer->endChangeset();
 
         return $end;
     }

--- a/Universal/Sniffs/Operators/DisallowStandalonePostIncrementDecrementSniff.php
+++ b/Universal/Sniffs/Operators/DisallowStandalonePostIncrementDecrementSniff.php
@@ -67,7 +67,7 @@ final class DisallowStandalonePostIncrementDecrementSniff implements Sniff
         $this->allowedTokens += Collections::namespacedNameTokens();
 
         /*
-         * Remove potential nullsafe object operator. In/decrement not allowed in write context,
+         * Remove nullsafe object operator. In/decrement not allowed in write context,
          * so ignore.
          */
         unset($this->allowedTokens[\T_NULLSAFE_OBJECT_OPERATOR]);

--- a/Universal/Sniffs/PHP/OneStatementInShortEchoTagSniff.php
+++ b/Universal/Sniffs/PHP/OneStatementInShortEchoTagSniff.php
@@ -36,9 +36,7 @@ final class OneStatementInShortEchoTagSniff implements Sniff
      */
     public function register()
     {
-        return [
-            \T_OPEN_TAG_WITH_ECHO,
-        ];
+        return [\T_OPEN_TAG_WITH_ECHO];
     }
 
     /**

--- a/Universal/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
+++ b/Universal/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
@@ -28,7 +28,7 @@ use PHPCSUtils\Tokens\Collections;
  * - Precision alignment *within* text strings (multi-line text strings, heredocs, nowdocs)
  *   will NOT be flagged by this sniff.
  * - The fixer works based on "best guess" and may not always result in the desired indentation.
- * - This fixer will use tabs or spaces based on whether tabs where present in the original indent.
+ * - This fixer will use tabs or spaces based on whether tabs were present in the original indent.
  *   Use the PHPCS native `Generic.WhiteSpace.DisallowTabIndent` or the
  *   `Generic.WhiteSpace.DisallowSpaceIndent` sniff to clean up the results if so desired.
  *

--- a/Universal/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
+++ b/Universal/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
@@ -304,7 +304,7 @@ final class PrecisionAlignmentSniff implements Sniff
                 case \T_END_NOWDOC:
                     /*
                      * PHPCS does not execute tab replacement in heredoc/nowdoc closer
-                     * tokens (last checked: PHPCS 3.7.1), so handle this ourselves.
+                     * tokens prior to PHPCS 3.7.2, so handle this ourselves.
                      */
                     $content = $tokens[$i]['content'];
                     if (\strpos($tokens[$i]['content'], "\t") !== false) {

--- a/Universal/Tests/Arrays/DuplicateArrayKeyUnitTest.php
+++ b/Universal/Tests/Arrays/DuplicateArrayKeyUnitTest.php
@@ -11,7 +11,6 @@
 namespace PHPCSExtra\Universal\Tests\Arrays;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
-use PHPCSUtils\BackCompat\Helper;
 
 /**
  * Unit test class for the DuplicateArrayKey sniff.

--- a/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
+++ b/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
@@ -37,7 +37,7 @@ final class DisallowInlineTabsUnitTest extends AbstractSniffUnitTest
          * next to impossible.
          * But having to continuously restart builds is getting silly.
          */
-        return (PHP_MAJOR_VERSION === 5 && PHP_MINOR_VERSION === 5);
+        return (\PHP_MAJOR_VERSION === 5 && \PHP_MINOR_VERSION === 5);
     }
 
     /**


### PR DESCRIPTION
### CS/QA: various minor code tweaks

### Docs: normalize `@since` tags

### DisallowAnonClassParentheses: minor code readability improvement

### Universal/PrecisionAlignment: update comment

... now upstream PR 3639 has been merged.

Ref:
* squizlabs/PHP_CodeSniffer#3639

### Docs: improve a few inline comments