### PR TITLE
Composer: remove dependency on the Composer PHPCS plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     "require" : {
         "php" : ">=5.4",
         "squizlabs/php_codesniffer" : "^3.7.1",
-        "dealerdirect/phpcodesniffer-composer-installer" : "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
         "phpcsstandards/phpcsutils" : "^1.0"
     },
     "require-dev" : {


### PR DESCRIPTION
... in favour of inheriting the dependency from PHPCSUtils.