### PR TITLE
Composer: update for PHPCSUtils 1.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php" : ">=5.4",
         "squizlabs/php_codesniffer" : "^3.7.1",
         "dealerdirect/phpcodesniffer-composer-installer" : "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
-        "phpcsstandards/phpcsutils" : "^1.0 || dev-develop"
+        "phpcsstandards/phpcsutils" : "^1.0"
     },
     "require-dev" : {
         "php-parallel-lint/php-parallel-lint": "^1.3.2",
@@ -38,8 +38,6 @@
             "dev-develop": "1.x-dev"
         }
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "scripts" : {
         "lint": [
             "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . --show-deprecated -e php --exclude vendor --exclude .git"


### PR DESCRIPTION
PHPCSUtils 1.0.0 has been tagged & released. :tada:

This means that the `dev-develop` branch should no longer be explicitly allowed and that the `minimum-stability`/`prefer-stable` settings should no longer be needed.

Ref: https://github.com/PHPCSStandards/PHPCSUtils/releases/tag/v1.0.0