### PR TITLE
:sparkles: New `Universal.CodeAnalysis.NoEchoSprintf` sniff

### DIFF
--- a/Universal/Docs/CodeAnalysis/NoEchoSprintfStandard.xml
+++ b/Universal/Docs/CodeAnalysis/NoEchoSprintfStandard.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="No Echo Sprintf"
+    >
+    <standard>
+    <![CDATA[
+    Detects use of `echo [v]sprintf(...);`. Use `printf()` instead.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: using [v]printf() or echo with anything but [v]sprintf().">
+        <![CDATA[
+<em>printf</em>('text %s text', $var);
+<em>echo callMe</em>('text %s text', $var);
+        ]]>
+        </code>
+        <code title="Invalid: using echo [v]sprintf().">
+        <![CDATA[
+<em>echo sprintf</em>('text %s text', $var);
+<em>echo vsprintf</em>('text %s text', [$var]);
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/CodeAnalysis/NoEchoSprintfSniff.php
+++ b/Universal/Sniffs/CodeAnalysis/NoEchoSprintfSniff.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2023 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\CodeAnalysis;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Detects use of `echo [v]sprintf();.
+ *
+ * @link https://www.php.net/manual/en/function.printf.php
+ * @link https://www.php.net/manual/en/function.sprintf.php
+ * @link https://www.php.net/manual/en/function.vprintf.php
+ * @link https://www.php.net/manual/en/function.vsprintf.php
+ *
+ * @since 1.1.0
+ */
+final class NoEchoSprintfSniff implements Sniff
+{
+
+    /**
+     * Functions to look for with their replacements.
+     *
+     * @since 1.1.0
+     *
+     * @var array<string, string>
+     */
+    private $targetFunctions = [
+        'sprintf'  => 'printf',
+        'vsprintf' => 'vprintf',
+    ];
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.1.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [\T_ECHO];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.1.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $skip   = Tokens::$emptyTokens;
+        $skip[] = \T_NS_SEPARATOR;
+
+        $next = $phpcsFile->findNext($skip, ($stackPtr + 1), null, true);
+        if ($next === false
+            || $tokens[$next]['code'] !== \T_STRING
+            || isset($this->targetFunctions[\strtolower($tokens[$next]['content'])]) === false
+        ) {
+            // Not our target.
+            return;
+        }
+
+        $detectedFunction = \strtolower($tokens[$next]['content']);
+
+        $openParens = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
+        if ($next === false
+            || $tokens[$openParens]['code'] !== \T_OPEN_PARENTHESIS
+            || isset($tokens[$openParens]['parenthesis_closer']) === false
+        ) {
+            // Live coding/parse error.
+            return;
+        }
+
+        $closeParens       = $tokens[$openParens]['parenthesis_closer'];
+        $afterFunctionCall = $phpcsFile->findNext(Tokens::$emptyTokens, ($closeParens + 1), null, true);
+        if ($afterFunctionCall === false
+            || ($tokens[$afterFunctionCall]['code'] !== \T_SEMICOLON
+            && $tokens[$afterFunctionCall]['code'] !== \T_CLOSE_TAG)
+        ) {
+            // Live coding/parse error or compound echo statement.
+            return;
+        }
+
+        $fix = $phpcsFile->addFixableError(
+            'Unnecessary "echo %s(...)" found. Use "%s(...)" instead.',
+            $next,
+            'Found',
+            [
+                $tokens[$next]['content'],
+                $this->targetFunctions[$detectedFunction],
+            ]
+        );
+
+        if ($fix === true) {
+            $phpcsFile->fixer->beginChangeset();
+
+            // Remove echo and whitespace.
+            $phpcsFile->fixer->replaceToken($stackPtr, '');
+
+            for ($i = ($stackPtr + 1); $i < $next; $i++) {
+                if ($tokens[$i]['code'] !== \T_WHITESPACE) {
+                    break;
+                }
+
+                $phpcsFile->fixer->replaceToken($i, '');
+            }
+
+            $phpcsFile->fixer->replaceToken($next, $this->targetFunctions[$detectedFunction]);
+
+            $phpcsFile->fixer->endChangeset();
+        }
+    }
+}

--- a/Universal/Tests/CodeAnalysis/NoEchoSprintfUnitTest.1.inc
+++ b/Universal/Tests/CodeAnalysis/NoEchoSprintfUnitTest.1.inc
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Not our targets.
+ */
+echo function_call();
+
+echo '<div>' . sprintf('%s - %d', $string, $number) . '</div>';
+
+echo \sprintf('%s - %d', $string, $number), 'text', sprintf('%s - %d', $string, $number);
+
+echo 'text' . sprintf('%s - %d', $string, $number);
+
+echo sprintf('%s - %d', $string, $number), \sprintf('%s - %d', $string, $number);
+
+/*
+ * The issue.
+ */
+echo sprintf('%s - %d', $string, $number);
+echo \sprintf(
+    '%s',
+    $string,
+) ?>
+<?php
+
+echo /*comment*/ SPRINTF('%s - %d', $string, $number);
+
+echo \SprintF /*comment*/ ('%s - %d', $string, $number) /*comment*/ ;
+
+echo vsprintf('%s - %d', [$string, $number]);
+echo \VsprintF('%s - %d', [$string, $number]);
+
+// Intentional parse error/live coding.
+// This needs to be the last test in the file.
+echo

--- a/Universal/Tests/CodeAnalysis/NoEchoSprintfUnitTest.1.inc.fixed
+++ b/Universal/Tests/CodeAnalysis/NoEchoSprintfUnitTest.1.inc.fixed
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Not our targets.
+ */
+echo function_call();
+
+echo '<div>' . sprintf('%s - %d', $string, $number) . '</div>';
+
+echo \sprintf('%s - %d', $string, $number), 'text', sprintf('%s - %d', $string, $number);
+
+echo 'text' . sprintf('%s - %d', $string, $number);
+
+echo sprintf('%s - %d', $string, $number), \sprintf('%s - %d', $string, $number);
+
+/*
+ * The issue.
+ */
+printf('%s - %d', $string, $number);
+\printf(
+    '%s',
+    $string,
+) ?>
+<?php
+
+/*comment*/ printf('%s - %d', $string, $number);
+
+\printf /*comment*/ ('%s - %d', $string, $number) /*comment*/ ;
+
+vprintf('%s - %d', [$string, $number]);
+\vprintf('%s - %d', [$string, $number]);
+
+// Intentional parse error/live coding.
+// This needs to be the last test in the file.
+echo

--- a/Universal/Tests/CodeAnalysis/NoEchoSprintfUnitTest.2.inc
+++ b/Universal/Tests/CodeAnalysis/NoEchoSprintfUnitTest.2.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Intentional parse error/live coding.
+// This needs to be the last test in the file.
+echo

--- a/Universal/Tests/CodeAnalysis/NoEchoSprintfUnitTest.3.inc
+++ b/Universal/Tests/CodeAnalysis/NoEchoSprintfUnitTest.3.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Intentional parse error/live coding.
+// This needs to be the last test in the file.
+echo \sprintf

--- a/Universal/Tests/CodeAnalysis/NoEchoSprintfUnitTest.4.inc
+++ b/Universal/Tests/CodeAnalysis/NoEchoSprintfUnitTest.4.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Intentional parse error/live coding.
+// This needs to be the last test in the file.
+echo \sprintf( 'text with %s placeholder', $var

--- a/Universal/Tests/CodeAnalysis/NoEchoSprintfUnitTest.5.inc
+++ b/Universal/Tests/CodeAnalysis/NoEchoSprintfUnitTest.5.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Intentional parse error/live coding.
+// This needs to be the last test in the file.
+echo \sprintf( 'text with %s placeholder', $var )

--- a/Universal/Tests/CodeAnalysis/NoEchoSprintfUnitTest.php
+++ b/Universal/Tests/CodeAnalysis/NoEchoSprintfUnitTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2023 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\CodeAnalysis;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the NoEchoSprintf sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\CodeAnalysis\NoEchoSprintfSniff
+ *
+ * @since 1.1.0
+ */
+final class NoEchoSprintfUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @param string $testFile The name of the file being tested.
+     *
+     * @return array <int line number> => <int number of errors>
+     */
+    public function getErrorList($testFile = '')
+    {
+        switch ($testFile) {
+            case 'NoEchoSprintfUnitTest.1.inc':
+                return [
+                    19 => 1,
+                    20 => 1,
+                    26 => 1,
+                    28 => 1,
+                    30 => 1,
+                    31 => 1,
+                ];
+
+            default:
+                return [];
+        }
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array <int line number> => <int number of warnings>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Detects use of the inefficient `echo [v]sprintf(...);` combi. Use `[v]printf()` instead.

Refs:
 * https://www.php.net/manual/en/function.printf.php
 * https://www.php.net/manual/en/function.sprintf.php
 * https://www.php.net/manual/en/function.vprintf.php
 * https://www.php.net/manual/en/function.vsprintf.php

Includes fixer.
Includes unit tests.
Includes documentation.