### PR TITLE
GH Actions: various tweaks

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: 'latest'
           coverage: none
           tools: cs2pr
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,10 +50,6 @@ jobs:
             phpcs_version: 'dev-master'
             experimental: true
 
-          #- php: '7.4'
-          #  phpcs_version: '4.0.x-dev'
-          #  experimental: true
-
     name: "Test${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
 
     continue-on-error: ${{ matrix.experimental }}
@@ -67,7 +63,7 @@ jobs:
       - name: Setup ini config
         id: set_ini
         run: |
-          if [[ "${{ matrix.phpcs_version }}" != "dev-master" && "${{ matrix.phpcs_version }}" != "4.0.x-dev" ]]; then
+          if [[ "${{ matrix.phpcs_version }}" != "dev-master" ]]; then
             echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> $GITHUB_OUTPUT
           else
             echo 'PHP_INI=error_reporting=-1, display_errors=On' >> $GITHUB_OUTPUT
@@ -79,22 +75,9 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
-        env:
-          # Token is needed for the PHPCS 4.x run against source.
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 'Composer: set PHPCS version for tests'
         run: composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-interaction
-
-      - name: 'Composer: conditionally prefer source for PHPCS'
-        if: ${{ startsWith( matrix.phpcs_version, '4' ) }}
-        # --prefer-source ensures that the PHPCS native unit test framework will be available in PHPCS 4.x.
-        run: composer config preferred-install.squizlabs/php_codesniffer source
-
-      - name: 'Composer: conditionally remove PHPCSDevtools'
-        if: ${{ startsWith( matrix.phpcs_version, '4' ) }}
-        # Remove devtools as it will not (yet) install on PHPCS 4.x.
-        run: composer remove --no-update --dev phpcsstandards/phpcsdevtools --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -198,7 +198,7 @@ jobs:
 
       - name: Install Coveralls
         if: ${{ success() }}
-        run: composer require php-coveralls/php-coveralls:"^2.4.2" --no-interaction
+        run: composer require php-coveralls/php-coveralls:"^2.5.3" --no-interaction
 
       - name: Upload coverage results to Coveralls
         if: ${{ success() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,34 +25,17 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      # Keys:
-      # - experimental: Whether the build is "allowed to fail".
       matrix:
         # The GHA matrix works different from Travis.
         # You can define jobs here and then augment them with extra variables in `include`,
         # as well as add extra jobs in `include`.
         # @link https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix
         #
-        # IMPORTANT: test runs shouldn't fail because of PHPCS being incompatible with a PHP version.
-        # - PHPCS will run without errors on PHP 5.4 - 7.2 on any supported version.
-        # - PHP 7.4 needs PHPCS 3.5.0+ to run without errors.
-        # - PHP 8.0 needs PHPCS 3.5.7+ to run without errors.
-        # - PHP 8.1 needs PHPCS 3.6.1+ to run without errors.
-        #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
-        php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '8.0', '8.1']
+        php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '8.0', '8.1', '8.2']
         phpcs_version: ['3.7.1', 'dev-master']
-        experimental: [false]
-
-        include:
-          # Experimental builds. These are allowed to fail.
-          - php: '8.2'
-            phpcs_version: 'dev-master'
-            experimental: true
 
     name: "Test${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
-
-    continue-on-error: ${{ matrix.experimental }}
 
     steps:
       - name: Checkout code
@@ -122,7 +105,7 @@ jobs:
 
     strategy:
       matrix:
-        # 7.4 should be updated to 8.0 when higher PHPUnit versions can be supported.
+        # 7.4 should be updated to 8.2 when higher PHPUnit versions can be supported.
         php: ['5.4', '7.4']
         phpcs_version: ['3.7.1', 'dev-master']
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ PHPCSExtra
 [![Minimum PHP Version](https://img.shields.io/packagist/php-v/phpcsstandards/phpcsextra.svg?maxAge=3600)](https://packagist.org/packages/phpcsstandards/phpcsextra)
 [![CS Build Status](https://github.com/PHPCSStandards/PHPCSExtra/workflows/CS/badge.svg?branch=develop)](https://github.com/PHPCSStandards/PHPCSExtra/actions?query=workflow%3ACS)
 [![Test Build Status](https://github.com/PHPCSStandards/PHPCSExtra/workflows/Test/badge.svg?branch=develop)](https://github.com/PHPCSStandards/PHPCSExtra/actions?query=workflow%3ATest)
-[![Tested on PHP 5.4 to 8.0](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4%20|%208.0-brightgreen.svg?maxAge=2419200)](https://github.com/PHPCSStandards/PHPCSExtra/actions?query=workflow%3ATest)
+[![Tested on PHP 5.4 to 8.2](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4%20|%208.0%20|%208.1%20|%208.2-brightgreen.svg?maxAge=2419200)](https://github.com/PHPCSStandards/PHPCSExtra/actions?query=workflow%3ATest)
 [![Coverage Status](https://coveralls.io/repos/github/PHPCSStandards/PHPCSExtra/badge.svg)](https://coveralls.io/github/PHPCSStandards/PHPCSExtra)
 
 [![License: LGPLv3](https://poser.pugx.org/phpcsstandards/phpcsextra/license)](https://github.com/PHPCSStandards/PHPCSExtra/blob/stable/LICENSE)


### PR DESCRIPTION
### GH Actions/test: up the minimum required version of the coverall tooling

Ref: https://github.com/php-coveralls/php-coveralls/releases

### GH Actions/test: remove unused steps related to PHPCS 4.x

These steps/directives all relate to testing against PHPCS 4.x, but this package is not being tested against PHPCS 4.x at this time and when this will be enabled again, these work-arounds may well no longer be needed anymore anyway, so let's remove it for now and re-evaluate what is needed when testing against PHPCS 4.x is re-enabled.

### GH Actions: no longer allow builds to fail against PHP 8.2

* Update the PHP version on which the CS run for this package is run to PHP `latest`.
* Remove the `continue-on-error` for PHP 8.2 in the `test` workflow (and remove the `experimental` key, which is now no longer used.
* Update the "Tested against" badge in the README.