### PR TITLE
:sparkles: New `Universal.FunctionDeclarations.NoLongClosures` sniff

### DIFF
--- a/Universal/Docs/FunctionDeclarations/NoLongClosuresStandard.xml
+++ b/Universal/Docs/FunctionDeclarations/NoLongClosuresStandard.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="No Long Closures"
+    >
+    <standard>
+    <![CDATA[
+    Forbids the use of long closures and recommends using named functions instead.
+
+    By default a closure is considered "longish" (warning) when it contains more than 5 lines of code and too long (error) when it contains more than 8 lines of code.
+    Also, by default only code lines are counted and blank lines and comment lines are ignored.
+    Each of these settings can be changed via the sniff configuration.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Short closure.">
+        <![CDATA[
+$closure = function() {
+    line1();
+    line2();
+    line3();
+};
+        ]]>
+        </code>
+        <code title="Invalid: Long closure.">
+        <![CDATA[
+$closure = function() {
+    line1();
+    line2();
+    line3();
+    line4();
+    line5();
+    line6();
+    line7();
+    line8();
+    line9();
+    line10();
+};
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/FunctionDeclarations/NoLongClosuresSniff.php
+++ b/Universal/Sniffs/FunctionDeclarations/NoLongClosuresSniff.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\FunctionDeclarations;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Forbids long closures.
+ *
+ * @since 1.1.0
+ */
+final class NoLongClosuresSniff implements Sniff
+{
+
+    /**
+     * Name of the metric.
+     *
+     * @since 1.1.0
+     *
+     * @var string
+     */
+    const METRIC_NAME_CODE = 'Closure length (code only)';
+
+    /**
+     * Name of the metric.
+     *
+     * @since 1.1.0
+     *
+     * @var string
+     */
+    const METRIC_NAME_COMMENTS = 'Closure length (code + comments)';
+
+    /**
+     * Name of the metric.
+     *
+     * @since 1.1.0
+     *
+     * @var string
+     */
+    const METRIC_NAME_ALL = 'Closure length (code + comments + blank lines)';
+
+    /**
+     * Maximum number of lines allowed before a closure is considered a "long" closure.
+     *
+     * Defaults to 5 lines, i.e. when a closure contains 6 lines, a warning will be thrown.
+     *
+     * @since 1.1.0
+     *
+     * @var int
+     */
+    public $recommendedLines = 5;
+
+    /**
+     * Maximum number of lines allowed before a closure is considered a "long" closure.
+     *
+     * Defaults to 8 lines, i.e. when a closure contains 9 lines, an error will be thrown.
+     *
+     * @since 1.1.0
+     *
+     * @var int
+     */
+    public $maxLines = 8;
+
+    /**
+     * Whether or not to exclude lines which only contain documentation in the line count.
+     *
+     * Defaults to `true`.
+     *
+     * @since 1.1.0
+     *
+     * @var bool
+     */
+    public $ignoreCommentLines = true;
+
+    /**
+     * Whether or not to exclude empty lines from the line count.
+     *
+     * Defaults to `true`.
+     *
+     * @since 1.1.0
+     *
+     * @var bool
+     */
+    public $ignoreEmptyLines = true;
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.1.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [\T_CLOSURE];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.1.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $this->recommendedLines = (int) $this->recommendedLines;
+        $this->maxLines         = (int) $this->maxLines;
+
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['scope_opener'], $tokens[$stackPtr]['scope_closer']) === false) {
+            // Live coding/parse error. Shouldn't be possible as in that case tokenizer won't retokenize to T_CLOSURE.
+            return; // @codeCoverageIgnore
+        }
+
+        $opener = $tokens[$stackPtr]['scope_opener'];
+        $closer = $tokens[$stackPtr]['scope_closer'];
+
+        $currentLine = $tokens[$opener]['line'];
+        $closerLine  = $tokens[$closer]['line'];
+
+        $codeLines    = 0;
+        $commentLines = 0;
+        $blankLines   = 0;
+
+        // Check whether the line of the scope opener needs to be counted, but ignore trailing comments on that line.
+        $firstNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($opener + 1), $closer, true);
+        if ($firstNonEmpty !== false && $tokens[$firstNonEmpty]['line'] === $currentLine) {
+            ++$codeLines;
+        }
+
+        // Check whether the line of the scope closer needs to be counted.
+        if ($closerLine !== $currentLine) {
+            $hasCommentTokens = false;
+            $hasCodeTokens    = false;
+            for ($i = ($closer - 1); $tokens[$i]['line'] === $closerLine && $i > $opener; $i--) {
+                if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === false) {
+                    $hasCodeTokens = true;
+                } elseif (isset(Tokens::$commentTokens[$tokens[$i]['code']]) === true) {
+                    $hasCommentTokens = true;
+                }
+            }
+
+            if ($hasCodeTokens === true) {
+                ++$codeLines;
+            } elseif ($hasCommentTokens === true) {
+                ++$commentLines;
+            }
+        }
+
+        // We've already examined the opener line, so move to the next line.
+        for ($i = ($opener + 1); $tokens[$i]['line'] === $currentLine && $i < $closer; $i++);
+        $currentLine = $tokens[$i]['line'];
+
+        // Walk tokens.
+        while ($currentLine !== $closerLine) {
+            $hasCommentTokens = false;
+            $hasCodeTokens    = false;
+
+            while ($tokens[$i]['line'] === $currentLine) {
+                if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === false) {
+                    $hasCodeTokens = true;
+                } elseif (isset(Tokens::$commentTokens[$tokens[$i]['code']]) === true) {
+                    $hasCommentTokens = true;
+                }
+
+                ++$i;
+            }
+
+            if ($hasCodeTokens === true) {
+                ++$codeLines;
+            } elseif ($hasCommentTokens === true) {
+                ++$commentLines;
+            } else {
+                // Only option left is that this is an empty line.
+                ++$blankLines;
+            }
+
+            $currentLine = $tokens[$i]['line'];
+        }
+
+        $nonBlankLines = ($codeLines + $commentLines);
+        $totalLines    = ($codeLines + $commentLines + $blankLines);
+        $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME_CODE, $codeLines . ' lines');
+        $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME_COMMENTS, $nonBlankLines . ' lines');
+        $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME_ALL, $totalLines . ' lines');
+
+        $lines = $codeLines;
+        if ($this->ignoreCommentLines === false) {
+            $lines += $commentLines;
+        }
+        if ($this->ignoreEmptyLines === false) {
+            $lines += $blankLines;
+        }
+
+        $errorSuffix = ' Declare a named function instead. Found closure containing %s lines';
+
+        if ($lines > $this->maxLines) {
+            $phpcsFile->addError(
+                'Closures which are longer than %s lines are forbidden.' . $errorSuffix,
+                $stackPtr,
+                'ExceedsMaximum',
+                [$this->maxLines, $lines]
+            );
+
+            return;
+        }
+
+        if ($lines > $this->recommendedLines) {
+            $phpcsFile->addWarning(
+                'It is recommended for closures to contain %s lines or less.' . $errorSuffix,
+                $stackPtr,
+                'ExceedsRecommended',
+                [$this->recommendedLines, $lines]
+            );
+        }
+    }
+}

--- a/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.1.inc
+++ b/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.1.inc
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * Verify line counting.
+ */
+$closure = function() {};
+$closure = function() {              };
+$closure = function() {   /* todo */   }; // OK, should count as 0 code, 0 comment line as comments is seen as trailing comment for opener.
+$closure = function($a) { return $a * $a; }; // OK, should count as 1 code line.
+
+$closure = function($a) { return $a * $a;
+}; // OK, should count as 1 code line.
+
+$closure = function($a) {
+    return $a * $a; }; // OK, should count as 1 code line.
+
+$closure = function($a) {
+    return $a * $a;
+    /* This comment should potentially be counted */ };
+
+
+// OK: we are looking for lines, not statements.
+$closure = function() { line1(); line2(); line3(); line4(); line5(); line6(); };
+
+$closure = function($a, $b) {
+    $b = $a; return $a * $a;
+};
+
+
+/*
+ * Deal with code/comments on the lines of the scope opener/closer.
+ */
+
+$closure = function() {
+    line1(); // Trailing comments should not influence the line count.
+    line2();
+    line3();
+    line4(); // Trailing comments should not influence the line count.
+    line5 /* Inline comments should not influence the line count. */ ();
+}; // OK.
+
+$closure = function() { line1();
+    line2();
+    line3();
+    line4();
+    line5();
+    line6();
+}; // Warning, code on scope opener line should be counted.
+
+$closure = function() {
+    line1();
+    line2();
+    line3();
+    line4();
+    line5();
+    line6(); }; // Warning, code on scope closer line should be counted.
+
+$closure = function() { line1();
+    line2();
+    line3();
+    line4();
+    line5();
+    line6(); }; // Warning, code on scope opener + closer line should be counted.
+
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreCommentLines false
+
+$closure = function() { // Trailing comment on scope opener line should be ignored.
+    line1();
+    line2();
+    line3();
+    line4();
+    line5();
+}; // OK.
+
+$closure = function() { // phpcs:ignore Standard.Cat -- Trailing comment on scope opener line should be ignored.
+    line1();
+    line2();
+    line3();
+    line4();
+    line5();
+}; // OK.
+
+$closure = function() {
+    line1();
+    line2();
+    line3();
+    line4();
+    line5();
+/* comment */ }; // Warning. Leading comment on scope closer line should be counted.
+
+$closure = function() {
+    line1();
+    line2();
+    line3();
+    line4();
+    line5();
+/* phpcs:ignore Standard.Cat */ }; // Warning. Leading comment on scope closer line should be counted.
+
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreCommentLines true
+
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures maxLines false
+$closure = function($a) { return $a * $a; }; // Error, invalid maxLines setting, evaluates to 0.
+
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures maxLines 0.5
+$closure = function($a) { return $a * $a; }; // Error, invalid maxLines setting, evaluates to 0.
+
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures maxLines foo
+$closure = function($a) { return $a * $a; }; // Error, invalid maxLines setting, evaluates to 0.
+
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures maxLines 8

--- a/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.10.inc
+++ b/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.10.inc
@@ -1,0 +1,80 @@
+<?php
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreCommentLines false
+
+/*
+ * OK.
+ */
+$closure = function() {
+    line1();
+};
+
+    $closure = function() {
+        line1();
+        line2();
+        line3();
+        line4();
+        line5();
+    };
+
+/*
+ * Warning.
+ */
+        $closure = function() {
+            line1();
+            line2();
+            line3();
+            line4();
+            line5();
+            line6();
+        };
+
+$closure = function() {
+echo
+2
++
+4
++
+6
+-
+8
+};
+
+/*
+ * Error.
+ */
+    $closure = function() {
+        line1();
+        line2();
+        line3();
+        line4();
+        line5();
+        line6();
+        line7();
+        line8();
+        line9();
+    };
+
+$closure = function() {
+    line1();
+    line2();
+    line3();
+    line4();
+    line5();
+    line6();
+    line7();
+    line8();
+    line9();
+    line10();
+    line11();
+    line12();
+    line13();
+    line14();
+    line15();
+    line16();
+    line17();
+    line18();
+    line19();
+    line20();
+};
+
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreCommentLines true

--- a/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.11.inc
+++ b/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.11.inc
@@ -1,0 +1,80 @@
+<?php
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreCommentLines false
+
+/*
+ * OK.
+ */
+$closure = function() {
+    line1();
+};
+
+    $closure = function() {
+        // Comment.
+        line2();
+        // Comment.
+        # Comment.
+        line5();
+    };
+
+/*
+ * Warning.
+ */
+$closure = function() {
+    /*
+     * Comment.
+     */
+    // Comment.
+    /* Comment
+     * Comment. */
+};
+
+        $closure = function() {
+            // Comment.
+            # Comment.
+            line3();
+            /* Comment.
+               Comment. */
+            line6();
+            /**
+             */
+        };
+
+/*
+ * Error.
+ */
+    $closure = function() {
+        // Comment.
+        line2();
+        /* Comment */
+        line4();
+        /** Comment */
+        line6();
+        // Comment.
+        line8();
+        # Comment
+    };
+
+$closure = function() {
+    /**
+     * Docblock
+     *
+     * Description.
+     *
+     * @tag
+     *
+     * @tag
+     */
+    line10();
+    // Comment.
+    // Comment.
+    // Comment.
+    // Comment.
+    /* Comment.
+
+
+
+       Comment. */
+    line20();
+};
+
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreCommentLines true

--- a/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.12.inc
+++ b/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.12.inc
@@ -1,0 +1,80 @@
+<?php
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreCommentLines false
+
+/*
+ * OK.
+ */
+$closure = function() {
+    line1();
+};
+
+        $closure = function() {
+
+
+
+
+            line5();
+        };
+
+/*
+ * Warning.
+ */
+    $closure = function() {
+
+
+
+
+
+
+    };
+
+$closure = function() {
+
+
+    line3();
+
+
+    line6();
+
+
+};
+
+/*
+ * Error.
+ */
+        $closure = function() {
+
+            line2();
+
+            line4();
+
+            line6();
+
+            line8();
+
+        };
+
+$closure = function() {
+
+
+
+
+
+
+
+
+
+    line10();
+
+
+
+
+
+
+
+
+
+    line20();
+};
+
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreCommentLines true

--- a/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.13.inc
+++ b/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.13.inc
@@ -1,0 +1,80 @@
+<?php
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreCommentLines false
+
+/*
+ * OK.
+ */
+$closure = function() {
+    line1();
+};
+
+    $closure = function() {
+
+        line2();
+        // Comment.
+        line4();
+
+    };
+
+/*
+ * Warning.
+ */
+$closure = function() {
+    // Comment.
+    # Comment.
+
+    /* Comment */
+
+
+};
+
+        $closure = function() {
+
+            # Comment.
+            line3();
+
+            /*
+             * Comment
+             */
+            line8();
+        };
+
+/*
+ * Error.
+ */
+$closure = function() {
+    // Comment
+    line2();
+
+    /* Comment */
+    line5();
+
+    # Comment.
+    line8();
+
+};
+
+    $closure = function() {
+        /**
+         * Docblock
+         *
+         * Description.
+         *
+         * @tag
+         *
+         * @tag
+         */
+        line10();
+
+
+
+
+
+
+
+
+
+        line20();
+    };
+
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreCommentLines true

--- a/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.14.inc
+++ b/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.14.inc
@@ -1,0 +1,80 @@
+<?php
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreEmptyLines false
+
+/*
+ * OK.
+ */
+$closure = function() {
+    line1();
+};
+
+    $closure = function() {
+        line1();
+        line2();
+        line3();
+        line4();
+        line5();
+    };
+
+/*
+ * Warning.
+ */
+        $closure = function() {
+            line1();
+            line2();
+            line3();
+            line4();
+            line5();
+            line6();
+        };
+
+$closure = function() {
+echo
+2
++
+4
++
+6
+-
+8
+};
+
+/*
+ * Error.
+ */
+    $closure = function() {
+        line1();
+        line2();
+        line3();
+        line4();
+        line5();
+        line6();
+        line7();
+        line8();
+        line9();
+    };
+
+$closure = function() {
+    line1();
+    line2();
+    line3();
+    line4();
+    line5();
+    line6();
+    line7();
+    line8();
+    line9();
+    line10();
+    line11();
+    line12();
+    line13();
+    line14();
+    line15();
+    line16();
+    line17();
+    line18();
+    line19();
+    line20();
+};
+
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreEmptyLines true

--- a/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.15.inc
+++ b/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.15.inc
@@ -1,0 +1,80 @@
+<?php
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreEmptyLines false
+
+/*
+ * OK.
+ */
+$closure = function() {
+    line1();
+};
+
+    $closure = function() {
+        // Comment.
+        line2();
+        // Comment.
+        # Comment.
+        line5();
+    };
+
+/*
+ * Warning.
+ */
+$closure = function() {
+    /*
+     * Comment.
+     */
+    // Comment.
+    /* Comment
+     * Comment. */
+};
+
+        $closure = function() {
+            // Comment.
+            # Comment.
+            line3();
+            /* Comment.
+               Comment. */
+            line6();
+            /**
+             */
+        };
+
+/*
+ * Error.
+ */
+    $closure = function() {
+        // Comment.
+        line2();
+        /* Comment */
+        line4();
+        /** Comment */
+        line6();
+        // Comment.
+        line8();
+        # Comment
+    };
+
+$closure = function() {
+    /**
+     * Docblock
+     *
+     * Description.
+     *
+     * @tag
+     *
+     * @tag
+     */
+    line10();
+    // Comment.
+    // Comment.
+    // Comment.
+    // Comment.
+    /* Comment.
+
+
+
+       Comment. */
+    line20();
+};
+
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreEmptyLines true

--- a/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.16.inc
+++ b/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.16.inc
@@ -1,0 +1,80 @@
+<?php
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreEmptyLines false
+
+/*
+ * OK.
+ */
+$closure = function() {
+    line1();
+};
+
+        $closure = function() {
+
+
+
+
+            line5();
+        };
+
+/*
+ * Warning.
+ */
+    $closure = function() {
+
+
+
+
+
+
+    };
+
+$closure = function() {
+
+
+    line3();
+
+
+    line6();
+
+
+};
+
+/*
+ * Error.
+ */
+        $closure = function() {
+
+            line2();
+
+            line4();
+
+            line6();
+
+            line8();
+
+        };
+
+$closure = function() {
+
+
+
+
+
+
+
+
+
+    line10();
+
+
+
+
+
+
+
+
+
+    line20();
+};
+
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreEmptyLines true

--- a/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.17.inc
+++ b/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.17.inc
@@ -1,0 +1,80 @@
+<?php
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreEmptyLines false
+
+/*
+ * OK.
+ */
+$closure = function() {
+    line1();
+};
+
+    $closure = function() {
+
+        line2();
+        // Comment.
+        line4();
+
+    };
+
+/*
+ * Warning.
+ */
+$closure = function() {
+    // Comment.
+    # Comment.
+
+    /* Comment */
+
+
+};
+
+        $closure = function() {
+
+            # Comment.
+            line3();
+
+            /*
+             * Comment
+             */
+            line8();
+        };
+
+/*
+ * Error.
+ */
+$closure = function() {
+    // Comment
+    line2();
+
+    /* Comment */
+    line5();
+
+    # Comment.
+    line8();
+
+};
+
+    $closure = function() {
+        /**
+         * Docblock
+         *
+         * Description.
+         *
+         * @tag
+         *
+         * @tag
+         */
+        line10();
+
+
+
+
+
+
+
+
+
+        line20();
+    };
+
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreEmptyLines true

--- a/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.18.inc
+++ b/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.18.inc
@@ -1,0 +1,81 @@
+<?php
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreCommentLines false
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreEmptyLines false
+/*
+ * OK.
+ */
+$closure = function() {
+    line1();
+};
+
+    $closure = function() {
+        line1();
+        line2();
+        line3();
+        line4();
+        line5();
+    };
+
+/*
+ * Warning.
+ */
+        $closure = function() {
+            line1();
+            line2();
+            line3();
+            line4();
+            line5();
+            line6();
+        };
+
+$closure = function() {
+echo
+2
++
+4
++
+6
+-
+8
+};
+
+/*
+ * Error.
+ */
+    $closure = function() {
+        line1();
+        line2();
+        line3();
+        line4();
+        line5();
+        line6();
+        line7();
+        line8();
+        line9();
+    };
+
+$closure = function() {
+    line1();
+    line2();
+    line3();
+    line4();
+    line5();
+    line6();
+    line7();
+    line8();
+    line9();
+    line10();
+    line11();
+    line12();
+    line13();
+    line14();
+    line15();
+    line16();
+    line17();
+    line18();
+    line19();
+    line20();
+};
+
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreEmptyLines true
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreCommentLines true

--- a/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.19.inc
+++ b/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.19.inc
@@ -1,0 +1,81 @@
+<?php
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreCommentLines false
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreEmptyLines false
+/*
+ * OK.
+ */
+$closure = function() {
+    line1();
+};
+
+    $closure = function() {
+        // Comment.
+        line2();
+        // Comment.
+        # Comment.
+        line5();
+    };
+
+/*
+ * Warning.
+ */
+$closure = function() {
+    /*
+     * Comment.
+     */
+    // Comment.
+    /* Comment
+     * Comment. */
+};
+
+        $closure = function() {
+            // Comment.
+            # Comment.
+            line3();
+            /* Comment.
+               Comment. */
+            line6();
+            /**
+             */
+        };
+
+/*
+ * Error.
+ */
+    $closure = function() {
+        // Comment.
+        line2();
+        /* Comment */
+        line4();
+        /** Comment */
+        line6();
+        // Comment.
+        line8();
+        # Comment
+    };
+
+$closure = function() {
+    /**
+     * Docblock
+     *
+     * Description.
+     *
+     * @tag
+     *
+     * @tag
+     */
+    line10();
+    // Comment.
+    // Comment.
+    // Comment.
+    // Comment.
+    /* Comment.
+
+
+
+       Comment. */
+    line20();
+};
+
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreEmptyLines true
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreCommentLines true

--- a/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.2.inc
+++ b/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.2.inc
@@ -1,0 +1,81 @@
+<?php /* Both lower than default values */
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures recommendedLines 2
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures maxLines 5
+/*
+ * OK.
+ */
+$closure = function() {
+    line1();
+};
+
+    $closure = function() {
+        line1();
+        line2();
+        line3();
+        line4();
+        line5();
+    };
+
+/*
+ * Warning.
+ */
+        $closure = function() {
+            line1();
+            line2();
+            line3();
+            line4();
+            line5();
+            line6();
+        };
+
+$closure = function() {
+echo
+2
++
+4
++
+6
+-
+8
+};
+
+/*
+ * Error.
+ */
+    $closure = function() {
+        line1();
+        line2();
+        line3();
+        line4();
+        line5();
+        line6();
+        line7();
+        line8();
+        line9();
+    };
+
+$closure = function() {
+    line1();
+    line2();
+    line3();
+    line4();
+    line5();
+    line6();
+    line7();
+    line8();
+    line9();
+    line10();
+    line11();
+    line12();
+    line13();
+    line14();
+    line15();
+    line16();
+    line17();
+    line18();
+    line19();
+    line20();
+};
+
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures recommendedLines 5
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures maxLines 8

--- a/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.20.inc
+++ b/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.20.inc
@@ -1,0 +1,81 @@
+<?php
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreCommentLines false
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreEmptyLines false
+/*
+ * OK.
+ */
+$closure = function() {
+    line1();
+};
+
+        $closure = function() {
+
+
+
+
+            line5();
+        };
+
+/*
+ * Warning.
+ */
+    $closure = function() {
+
+
+
+
+
+
+    };
+
+$closure = function() {
+
+
+    line3();
+
+
+    line6();
+
+
+};
+
+/*
+ * Error.
+ */
+        $closure = function() {
+
+            line2();
+
+            line4();
+
+            line6();
+
+            line8();
+
+        };
+
+$closure = function() {
+
+
+
+
+
+
+
+
+
+    line10();
+
+
+
+
+
+
+
+
+
+    line20();
+};
+
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreEmptyLines true
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreCommentLines true

--- a/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.21.inc
+++ b/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.21.inc
@@ -1,0 +1,81 @@
+<?php
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreCommentLines false
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreEmptyLines false
+/*
+ * OK.
+ */
+$closure = function() {
+    line1();
+};
+
+    $closure = function() {
+
+        line2();
+        // Comment.
+        line4();
+
+    };
+
+/*
+ * Warning.
+ */
+$closure = function() {
+    // Comment.
+    # Comment.
+
+    /* Comment */
+
+
+};
+
+        $closure = function() {
+
+            # Comment.
+            line3();
+
+            /*
+             * Comment
+             */
+            line8();
+        };
+
+/*
+ * Error.
+ */
+$closure = function() {
+    // Comment
+    line2();
+
+    /* Comment */
+    line5();
+
+    # Comment.
+    line8();
+
+};
+
+    $closure = function() {
+        /**
+         * Docblock
+         *
+         * Description.
+         *
+         * @tag
+         *
+         * @tag
+         */
+        line10();
+
+
+
+
+
+
+
+
+
+        line20();
+    };
+
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreEmptyLines true
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures ignoreCommentLines true

--- a/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.3.inc
+++ b/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.3.inc
@@ -1,0 +1,81 @@
+<?php /* Both higher than default values */
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures recommendedLines 8
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures maxLines 15
+/*
+ * OK.
+ */
+$closure = function() {
+    line1();
+};
+
+    $closure = function() {
+        line1();
+        line2();
+        line3();
+        line4();
+        line5();
+    };
+
+/*
+ * Warning.
+ */
+        $closure = function() {
+            line1();
+            line2();
+            line3();
+            line4();
+            line5();
+            line6();
+        };
+
+$closure = function() {
+echo
+2
++
+4
++
+6
+-
+8
+};
+
+/*
+ * Error.
+ */
+    $closure = function() {
+        line1();
+        line2();
+        line3();
+        line4();
+        line5();
+        line6();
+        line7();
+        line8();
+        line9();
+    };
+
+$closure = function() {
+    line1();
+    line2();
+    line3();
+    line4();
+    line5();
+    line6();
+    line7();
+    line8();
+    line9();
+    line10();
+    line11();
+    line12();
+    line13();
+    line14();
+    line15();
+    line16();
+    line17();
+    line18();
+    line19();
+    line20();
+};
+
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures recommendedLines 5
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures maxLines 8

--- a/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.4.inc
+++ b/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.4.inc
@@ -1,0 +1,80 @@
+<?php
+/* MaxLines set to very high value, effectively turning errors off, leaving only warnings. */
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures maxLines 9999
+/*
+ * OK.
+ */
+$closure = function() {
+    line1();
+};
+
+    $closure = function() {
+        line1();
+        line2();
+        line3();
+        line4();
+        line5();
+    };
+
+/*
+ * Warning.
+ */
+        $closure = function() {
+            line1();
+            line2();
+            line3();
+            line4();
+            line5();
+            line6();
+        };
+
+$closure = function() {
+echo
+2
++
+4
++
+6
+-
+8
+};
+
+/*
+ * Error.
+ */
+    $closure = function() {
+        line1();
+        line2();
+        line3();
+        line4();
+        line5();
+        line6();
+        line7();
+        line8();
+        line9();
+    };
+
+$closure = function() {
+    line1();
+    line2();
+    line3();
+    line4();
+    line5();
+    line6();
+    line7();
+    line8();
+    line9();
+    line10();
+    line11();
+    line12();
+    line13();
+    line14();
+    line15();
+    line16();
+    line17();
+    line18();
+    line19();
+    line20();
+};
+
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures maxLines 8

--- a/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.5.inc
+++ b/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.5.inc
@@ -1,0 +1,80 @@
+<?php
+/* Recommended set to a value higher than the maxLines, effectively turning warnings off, leaving only errors. */
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures recommendedLines 10
+/*
+ * OK.
+ */
+$closure = function() {
+    line1();
+};
+
+    $closure = function() {
+        line1();
+        line2();
+        line3();
+        line4();
+        line5();
+    };
+
+/*
+ * Warning.
+ */
+        $closure = function() {
+            line1();
+            line2();
+            line3();
+            line4();
+            line5();
+            line6();
+        };
+
+$closure = function() {
+echo
+2
++
+4
++
+6
+-
+8
+};
+
+/*
+ * Error.
+ */
+    $closure = function() {
+        line1();
+        line2();
+        line3();
+        line4();
+        line5();
+        line6();
+        line7();
+        line8();
+        line9();
+    };
+
+$closure = function() {
+    line1();
+    line2();
+    line3();
+    line4();
+    line5();
+    line6();
+    line7();
+    line8();
+    line9();
+    line10();
+    line11();
+    line12();
+    line13();
+    line14();
+    line15();
+    line16();
+    line17();
+    line18();
+    line19();
+    line20();
+};
+
+// phpcs:set Universal.FunctionDeclarations.NoLongClosures recommendedLines 5

--- a/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.6.inc
+++ b/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.6.inc
@@ -1,0 +1,78 @@
+<?php
+
+
+/*
+ * OK.
+ */
+$closure = function() {
+    line1();
+};
+
+    $closure = function() {
+        line1();
+        line2();
+        line3();
+        line4();
+        line5();
+    };
+
+/*
+ * Warning.
+ */
+        $closure = function() {
+            line1();
+            line2();
+            line3();
+            line4();
+            line5();
+            line6();
+        };
+
+$closure = function() {
+echo
+2
++
+4
++
+6
+-
+8
+};
+
+/*
+ * Error.
+ */
+    $closure = function() {
+        line1();
+        line2();
+        line3();
+        line4();
+        line5();
+        line6();
+        line7();
+        line8();
+        line9();
+    };
+
+$closure = function() {
+    line1();
+    line2();
+    line3();
+    line4();
+    line5();
+    line6();
+    line7();
+    line8();
+    line9();
+    line10();
+    line11();
+    line12();
+    line13();
+    line14();
+    line15();
+    line16();
+    line17();
+    line18();
+    line19();
+    line20();
+};

--- a/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.7.inc
+++ b/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.7.inc
@@ -1,0 +1,78 @@
+<?php
+
+
+/*
+ * OK.
+ */
+$closure = function() {
+    line1();
+};
+
+    $closure = function() {
+        // Comment.
+        line2();
+        // Comment.
+        # Comment.
+        line5();
+    };
+
+/*
+ * Warning.
+ */
+$closure = function() {
+    /*
+     * Comment.
+     */
+    // Comment.
+    /* Comment
+     * Comment. */
+};
+
+        $closure = function() {
+            // Comment.
+            # Comment.
+            line3();
+            /* Comment.
+               Comment. */
+            line6();
+            /**
+             */
+        };
+
+/*
+ * Error.
+ */
+    $closure = function() {
+        // Comment.
+        line2();
+        /* Comment */
+        line4();
+        /** Comment */
+        line6();
+        // Comment.
+        line8();
+        # Comment
+    };
+
+$closure = function() {
+    /**
+     * Docblock
+     *
+     * Description.
+     *
+     * @tag
+     *
+     * @tag
+     */
+    line10();
+    // Comment.
+    // Comment.
+    // Comment.
+    // Comment.
+    /* Comment.
+
+
+
+       Comment. */
+    line20();
+};

--- a/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.8.inc
+++ b/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.8.inc
@@ -1,0 +1,78 @@
+<?php
+
+
+/*
+ * OK.
+ */
+$closure = function() {
+    line1();
+};
+
+        $closure = function() {
+
+
+
+
+            line5();
+        };
+
+/*
+ * Warning.
+ */
+    $closure = function() {
+
+
+
+
+
+
+    };
+
+$closure = function() {
+
+
+    line3();
+
+
+    line6();
+
+
+};
+
+/*
+ * Error.
+ */
+        $closure = function() {
+
+            line2();
+
+            line4();
+
+            line6();
+
+            line8();
+
+        };
+
+$closure = function() {
+
+
+
+
+
+
+
+
+
+    line10();
+
+
+
+
+
+
+
+
+
+    line20();
+};

--- a/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.9.inc
+++ b/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.9.inc
@@ -1,0 +1,78 @@
+<?php
+
+
+/*
+ * OK.
+ */
+$closure = function() {
+    line1();
+};
+
+    $closure = function() {
+
+        line2();
+        // Comment.
+        line4();
+
+    };
+
+/*
+ * Warning.
+ */
+$closure = function() {
+    // Comment.
+    # Comment.
+
+    /* Comment */
+
+
+};
+
+        $closure = function() {
+
+            # Comment.
+            line3();
+
+            /*
+             * Comment
+             */
+            line8();
+        };
+
+/*
+ * Error.
+ */
+$closure = function() {
+    // Comment
+    line2();
+
+    /* Comment */
+    line5();
+
+    # Comment.
+    line8();
+
+};
+
+    $closure = function() {
+        /**
+         * Docblock
+         *
+         * Description.
+         *
+         * @tag
+         *
+         * @tag
+         */
+        line10();
+
+
+
+
+
+
+
+
+
+        line20();
+    };

--- a/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.php
+++ b/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\FunctionDeclarations;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the NoLongClosures sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\FunctionDeclarations\NoLongClosuresSniff
+ *
+ * @since 1.0.0
+ */
+final class NoLongClosuresUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @param string $testFile The name of the file being tested.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getErrorList($testFile = '')
+    {
+        switch ($testFile) {
+            case 'NoLongClosuresUnitTest.1.inc':
+                return [
+                    102 => 1,
+                    105 => 1,
+                    108 => 1,
+                ];
+
+            case 'NoLongClosuresUnitTest.2.inc':
+                return [
+                    22 => 1,
+                    31 => 1,
+                    45 => 1,
+                    57 => 1,
+                ];
+
+            case 'NoLongClosuresUnitTest.3.inc':
+            case 'NoLongClosuresUnitTest.13.inc':
+            case 'NoLongClosuresUnitTest.17.inc':
+                return [
+                    57 => 1,
+                ];
+
+            case 'NoLongClosuresUnitTest.5.inc':
+            case 'NoLongClosuresUnitTest.6.inc':
+            case 'NoLongClosuresUnitTest.10.inc':
+            case 'NoLongClosuresUnitTest.11.inc':
+            case 'NoLongClosuresUnitTest.14.inc':
+            case 'NoLongClosuresUnitTest.16.inc':
+            case 'NoLongClosuresUnitTest.18.inc':
+            case 'NoLongClosuresUnitTest.19.inc':
+            case 'NoLongClosuresUnitTest.20.inc':
+            case 'NoLongClosuresUnitTest.21.inc':
+                return [
+                    45 => 1,
+                    57 => 1,
+                ];
+
+            case 'NoLongClosuresUnitTest.7.inc':
+            case 'NoLongClosuresUnitTest.8.inc':
+            case 'NoLongClosuresUnitTest.9.inc':
+            case 'NoLongClosuresUnitTest.12.inc':
+            case 'NoLongClosuresUnitTest.15.inc':
+            default:
+                return [];
+        }
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @param string $testFile The name of the file being tested.
+     *
+     * @return array <int line number> => <int number of warnings>
+     */
+    public function getWarningList($testFile = '')
+    {
+        switch ($testFile) {
+            case 'NoLongClosuresUnitTest.1.inc':
+                return [
+                    42 => 1,
+                    50 => 1,
+                    58 => 1,
+                    83 => 1,
+                    91 => 1,
+                ];
+
+            case 'NoLongClosuresUnitTest.2.inc':
+                return [
+                    11 => 1,
+                ];
+
+            case 'NoLongClosuresUnitTest.3.inc':
+            case 'NoLongClosuresUnitTest.17.inc':
+                return [
+                    45 => 1,
+                ];
+
+            case 'NoLongClosuresUnitTest.4.inc':
+                return [
+                    22 => 1,
+                    31 => 1,
+                    45 => 1,
+                    57 => 1,
+                ];
+
+            case 'NoLongClosuresUnitTest.6.inc':
+            case 'NoLongClosuresUnitTest.10.inc':
+            case 'NoLongClosuresUnitTest.11.inc':
+            case 'NoLongClosuresUnitTest.14.inc':
+            case 'NoLongClosuresUnitTest.16.inc':
+            case 'NoLongClosuresUnitTest.18.inc':
+            case 'NoLongClosuresUnitTest.19.inc':
+            case 'NoLongClosuresUnitTest.20.inc':
+            case 'NoLongClosuresUnitTest.21.inc':
+                return [
+                    22 => 1,
+                    31 => 1,
+                ];
+
+            case 'NoLongClosuresUnitTest.13.inc':
+                return [
+                    31 => 1,
+                    45 => 1,
+                ];
+
+            case 'NoLongClosuresUnitTest.5.inc':
+            case 'NoLongClosuresUnitTest.7.inc':
+            case 'NoLongClosuresUnitTest.8.inc':
+            case 'NoLongClosuresUnitTest.9.inc':
+            case 'NoLongClosuresUnitTest.12.inc':
+            case 'NoLongClosuresUnitTest.15.inc':
+            default:
+                return [];
+        }
+    }
+}


### PR DESCRIPTION
New sniff to check for "long" closures and recommend using named functions instead.

The sniff is fully configurable via the following properties:
* (int) `recommendedLines` - this determines when a warning will be thrown. Defaults to `5`, which means that a warning will be thrown if the closure is more than 5 lines long.
* (int) `maxLines` - this determines when an error will be thrown. Defaults to `8`, which means that an error will be thrown if the closure is more than 8 lines long.
* (bool) `ignoreCommentLines` - whether or not comment-only lines should be ignored for the lines count. Defaults to `true`.
* (bool) `ignoreEmptyLines` - whether or not blank lines should be ignored for the lines count. Defaults to `true`.

The error and the warning have their own error codes  - `ExceedsMaximum` and `ExceedsRecommended` - and can be included/excluded separately from a ruleset.

Includes unit tests.
Includes documentation.
Includes metrics.

Closes #192