### PR TITLE
Universal/ConstructorDestructorReturn: ignore nested functions/closures

### DIFF
--- a/Universal/Tests/CodeAnalysis/ConstructorDestructorReturnUnitTest.inc
+++ b/Universal/Tests/CodeAnalysis/ConstructorDestructorReturnUnitTest.inc
@@ -123,3 +123,34 @@ interface InterfaceMethodReturnTypes {
 
     public function __destruct(): void;
 }
+
+// Issue #201 - prevent false positives for nested functions/closures.
+class NestedFunctions {
+    public function __construct() {
+        function global_function() {
+            return true;
+        }
+    }
+
+    public function __construct() {
+        function global_function($foo) {
+            return $foo;
+        }
+    }
+}
+
+class NestedClosures {
+    public function __construct() {
+        do_something(
+            function () {
+                return true;
+            },
+        );
+    }
+
+    public function __construct() {
+        $this->callback = function () {
+            return 10;
+        };
+    }
+}

--- a/Universal/Tests/CodeAnalysis/ConstructorDestructorReturnUnitTest.inc.fixed
+++ b/Universal/Tests/CodeAnalysis/ConstructorDestructorReturnUnitTest.inc.fixed
@@ -122,3 +122,34 @@ interface InterfaceMethodReturnTypes {
 
     public function __destruct();
 }
+
+// Issue #201 - prevent false positives for nested functions/closures.
+class NestedFunctions {
+    public function __construct() {
+        function global_function() {
+            return true;
+        }
+    }
+
+    public function __construct() {
+        function global_function($foo) {
+            return $foo;
+        }
+    }
+}
+
+class NestedClosures {
+    public function __construct() {
+        do_something(
+            function () {
+                return true;
+            },
+        );
+    }
+
+    public function __construct() {
+        $this->callback = function () {
+            return 10;
+        };
+    }
+}


### PR DESCRIPTION
Closures and named (global) functions can be declared _within_ a constructor/destructor method and can be declared to `return` a value.

As things were, the sniff did not take this into account and would throw false positives for the `ReturnValueFound` error code when this situation was encountered.

The fix as now applied, "jumps" over all nested function declarations within constructors/destructors (including arrow functions, even though thoe can't have a `return`).

Includes tests safeguarding this fix.

Fixes #201