### PR TITLE
Modernize.FunctionCalls.Dirname: prevent false positives on PHP 8.0+ attributes

### DIFF
--- a/Modernize/Sniffs/FunctionCalls/DirnameSniff.php
+++ b/Modernize/Sniffs/FunctionCalls/DirnameSniff.php
@@ -70,6 +70,11 @@ final class DirnameSniff implements Sniff
             return;
         }
 
+        if (empty($tokens[$stackPtr]['nested_attributes']) === false) {
+            // Class instantiation in attribute, not function call.
+            return;
+        }
+
         // Check if it is really a function call to the global function.
         $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
 

--- a/Modernize/Tests/FunctionCalls/DirnameUnitTest.inc
+++ b/Modernize/Tests/FunctionCalls/DirnameUnitTest.inc
@@ -136,6 +136,12 @@ $path = dirname(
     )
 );
 
+class AttributesShouldBeIgnored
+{
+    #[DirName(__FILE__)]
+    public function foo(): void
+    {}
+}
 
 // Parse error.
 // This must be the last test in the file.

--- a/Modernize/Tests/FunctionCalls/DirnameUnitTest.inc.fixed
+++ b/Modernize/Tests/FunctionCalls/DirnameUnitTest.inc.fixed
@@ -120,6 +120,12 @@ $path = dirname(
                 path: __DIR__
             , levels: 6);
 
+class AttributesShouldBeIgnored
+{
+    #[DirName(__FILE__)]
+    public function foo(): void
+    {}
+}
 
 // Parse error.
 // This must be the last test in the file.


### PR DESCRIPTION
`T_STRING` tokens in PHP 8.0+ attributes are either class names or possibly constant names (as a parameter for the class instantiation). They are never function calls.

This commit ensures that `T_STRING` tokens in attributes are not confused with function calls.

Includes unit test.