### PR TITLE
Universal/DisallowShortListSyntax: minor simplification

### DIFF
--- a/Universal/Sniffs/Lists/DisallowShortListSyntaxSniff.php
+++ b/Universal/Sniffs/Lists/DisallowShortListSyntaxSniff.php
@@ -39,10 +39,7 @@ final class DisallowShortListSyntaxSniff implements Sniff
      */
     public function register()
     {
-        $targets          = Collections::shortArrayListOpenTokensBC();
-        $targets[\T_LIST] = \T_LIST; // Only for recording metrics.
-
-        return $targets;
+        return Collections::listOpenTokensBC();
     }
 
     /**


### PR DESCRIPTION
PHPCSUtils 1.0.0-rc1 introduces the `Collections::listOpenTokensBC()` token collection which can replace the custom code.