### PR TITLE
.gitattributes: update export-ignores

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,16 +5,19 @@
 # https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production
 # https://blog.madewithlove.be/post/gitattributes/
 #
-/.coveralls.yml export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
-/.github/ export-ignore
-/phpcs.xml.dist export-ignore
-/phpunit.xml.dist export-ignore
-/phpunit-bootstrap.php export-ignore
-/Modernize/Tests/ export-ignore
+.coveralls.yml           export-ignore
+.gitattributes           export-ignore
+.gitignore               export-ignore
+.remarkignore            export-ignore
+.remarkrc                export-ignore
+.yamllint.yml            export-ignore
+phpcs.xml.dist           export-ignore
+phpunit.xml.dist         export-ignore
+phpunit-bootstrap.php    export-ignore
+/.github/                export-ignore
+/Modernize/Tests/        export-ignore
 /NormalizedArrays/Tests/ export-ignore
-/Universal/Tests/ export-ignore
+/Universal/Tests/        export-ignore
 
 #
 # Auto detect text files and perform LF normalization


### PR DESCRIPTION
Follow up on #186 which added some new configuration files, but didn't export ignore them.

Includes aligning the values for better readability.