### PR TITLE
Modernize/Dirname: magic constants are case-insensitive

### DIFF
--- a/Modernize/Sniffs/FunctionCalls/DirnameSniff.php
+++ b/Modernize/Sniffs/FunctionCalls/DirnameSniff.php
@@ -118,7 +118,7 @@ final class DirnameSniff implements Sniff
         /*
          * PHP 5.3+: Detect use of dirname(__FILE__).
          */
-        if ($pathParam['clean'] === '__FILE__') {
+        if (\strtoupper($pathParam['clean']) === '__FILE__') {
             // Determine if the issue is auto-fixable.
             $hasComment = $phpcsFile->findNext(Tokens::$commentTokens, ($opener + 1), $closer);
             $fixable    = ($hasComment === false);

--- a/Modernize/Tests/FunctionCalls/DirnameUnitTest.inc
+++ b/Modernize/Tests/FunctionCalls/DirnameUnitTest.inc
@@ -48,7 +48,7 @@ $path = dirname(\dirname(__DIR__) . '/file.php'); // Nested dirname() call not s
  * These should be flagged for use of dirname(__FILE__).
  */
 $path = dirname(__FILE__);
-$path = \dirname (   __FILE__  ,  ) ; // Includes trailing comma.
+$path = \dirname (   __file__  ,  ) ; // Includes trailing comma.
 
 $path = DirName(__FILE__ /* todo: replace with __DIR__ */); // Not auto-fixable.
 
@@ -70,7 +70,7 @@ $path = dirname(path: __FILE__, levels: 1);
 $path = dirname(levels: 3, path: __FILE__);
 
 // phpcs:ignore Modernize.FunctionCalls.Dirname.Nested -- Only apply __DIR__ fix, not $levels.
-$path = dirname(dirname(dirname(dirname(__FILE__))));
+$path = dirname(dirname(dirname(dirname(__file__))));
 
 
 /*
@@ -129,7 +129,7 @@ $path = dirname(
         levels: 2,
         path: dirname(
             path: dirname(
-                path: __FILE__
+                path: __file__
             ),
             levels: 3,
         )


### PR DESCRIPTION
Includes a few updated unit tests to safeguard the fix.