### PR TITLE
GH Actions: various minor tweaks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -184,7 +184,7 @@ jobs:
 
     steps:
       - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,9 +164,10 @@ jobs:
           php-version: 7.4
           coverage: none
 
+      # Global install is used to prevent a conflict with the local composer.lock in PHP 8.0+.
       - name: Install Coveralls
         if: ${{ success() }}
-        run: composer require php-coveralls/php-coveralls:"^2.5.3" --no-interaction
+        run: composer global require php-coveralls/php-coveralls:"^2.5.3" --no-interaction
 
       - name: Upload coverage results to Coveralls
         if: ${{ success() }}
@@ -174,7 +175,7 @@ jobs:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_PARALLEL: true
           COVERALLS_FLAG_NAME: php-${{ matrix.php }}-phpcs-${{ matrix.phpcs_version }}
-        run: vendor/bin/php-coveralls -v -x build/logs/clover.xml
+        run: php-coveralls -v -x build/logs/clover.xml
 
   coveralls-finish:
     needs: coverage


### PR DESCRIPTION
### GH Actions: used a named branch for coverallsapp

The `coverallsapp/github-action` action runner has (finally) created a named branch for the 1.x (and the 2.x) series, so let's use that.

Ref: coverallsapp/github-action#100

### GH Actions: fix CI

Grrr....

When PHPUnit has been installed on a high PHP version, some of the dependencies of PHPUnit may now be installed in versions not compatible with PHP 7.4, which would block the install of the Coveralls package.

While this is not (yet) a problem in this repo as the max PHPUnit version is set to PHPUnit 7.x, the issue should still be prevented.

Installing PHP Coveralls globally instead should fix it.

I just wish PHP Coveralls would finally release a version compatible with PHP >  8.0....