### PR TITLE
Composer: add PHPCSDevCS to the dependencies

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -43,9 +43,6 @@ jobs:
           composer remove --no-update --dev phpunit/phpunit --no-scripts --no-interaction
           # Using PHPCS `master` as an early detection system for bugs upstream.
           composer require --no-update squizlabs/php_codesniffer:"dev-master" --no-interaction
-          # Add PHPCSDevCS - this is the CS ruleset we use.
-          # This is not in the composer.json as it has different minimum PHPCS reqs and would conflict.
-          composer require --no-update --dev phpcsstandards/phpcsdevcs:"^1.1.3" --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     "require-dev" : {
         "php-parallel-lint/php-parallel-lint": "^1.3.2",
         "php-parallel-lint/php-console-highlighter": "^1.0",
+        "phpcsstandards/phpcsdevcs": "^1.1.5",
         "phpcsstandards/phpcsdevtools": "^1.2.0",
         "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0"
     },
@@ -43,21 +44,11 @@
         "lint": [
             "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . --show-deprecated -e php --exclude vendor --exclude .git"
         ],
-        "install-devcs": [
-            "composer require --dev phpcsstandards/phpcsdevcs:\"^1.1.3\" --no-suggest --no-interaction"
-        ],
-        "remove-devcs": [
-            "composer remove --dev phpcsstandards/phpcsdevcs --no-interaction"
-        ],
         "checkcs": [
-            "@install-devcs",
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
-            "@remove-devcs"
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
         ],
         "fixcs": [
-            "@install-devcs",
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf",
-            "@remove-devcs"
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
         ],
         "check-complete": [
             "@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./Modernize ./NormalizedArrays ./Universal"


### PR DESCRIPTION
PHPCSDevCS was previously not added to the `require-dev` dependencies as the minimum supported PHPCS version conflicted with the minimum supported PHPCS version of this package.

Now this is no longer the case, the package can be safely added to `require-dev` and work-arounds can be removed.