### PR TITLE
GH Actions: prevent failing build

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -25,7 +25,7 @@
     "remark-lint-no-unneeded-full-reference-link",
     "remark-lint-no-unused-definitions",
     ["remark-lint-strikethrough-marker", "~~"],
-    ["remark-lint-table-cell-padding", "consistent"],
+    "remark-lint-table-pipe-alignment",
     "remark-lint-heading-whitespace",
     "remark-lint-list-item-punctuation",
     "remark-lint-match-punctuation",


### PR DESCRIPTION
Somewhere in the Remark toolchain something has changed which means that it now throws warnings about the cell padding for aligned tables.

As those aligned tables are by design (for readability during maintenance of the markdown), this commit is set up to removes those warnings and to enforce aligned tables.

The build for this repo is not (yet) failing as no tables are used in markdown, but this change prevent issues further down the line.

Refs:
* https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-table-pipe-alignment
* https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-table-cell-padding