### PR TITLE
Universal/DisallowInlineTabs: add extra tests + remove redundancy

### DIFF
--- a/Universal/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
+++ b/Universal/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
@@ -122,12 +122,11 @@ final class DisallowInlineTabsSniff implements Sniff
                 $dummy->replaceTabsInToken($token);
             }
 
+            /*
+             * Tokens only have the 'orig_content' key if they contain tabs,
+             * so from here on out, we **know** there will be tabs in the content.
+             */
             $origContent = $token['orig_content'];
-
-            if ($origContent === '' || \strpos($origContent, "\t") === false) {
-                // If there are no tabs, we can continue, no matter what.
-                continue;
-            }
 
             $multiLineComment = false;
             if (($tokens[$i]['code'] === \T_COMMENT

--- a/Universal/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
+++ b/Universal/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
@@ -94,6 +94,10 @@ final class DisallowInlineTabsSniff implements Sniff
             $this->tabWidth = Helper::getTabWidth($phpcsFile);
         }
 
+        if (defined('PHP_CODESNIFFER_IN_TESTS')) {
+            $this->tabWidth = Helper::getCommandLineData($phpcsFile, 'tabWidth');
+        }
+
         $tokens = $phpcsFile->getTokens();
         $dummy  = new DummyTokenizer('', $phpcsFile->config);
 
@@ -115,7 +119,7 @@ final class DisallowInlineTabsSniff implements Sniff
                     continue;
                 }
 
-                $dummy->replaceTabsInToken($token, ' ', ' ', $this->tabWidth);
+                $dummy->replaceTabsInToken($token);
             }
 
             $origContent = $token['orig_content'];

--- a/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.5.inc.fixed
+++ b/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.5.inc.fixed
@@ -1,35 +1,35 @@
 <?php
 /* *** TESTING WITHOUT A TAB WIDTH SET *** */
 /**
- * @param int    $var    Description - Bad: alignment using tabs.
+ * @param int  $var  Description - Bad: alignment using tabs.
  * @param string $string Another description.
  */
 
 			$expected = ( $column - 1 );
-			$found     = ( $this->tokens[ $closer ]['column'] - 1 ); // Bad.
-			$error     = 'Array closer not aligned correctly; expected %s space(s) but found %s'; // Bad.
-			$data      = array( // Bad.
+			$found   = ( $this->tokens[ $closer ]['column'] - 1 ); // Bad.
+			$error   = 'Array closer not aligned correctly; expected %s space(s) but found %s'; // Bad.
+			$data   = array( // Bad.
 				$expected_value => 'data',
-				$found          => 'more_data', // Bad.
+				$found   => 'more_data', // Bad.
 			);
 
 /*
  * Test that the tab replacements do not negatively influence existing mid-line alignments.
  */
-$a        = true;
-$aa       = true;
-$aaa      = true;
-$aaaa     = true;
-$aaaaa    = true;
+$a    = true;
+$aa    = true;
+$aaa   = true;
+$aaaa   = true;
+$aaaaa   = true;
 $aaaaaa   = true;
 $aaaaaaa  = true;
 $aaaaaaaa = true;
 
-// Test tab replacement in  inline comments.
+// Test tab replacement in inline comments.
 
 		/*
-		 * Tab indented     and inline tabs.
+		 * Tab indented  and inline tabs.
 		 */
 
-		// Tab indented       and inline tabs.
-		// Tab indented       and inline tabs.
+		// Tab indented  and inline tabs.
+		// Tab indented  and inline tabs.

--- a/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.6.inc
+++ b/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.6.inc
@@ -1,0 +1,43 @@
+<?php
+
+/* *** SPACE BASED FILE - NO ERRORS OR WARNINGS EXPECTED AT ALL *** */
+
+/**
+ * @param int    $var    Description.
+ * @param string $string Another description.
+ */
+
+            $expected = ( $column - 1 );
+            $found    = ( $this->tokens[ $closer ]['column'] - 1 );
+            $error    = 'Array closer not aligned correctly; expected %s space(s) but found %s';
+            $data     = array(
+                $expected_value => 'data',
+                $found          => 'more_data',
+            );
+
+/**
+ * @param int    $var    Description
+ * @param string $string Another description.
+ */
+
+            $expected = ( $column - 1 );
+            $found    = ( $this->tokens[ $closer ]['column'] - 1 );
+            $error    = 'Array closer not aligned correctly; expected %s space(s) but found %s';
+            $data     = array(
+                $expected_value => 'data',
+                $found          => 'more_data',
+            );
+
+$a        = true;
+$aa       = true;
+$aaa      = true;
+$aaaa     = true;
+$aaaaa    = true;
+$aaaaaa   = true;
+$aaaaaaa  = true;
+$aaaaaaaa = true;
+
+    /**
+     * @param   int     $var    Description.
+     * @param   string  $string Another description.
+     */

--- a/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
+++ b/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
@@ -55,8 +55,8 @@ final class DisallowInlineTabsUnitTest extends AbstractSniffUnitTest
             return;
         }
 
-        if ($testFile === 'DisallowInlineTabsUnitTest.5.inc') {
-            // Set to the default.
+        if ($testFile === 'DisallowInlineTabsUnitTest.5.inc' || $testFile === 'DisallowInlineTabsUnitTest.6.inc') {
+            // Set to the default (results in tab width 1).
             $config->tabWidth = 0;
             return;
         }


### PR DESCRIPTION
### Universal/DisallowInlineTabs: add extra tests + fix test tab handling

* Add a space-based test case file which shouldn't yield any errors or warnings at all.
* Make sure that the "tabwidth" set for test files is correctly respected.
* Fix the `DisallowInlineTabsUnitTest.5.inc` fixed file.

### Universal/DisallowInlineTabs: remove some redundant code

The `'orig_content'` key only gets set when there are tabs in the token content, so no need for the extra check.