### PR TITLE
GH Actions: tweak related to remark job

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -4,8 +4,6 @@ on:
   # Run on all pushes and on all pull requests.
   # Prevent the build from running when there are only irrelevant changes.
   push:
-    paths-ignore:
-      - '**.md'
   pull_request:
   # Allow manually triggering the workflow.
   workflow_dispatch:

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -139,8 +139,8 @@ jobs:
           remark-lint-heading-whitespace
           remark-lint-list-item-punctuation
           remark-lint-match-punctuation
+          remark-lint-no-dead-urls
           remark-lint-no-hr-after-heading
-          remark-lint-are-links-valid-alive
           remark-lint-are-links-valid-duplicate
           remark-validate-links
 

--- a/.remarkrc
+++ b/.remarkrc
@@ -8,6 +8,7 @@
     ["remark-lint-linebreak-style", "unix"],
     ["remark-lint-link-title-style", "\""],
     ["remark-lint-ordered-list-marker-style", "."],
+    ["remark-lint-no-dead-urls", {"skipUrlPatterns": ["https://www.php.net/"]}],
     "remark-lint-no-duplicate-defined-urls",
     "remark-lint-no-duplicate-definitions",
     "remark-lint-no-empty-url",
@@ -29,7 +30,6 @@
     "remark-lint-list-item-punctuation",
     "remark-lint-match-punctuation",
     "remark-lint-no-hr-after-heading",
-    "remark-lint-are-links-valid-alive",
     "remark-lint-are-links-valid-duplicate",
     "remark-validate-links"
   ]


### PR DESCRIPTION
### GH Actions: run `basics` always

As the `basics` workflow includes markdown related jobs, the `paths-ignore` for markdown files only changes on push should be removed.

### RemarkLint: switch plugin

The [`remark-lint-are-links-valid-alive`](https://github.com/wemake-services/remark-lint-are-links-valid) plugin has been abandoned and doesn't allow to skip false positives.
The [`remark-lint-no-dead-urls`](https://github.com/remarkjs/remark-lint-no-dead-urls) plugin is still maintained and does allow adding some configuration to skip false positives.

This commit switches the one plugin out for the other.