### PR TITLE
GH Actions: various tweaks / PHP 8.2 not allowed to fail

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -54,8 +54,8 @@ jobs:
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Install xmllint
         run: |

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -64,16 +64,16 @@ jobs:
         if: matrix.php != 'latest'
         uses: "ramsey/composer-install@v2"
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
-      # For the PHP "latest", we need to install with ignore platform reqs as not all PHPUnit 7.x dependencies allow it.
+      # For PHP "latest", we need to install with ignore platform reqs as not all PHPUnit 7.x dependencies allow it.
       - name: Install Composer dependencies - with ignore platform
         if: matrix.php == 'latest'
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: --ignore-platform-reqs
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Lint against parse errors
         if: matrix.phpcs_version == 'dev-master'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,10 +32,12 @@ jobs:
         # @link https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
-        php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '8.0', '8.1', '8.2']
+        php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '8.0', '8.1', '8.2', '8.3']
         phpcs_version: ['3.7.1', 'dev-master']
 
     name: "Test${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
+
+    continue-on-error: ${{ matrix.php == '8.3' }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,8 +68,8 @@ jobs:
         if: ${{ startsWith( matrix.php, '8' ) == false }}
         uses: "ramsey/composer-install@v2"
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       # For the PHP 8/"nightly", we need to install with ignore platform reqs as we're still using PHPUnit 7.
       - name: Install Composer dependencies - with ignore platform
@@ -77,7 +77,7 @@ jobs:
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: --ignore-platform-reqs
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Lint against parse errors
         if: matrix.phpcs_version == 'dev-master'
@@ -144,8 +144,8 @@ jobs:
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Lint against parse errors
         if: matrix.phpcs_version == 'dev-master'


### PR DESCRIPTION
### GH Actions: minor simplification

... of the bash `date` command in the earlier pulled cache busting.

### GH Actions: update PHP versions in workflows

PHP 8.2 has been released today 🎉 and the `setup-php` action has announced support for PHP 8.3, so adding PHP 8.3 to the matrix and no longer allowing PHP 8.2 to fail the build.

Note: PHPCS does not (yet) have full syntax support for PHP 8.2, but it does have runtime support (for the most part, see squizlabs/PHP_CodeSniffer#3629).

Builds against PHP 8.3 are still allowed to fail for now.