### PR TITLE
:sparkles: New `Universal.UseStatements.DisallowMixedGroupUse` sniff

### DIFF
--- a/Universal/Docs/UseStatements/DisallowMixedGroupUseStandard.xml
+++ b/Universal/Docs/UseStatements/DisallowMixedGroupUseStandard.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Disallow Mixed Group Use"
+    >
+    <standard>
+    <![CDATA[
+    Disallow group use statements which combine imports for namespace/OO, functions and/or constants in one statement.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Single type group use statements.">
+        <![CDATA[
+use Some\NS\ {
+    ClassName,
+    AnotherClass,
+};
+use function Some\NS\ {
+    SubLevel\functionName,
+    SubLevel\AnotherFunction,
+};
+use const Some\NS\ {
+    Constants\MY_CONSTANT as SOME_CONSTANT,
+};
+        ]]>
+        </code>
+        <code title="Invalid: Mixed group use statement.">
+        <![CDATA[
+use Some\NS\ {
+    ClassName,
+    function SubLevel\functionName,
+    const MY_CONSTANT as SOME_CONSTANT,
+    function SubLevel\AnotherName,
+    AnotherLevel,
+};
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/UseStatements/DisallowMixedGroupUseSniff.php
+++ b/Universal/Sniffs/UseStatements/DisallowMixedGroupUseSniff.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\UseStatements;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\GetTokensAsString;
+use PHPCSUtils\Utils\UseStatements;
+
+/**
+ * Disallow group use statements which combine imports for namespace/OO, functions
+ * and/or constants in one statement.
+ *
+ * Note: the fixer will use a semi-standardized format for group use statements.
+ * If there are more specific requirements for the formatting of group use statements,
+ * the ruleset configurator should ensure that additional sniffs are included in the
+ * ruleset to enforce the required format.
+ *
+ * @since 1.1.0
+ */
+final class DisallowMixedGroupUseSniff implements Sniff
+{
+
+    /**
+     * Name of the "Use import source" metric.
+     *
+     * @since 1.1.0
+     *
+     * @var string
+     */
+    const METRIC_NAME = 'Import use statement type';
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.1.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [\T_USE];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.1.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (UseStatements::isImportUse($phpcsFile, $stackPtr) === false) {
+            // Closure or trait use statement. Bow out.
+            return;
+        }
+
+        $useStatements = UseStatements::splitImportUseStatement($phpcsFile, $stackPtr);
+
+        $ooCount       = \count($useStatements['name']);
+        $functionCount = \count($useStatements['function']);
+        $constantCount = \count($useStatements['const']);
+        $totalCount    = $ooCount + $functionCount + $constantCount;
+
+        if ($totalCount === 0) {
+            // There must have been a parse error. Bow out.
+            return;
+        }
+
+        // End of statement will always be found, otherwise the import statement parsing would have failed.
+        $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($stackPtr + 1));
+        $groupStart     = $phpcsFile->findNext(\T_OPEN_USE_GROUP, ($stackPtr + 1), $endOfStatement);
+
+        if ($groupStart === false) {
+            // Not a group use statement. Just record the metric.
+            if ($totalCount === 1) {
+                $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'single import');
+            } else {
+                $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'multi import');
+            }
+
+            return;
+        }
+
+        if ($totalCount === 1
+            || ($ooCount !== 0 && $functionCount === 0 && $constantCount === 0)
+            || ($ooCount === 0 && $functionCount !== 0 && $constantCount === 0)
+            || ($ooCount === 0 && $functionCount === 0 && $constantCount !== 0)
+        ) {
+            // Not a *mixed* group use statement.
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'group use, single type');
+            return;
+        }
+
+        $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'group use, multi type');
+
+        $error = 'Group use statements should import one type of construct.'
+            . ' Mixed group use statement found importing %d namespaces/OO names, %d functions and %d constants.';
+        $code  = 'Found';
+        $data  = [$ooCount, $functionCount, $constantCount];
+
+        $hasComment = $phpcsFile->findNext(Tokens::$commentTokens, ($stackPtr + 1), $endOfStatement);
+        if ($hasComment !== false) {
+            // Don't attempt to auto-fix is there are comments or PHPCS annotations in the statement.
+            $phpcsFile->addError($error, $stackPtr, $code, $data);
+            return;
+        }
+
+        $fix = $phpcsFile->addFixableError($error, $stackPtr, $code, $data);
+
+        if ($fix === false) {
+            return;
+        }
+
+        /*
+         * Fix it.
+         *
+         * This fixer complies with the following (arbitrary) requirements:
+         * - It will re-use the original base "group" name, i.e. the part before \{.
+         * - It take take aliases into account, but only when something is aliased to a different name.
+         *   Aliases re-using the original name will be removed.
+         * - The fix will not add a trailing comma after the last group use sub-statement.
+         *   This is a PHP 7.2+ feature.
+         *   If a standard wants to enforce trailing commas, they should use a separate sniff for that.
+         * - If there is only 1 statement of a certain type, the replacement will be a single
+         *   import use statement, not a group use statement.
+         */
+
+        $phpcsFile->fixer->beginChangeset();
+
+        // Ensure that a potential close PHP tag ending the statement is not removed.
+        $tokens     = $phpcsFile->getTokens();
+        $endRemoval = $endOfStatement;
+        if ($tokens[$endOfStatement]['code'] !== \T_SEMICOLON) {
+            $endRemoval = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($endOfStatement - 1), null, true);
+        }
+
+        // Remove old statement with the exception of the `use` keyword.
+        for ($i = ($stackPtr + 1); $i <= $endRemoval; $i++) {
+            $phpcsFile->fixer->replaceToken($i, '');
+        }
+
+        // Build up the new use import statements.
+        $newStatements = [];
+
+        $useIndent    = \str_repeat(' ', ($tokens[$stackPtr]['column'] - 1));
+        $insideIndent = $useIndent . \str_repeat(' ', 4);
+
+        $baseGroupName = GetTokensAsString::noEmpties($phpcsFile, ($stackPtr + 1), ($groupStart - 1));
+
+        foreach ($useStatements as $type => $statements) {
+            $count = \count($statements);
+            if ($count === 0) {
+                continue;
+            }
+
+            $typeName = $type . ' ';
+            if ($type === 'name') {
+                $typeName = '';
+            }
+
+            if ($count === 1) {
+                $fqName = \reset($statements);
+                $alias  = \key($statements);
+
+                $newStatement = 'use ' . $typeName . $fqName;
+
+                $unqualifiedName = \ltrim(\substr($fqName, \strrpos($fqName, '\\')), '\\');
+                if ($unqualifiedName !== $alias) {
+                    $newStatement .= ' as ' . $alias;
+                }
+
+                $newStatement .= ';';
+
+                $newStatements[] = $newStatement;
+                continue;
+            }
+
+            // Multiple statements, add a single-type group use statement.
+            $newStatement = 'use ' . $typeName . $baseGroupName . '{' . $phpcsFile->eolChar;
+
+            foreach ($statements as $alias => $fqName) {
+                $partialName   = \str_replace($baseGroupName, '', $fqName);
+                $newStatement .= $insideIndent . $partialName;
+
+                $unqualifiedName = \ltrim(\substr($partialName, \strrpos($partialName, '\\')), '\\');
+                if ($unqualifiedName !== $alias) {
+                    $newStatement .= ' as ' . $alias;
+                }
+
+                $newStatement .= ',' . $phpcsFile->eolChar;
+            }
+
+            // Remove trailing comma after last statement as that's PHP 7.2+.
+            $newStatement = \rtrim($newStatement, ',' . $phpcsFile->eolChar);
+
+            $newStatement   .= $phpcsFile->eolChar . $useIndent . '};';
+            $newStatements[] = $newStatement;
+        }
+
+        $replacement = \implode($phpcsFile->eolChar . $useIndent, $newStatements);
+
+        $phpcsFile->fixer->replaceToken($stackPtr, $replacement);
+
+        $phpcsFile->fixer->endChangeset();
+    }
+}

--- a/Universal/Tests/UseStatements/DisallowMixedGroupUseUnitTest.inc
+++ b/Universal/Tests/UseStatements/DisallowMixedGroupUseUnitTest.inc
@@ -1,0 +1,123 @@
+<?php
+
+// Ignore as not import use.
+$closure = function() use($bar) {
+    return $bar;
+};
+
+class Foo {
+    use MyNamespace\Bar;
+}
+
+// Ignore, not group use statements.
+use My\NS\SomeClass;
+use My\NS\SomeClass as OtherClass;
+use function MyNamespace\myFunction;
+use const MyNamespace\YOUR_CONST as CONST_ALIAS;
+
+use Vendor\Foo\ClassA as ClassABC,
+    Vendor\Bar\InterfaceB,
+    Vendor\Baz\ClassC;
+
+use function foo\math\sin, foo\math\cos as FooCos, foo\math\cosh;
+
+// Ignore, single type group use statements.
+use FooLibrary\Bar\Baz\{ ClassA, ClassB, ClassC, ClassD as Fizbo };
+
+use some\namespacing\{
+    SomeClassA,
+    deeper\level\SomeClassB,
+    another\level\SomeClassC as C
+};
+
+use function bar\math\{
+    Msin,
+    level\Mcos as BarCos,
+    Mcosh,
+};
+
+use function foo\math\{ sin, cos, cosh };
+
+use const
+        bar\math\{ BGAMMA as BAR_GAMMA, BGOLDEN_RATIO };
+
+/*
+ * Mixed group use statements. These should be flagged.
+ */
+use WithComments\NonAutoFixable\{
+    // Comment.
+    ClassName,
+    # Comment.
+    function foo
+};
+
+use WithAnnotation\NonAutoFixable\{
+    // phpcs:ignore Stnd.Cat.SniffName -- for reasons.
+    ClassName,
+    // phpcs:ignore Stnd.Cat.SniffName -- for reasons.
+    function foo
+};
+
+// Blank lines within will be ignored/removed by the fixer.
+use SingleLevel\ {
+    ClassName,
+
+    function SubLevel\functionName,
+    const Constants\CONSTANT_NAME as SOME_CONSTANT,
+
+    const Constants\MY_CONSTANT,
+    function SubLevel\AnotherName,
+    AnotherLevel,
+};
+
+            use Multi\Level\{
+                ClassName,
+                function SubLevel\functionName,
+                const Constants\CONSTANT_NAME as SOME_CONSTANT,
+                const Constants\MY_CONSTANT,
+                function SubLevel\AnotherName,
+                AnotherLevel
+            };
+
+// Note: alias for "ClassName as ClassName" will be removed.
+use Triple\Sub\Level\{
+    ClassName as ClassName,
+    function SubLevel\functionName,
+    const Constants\CONSTANT_NAME as SOME_CONSTANT,
+    function SubLevel\AnotherName,
+    const Constants\MY_CONSTANT,
+    AnotherLevel,
+} ?>
+<?php
+	// Deliberate use of tab indentation for testing purposes!
+	use Two\Types\A\{
+		ClassName,
+		function SubLevel\functionName,
+		function SubLevel\AnotherName as notherName,
+		AnotherLevel
+	};
+
+use Two\Types\B\{
+    ClassName,
+    const Constants\CONSTANT_NAME as SOME_CONSTANT,
+    const Constants\MY_CONSTANT,
+    AnotherLevel,
+};
+
+use Two\Types\C\{
+    function SubLevel\functionName,
+    const Constants\CONSTANT_NAME as SOME_CONSTANT,
+    function SubLevel\AnotherName,
+};
+
+use One\OfEach\{
+    ClassName,
+    function SubLevel\functionName,
+    const Constants\CONSTANT_NAME as SOME_CONSTANT,
+};
+
+
+// Intentional parse error.
+// This has to be the last test in the file.
+use MyNS\Level\{
+    Something,

--- a/Universal/Tests/UseStatements/DisallowMixedGroupUseUnitTest.inc.fixed
+++ b/Universal/Tests/UseStatements/DisallowMixedGroupUseUnitTest.inc.fixed
@@ -1,0 +1,135 @@
+<?php
+
+// Ignore as not import use.
+$closure = function() use($bar) {
+    return $bar;
+};
+
+class Foo {
+    use MyNamespace\Bar;
+}
+
+// Ignore, not group use statements.
+use My\NS\SomeClass;
+use My\NS\SomeClass as OtherClass;
+use function MyNamespace\myFunction;
+use const MyNamespace\YOUR_CONST as CONST_ALIAS;
+
+use Vendor\Foo\ClassA as ClassABC,
+    Vendor\Bar\InterfaceB,
+    Vendor\Baz\ClassC;
+
+use function foo\math\sin, foo\math\cos as FooCos, foo\math\cosh;
+
+// Ignore, single type group use statements.
+use FooLibrary\Bar\Baz\{ ClassA, ClassB, ClassC, ClassD as Fizbo };
+
+use some\namespacing\{
+    SomeClassA,
+    deeper\level\SomeClassB,
+    another\level\SomeClassC as C
+};
+
+use function bar\math\{
+    Msin,
+    level\Mcos as BarCos,
+    Mcosh,
+};
+
+use function foo\math\{ sin, cos, cosh };
+
+use const
+        bar\math\{ BGAMMA as BAR_GAMMA, BGOLDEN_RATIO };
+
+/*
+ * Mixed group use statements. These should be flagged.
+ */
+use WithComments\NonAutoFixable\{
+    // Comment.
+    ClassName,
+    # Comment.
+    function foo
+};
+
+use WithAnnotation\NonAutoFixable\{
+    // phpcs:ignore Stnd.Cat.SniffName -- for reasons.
+    ClassName,
+    // phpcs:ignore Stnd.Cat.SniffName -- for reasons.
+    function foo
+};
+
+// Blank lines within will be ignored/removed by the fixer.
+use SingleLevel\{
+    ClassName,
+    AnotherLevel
+};
+use function SingleLevel\{
+    SubLevel\functionName,
+    SubLevel\AnotherName
+};
+use const SingleLevel\{
+    Constants\CONSTANT_NAME as SOME_CONSTANT,
+    Constants\MY_CONSTANT
+};
+
+            use Multi\Level\{
+                ClassName,
+                AnotherLevel
+            };
+            use function Multi\Level\{
+                SubLevel\functionName,
+                SubLevel\AnotherName
+            };
+            use const Multi\Level\{
+                Constants\CONSTANT_NAME as SOME_CONSTANT,
+                Constants\MY_CONSTANT
+            };
+
+// Note: alias for "ClassName as ClassName" will be removed.
+use Triple\Sub\Level\{
+    ClassName,
+    AnotherLevel
+};
+use function Triple\Sub\Level\{
+    SubLevel\functionName,
+    SubLevel\AnotherName
+};
+use const Triple\Sub\Level\{
+    Constants\CONSTANT_NAME as SOME_CONSTANT,
+    Constants\MY_CONSTANT
+}; ?>
+<?php
+	// Deliberate use of tab indentation for testing purposes!
+	use Two\Types\A\{
+        ClassName,
+        AnotherLevel
+    };
+    use function Two\Types\A\{
+        SubLevel\functionName,
+        SubLevel\AnotherName as notherName
+    };
+
+use Two\Types\B\{
+    ClassName,
+    AnotherLevel
+};
+use const Two\Types\B\{
+    Constants\CONSTANT_NAME as SOME_CONSTANT,
+    Constants\MY_CONSTANT
+};
+
+use function Two\Types\C\{
+    SubLevel\functionName,
+    SubLevel\AnotherName
+};
+use const Two\Types\C\Constants\CONSTANT_NAME as SOME_CONSTANT;
+
+use One\OfEach\ClassName;
+use function One\OfEach\SubLevel\functionName;
+use const One\OfEach\Constants\CONSTANT_NAME as SOME_CONSTANT;
+
+
+// Intentional parse error.
+// This has to be the last test in the file.
+use MyNS\Level\{
+    Something,

--- a/Universal/Tests/UseStatements/DisallowMixedGroupUseUnitTest.php
+++ b/Universal/Tests/UseStatements/DisallowMixedGroupUseUnitTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\UseStatements;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the DisallowMixedGroupUse sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\UseStatements\DisallowMixedGroupUseSniff
+ *
+ * @since 1.0.0
+ */
+final class DisallowMixedGroupUseUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Get a list of CLI values to set before the file is tested.
+     *
+     * @param string                  $testFile The name of the file being tested.
+     * @param \PHP_CodeSniffer\Config $config   The config data for the test run.
+     *
+     * @return void
+     */
+    public function setCliValues($testFile, $config)
+    {
+        $config->tabWidth = 4;
+    }
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getErrorList()
+    {
+        return [
+            47  => 1,
+            54  => 1,
+            62  => 1,
+            73  => 1,
+            83  => 1,
+            93  => 1,
+            100 => 1,
+            107 => 1,
+            113 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array <int line number> => <int number of warnings>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
New sniff to disallow group use statements which combine imports for namespace/OO, functions and/or constants in one statement.

Note: the fixer will use a semi-standardized format for group use statements. If there are more specific requirements for the formatting of group use statements, the ruleset configurator should ensure that additional sniffs are included in the ruleset to enforce the required format.

Includes fixer.
Includes unit tests.
Includes documentation.
Includes metrics.