### PR TITLE
Universal/LowercaseClassResolutionKeyword: bug fix for functions called "class"

### DIFF
--- a/Universal/Sniffs/Constants/LowercaseClassResolutionKeywordSniff.php
+++ b/Universal/Sniffs/Constants/LowercaseClassResolutionKeywordSniff.php
@@ -67,6 +67,12 @@ final class LowercaseClassResolutionKeywordSniff implements Sniff
             return;
         }
 
+        $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($nextToken !== false && $tokens[$nextToken]['code'] === \T_OPEN_PARENTHESIS) {
+            // Function call or declaration for a function called "class".
+            return;
+        }
+
         $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if ($prevToken === false || $tokens[$prevToken]['code'] !== \T_DOUBLE_COLON) {
             return;

--- a/Universal/Tests/Constants/LowercaseClassResolutionKeywordUnitTest.inc
+++ b/Universal/Tests/Constants/LowercaseClassResolutionKeywordUnitTest.inc
@@ -27,3 +27,12 @@ namespace MyNameSpace {
 echo bar::CLASS;
 
 array_map([\MyNameSpace\xyz :: /* comment */ Class, 'methodName'], $array);
+
+// Safeguard against false positives for methods called "class".
+class NotTheMagicConstant {
+    public function &Class() {
+        self::Class();
+        NotTheMagicConstant::CLASS();
+        My\Class\ClassName::clASS();
+    }
+}

--- a/Universal/Tests/Constants/LowercaseClassResolutionKeywordUnitTest.inc.fixed
+++ b/Universal/Tests/Constants/LowercaseClassResolutionKeywordUnitTest.inc.fixed
@@ -27,3 +27,12 @@ namespace MyNameSpace {
 echo bar::class;
 
 array_map([\MyNameSpace\xyz :: /* comment */ class, 'methodName'], $array);
+
+// Safeguard against false positives for methods called "class".
+class NotTheMagicConstant {
+    public function &Class() {
+        self::Class();
+        NotTheMagicConstant::CLASS();
+        My\Class\ClassName::clASS();
+    }
+}


### PR DESCRIPTION
Since PHP 7.0, `class` can be used as a method name. The sniff did not take this into account correctly.

Fixed now.

Includes unit tests.