### PR TITLE
:sparkles: New `Universal.UseStatements.KeywordSpacing` sniff

### DIFF
--- a/Universal/Docs/UseStatements/KeywordSpacingStandard.xml
+++ b/Universal/Docs/UseStatements/KeywordSpacingStandard.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Import Use Keyword Spacing"
+    >
+    <standard>
+    <![CDATA[
+    Enforce a single space after the `use`, `function`, `const` keywords and both before and after the `as` keyword in import `use` statements.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Single space used around keywords.">
+        <![CDATA[
+use<em> </em>function<em> </em>strpos;
+use<em> </em>const<em> </em>PHP_EOL<em> </em>as<em> </em>MY_EOL;
+        ]]>
+        </code>
+        <code title="Invalid: Incorrect spacing used around keywords.">
+        <![CDATA[
+use<em>    </em>function<em>   </em>strpos;
+use<em>
+  </em>const<em>
+  </em>PHP_EOL<em>
+  </em>as<em>
+  </em>MY_EOL;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/UseStatements/KeywordSpacingSniff.php
+++ b/Universal/Sniffs/UseStatements/KeywordSpacingSniff.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2023 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\UseStatements;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Fixers\SpacesFixer;
+use PHPCSUtils\Utils\UseStatements;
+
+/**
+ * Enforce a single space after the keywords in import `use` statements.
+ *
+ * The keywords this sniff check are `use`, `function`, `const` and `as`.
+ * For `as`, the space *before* the keyword is also checked to be a single space.
+ *
+ * @since 1.1.0
+ */
+final class KeywordSpacingSniff implements Sniff
+{
+
+    /**
+     * Name of the metric for spacing before.
+     *
+     * @since 1.1.0
+     *
+     * @var string
+     */
+    const METRIC_NAME_BEFORE = 'Space before "%s" keyword in import use statement';
+
+    /**
+     * Name of the metric for spacing after.
+     *
+     * @since 1.1.0
+     *
+     * @var string
+     */
+    const METRIC_NAME_AFTER = 'Space after "%s" keyword in import use statement';
+
+    /**
+     * A list of keywords that are tokenized as `T_STRING` in import `use` statements.
+     *
+     * @since 1.1.0
+     *
+     * @var array(string => string)
+     */
+    protected $keywords = [
+        'const'    => true,
+        'function' => true,
+    ];
+
+    /**
+     * Returns an array of tokens this sniff wants to listen for.
+     *
+     * @since 1.1.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [\T_USE];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.1.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (UseStatements::isImportUse($phpcsFile, $stackPtr) === false) {
+            // Trait or closure use statement.
+            return;
+        }
+
+        $tokens         = $phpcsFile->getTokens();
+        $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($stackPtr + 1));
+        if ($endOfStatement === false) {
+            // Live coding or parse error.
+            return;
+        }
+
+        // Check the spacing after the `use` keyword.
+        $this->checkSpacingAfterKeyword($phpcsFile, $stackPtr, $tokens[$stackPtr]['content']);
+
+        // Check the spacing before and after each `as` keyword.
+        $current = $stackPtr;
+        do {
+            $current = $phpcsFile->findNext(\T_AS, ($current + 1), $endOfStatement);
+            if ($current === false) {
+                break;
+            }
+
+            // Prevent false positives when "as" is used within a "name".
+            if (isset(Tokens::$emptyTokens[$tokens[($current - 1)]['code']]) === true) {
+                $this->checkSpacingBeforeKeyword($phpcsFile, $current, $tokens[$current]['content']);
+                $this->checkSpacingAfterKeyword($phpcsFile, $current, $tokens[$current]['content']);
+            }
+        } while (true);
+
+        /*
+         * Check the spacing after `function` and `const` keywords.
+         */
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if (isset($this->keywords[\strtolower($tokens[$nextNonEmpty]['content'])]) === true) {
+            // Keyword found at start of statement, applies to whole statement.
+            $this->checkSpacingAfterKeyword($phpcsFile, $nextNonEmpty, $tokens[$nextNonEmpty]['content']);
+            return;
+        }
+
+        // This may still be a group use statement with function/const substatements.
+        $openGroup = $phpcsFile->findNext(\T_OPEN_USE_GROUP, ($stackPtr + 1), $endOfStatement);
+        if ($openGroup === false) {
+            // Not a group use statement.
+            return;
+        }
+
+        $closeGroup = $phpcsFile->findNext(\T_CLOSE_USE_GROUP, ($openGroup + 1), $endOfStatement);
+
+        $current = $openGroup;
+        do {
+            $current = $phpcsFile->findNext(Tokens::$emptyTokens, ($current + 1), $closeGroup, true);
+            if ($current === false) {
+                return;
+            }
+
+            if (isset($this->keywords[\strtolower($tokens[$current]['content'])]) === true) {
+                $this->checkSpacingAfterKeyword($phpcsFile, $current, $tokens[$current]['content']);
+            }
+
+            // We're within the use group, so find the next comma.
+            $current = $phpcsFile->findNext(\T_COMMA, ($current + 1), $closeGroup);
+        } while ($current !== false);
+    }
+
+    /**
+     * Check the spacing before a found keyword.
+     *
+     * @since 1.1.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the keyword in the token stack.
+     * @param string                      $content   The keyword as found.
+     *
+     * @return void
+     */
+    public function checkSpacingBeforeKeyword(File $phpcsFile, $stackPtr, $content)
+    {
+        $contentLC    = \strtolower($content);
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+
+        SpacesFixer::checkAndFix(
+            $phpcsFile,
+            $stackPtr,
+            $prevNonEmpty,
+            1, // Expected spaces.
+            'Expected %s before the "' . $contentLC . '" keyword. Found: %s',
+            'SpaceBefore' . \ucfirst($contentLC),
+            'error',
+            0, // Severity.
+            \sprintf(self::METRIC_NAME_BEFORE, $contentLC)
+        );
+    }
+
+    /**
+     * Check the spacing after a found keyword.
+     *
+     * @since 1.1.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the keyword in the token stack.
+     * @param string                      $content   The keyword as found.
+     *
+     * @return void
+     */
+    public function checkSpacingAfterKeyword(File $phpcsFile, $stackPtr, $content)
+    {
+        $contentLC    = \strtolower($content);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+
+        SpacesFixer::checkAndFix(
+            $phpcsFile,
+            $stackPtr,
+            $nextNonEmpty,
+            1, // Expected spaces.
+            'Expected %s after the "' . $contentLC . '" keyword. Found: %s',
+            'SpaceAfter' . \ucfirst($contentLC),
+            'error',
+            0, // Severity.
+            \sprintf(self::METRIC_NAME_AFTER, $contentLC)
+        );
+    }
+}

--- a/Universal/Tests/UseStatements/KeywordSpacingUnitTest.1.inc
+++ b/Universal/Tests/UseStatements/KeywordSpacingUnitTest.1.inc
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * OK.
+ */
+// Ignore as not import use keywords.
+$closure = function   () use   ($bar) {
+    return $bar;
+};
+
+class Foo {
+    use   MyNamespace\Bar;
+
+    const   MY_CONST = 123;
+    public function   foo() {}
+}
+
+const ABC = false;
+function Foo() {}
+
+foreach ($a   as   $k => $v) {}
+
+// Ignore, spacing is already correct.
+use Vendor\Package\Name as OtherName;
+use function Vendor\Package\functionName as otherFunction;
+use const Vendor\Package\CONSTANT_NAME as OTHER_CONSTANT;
+
+use Vendor\Package\MultiStatement as Multi,
+    DateTime as dateT;
+
+use function Vendor\Package\MultiFunction as MFunction,
+    strpos as pos;
+
+USE Some\NS\ {
+   ClassName As OtherClassName,
+   Function SubLevel\functionName AS OtherFunctionName,
+   CONST Constants\MYCONSTANT as OTHERCONSTANT,
+};
+
+// Ignore, "function", "const", "as" are used as part of a name (PHP 8.0+), not as the keyword.
+use Vendor\Package\As\Name as Something;
+use function Vendor\Function\Name as some_function;
+use Vendor\Const\Name as CONSTANT_HANDLER;
+
+/*
+ * Error.
+ */
+use  Vendor\Package\Name  as  OtherName;
+use
+
+   Function
+
+   Vendor\Package\functionName
+
+   as
+
+   otherFunction;
+use FuncTion\Util\functionB;
+use  CONST  Vendor\Package\CONSTANT_NAME   as   OTHER_CONSTANT;
+use Const\Util\MyClass\CONSTANT_Y;
+
+use Vendor\Package\MultiStatement as   Multi,
+    DateTime   AS   dateT;
+
+Use  function   Vendor\Package\MultiFunction  as  MFunction,
+    strpos  as  pos;
+
+use   Some\NS\{
+   ClassName
+     as  OtherClassName,
+   function   SubLevel\functionName
+     as  OtherFunctionName,
+   const   Constants\MYCONSTANT
+     as  OTHERCONSTANT,
+};
+
+// Invalid code, but will still be handled.
+use;

--- a/Universal/Tests/UseStatements/KeywordSpacingUnitTest.1.inc.fixed
+++ b/Universal/Tests/UseStatements/KeywordSpacingUnitTest.1.inc.fixed
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * OK.
+ */
+// Ignore as not import use keywords.
+$closure = function   () use   ($bar) {
+    return $bar;
+};
+
+class Foo {
+    use   MyNamespace\Bar;
+
+    const   MY_CONST = 123;
+    public function   foo() {}
+}
+
+const ABC = false;
+function Foo() {}
+
+foreach ($a   as   $k => $v) {}
+
+// Ignore, spacing is already correct.
+use Vendor\Package\Name as OtherName;
+use function Vendor\Package\functionName as otherFunction;
+use const Vendor\Package\CONSTANT_NAME as OTHER_CONSTANT;
+
+use Vendor\Package\MultiStatement as Multi,
+    DateTime as dateT;
+
+use function Vendor\Package\MultiFunction as MFunction,
+    strpos as pos;
+
+USE Some\NS\ {
+   ClassName As OtherClassName,
+   Function SubLevel\functionName AS OtherFunctionName,
+   CONST Constants\MYCONSTANT as OTHERCONSTANT,
+};
+
+// Ignore, "function", "const", "as" are used as part of a name (PHP 8.0+), not as the keyword.
+use Vendor\Package\As\Name as Something;
+use function Vendor\Function\Name as some_function;
+use Vendor\Const\Name as CONSTANT_HANDLER;
+
+/*
+ * Error.
+ */
+use Vendor\Package\Name as OtherName;
+use Function Vendor\Package\functionName as otherFunction;
+use FuncTion \Util\functionB;
+use CONST Vendor\Package\CONSTANT_NAME as OTHER_CONSTANT;
+use Const \Util\MyClass\CONSTANT_Y;
+
+use Vendor\Package\MultiStatement as Multi,
+    DateTime AS dateT;
+
+Use function Vendor\Package\MultiFunction as MFunction,
+    strpos as pos;
+
+use Some\NS\{
+   ClassName as OtherClassName,
+   function SubLevel\functionName as OtherFunctionName,
+   const Constants\MYCONSTANT as OTHERCONSTANT,
+};
+
+// Invalid code, but will still be handled.
+use ;

--- a/Universal/Tests/UseStatements/KeywordSpacingUnitTest.2.inc
+++ b/Universal/Tests/UseStatements/KeywordSpacingUnitTest.2.inc
@@ -1,0 +1,11 @@
+<?php
+
+/*
+ * The behaviour of the sniff for this code sample will be different depending on the PHP version.
+ * For PHP < 8.0, it will correctly flag this as "no space" after the `use` keyword.
+ * For PHP 8.0+, this will no longer be flagged as keywords are allowed in namespaced names,
+ * so the `use` is tokenized as `T_STRING` instead of `T_USE` and won't be flagged.
+ *
+ * For this reason, there is no "fixed" file included as the test would not be able to pass on PHP 8.0+.
+ */
+use\Util\MyOtherClass;

--- a/Universal/Tests/UseStatements/KeywordSpacingUnitTest.3.inc
+++ b/Universal/Tests/UseStatements/KeywordSpacingUnitTest.3.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Live coding/parse error. Ignore.
+// This must be the last test in the file.
+use

--- a/Universal/Tests/UseStatements/KeywordSpacingUnitTest.4.inc
+++ b/Universal/Tests/UseStatements/KeywordSpacingUnitTest.4.inc
@@ -1,0 +1,6 @@
+<?php
+
+// Live coding/parse error. Ignore.
+// This must be the last test in the file.
+use Vendor\Package\{
+    function   SomeName

--- a/Universal/Tests/UseStatements/KeywordSpacingUnitTest.php
+++ b/Universal/Tests/UseStatements/KeywordSpacingUnitTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2023 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\UseStatements;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the KeywordSpacing sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\UseStatements\KeywordSpacingSniff
+ *
+ * @since 1.1.0
+ */
+final class KeywordSpacingUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @param string $testFile The name of the file being tested.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList($testFile = '')
+    {
+        switch ($testFile) {
+            case 'KeywordSpacingUnitTest.1.inc':
+                return [
+                    48 => 3,
+                    49 => 1,
+                    51 => 1,
+                    55 => 2,
+                    58 => 1,
+                    59 => 4,
+                    60 => 1,
+                    62 => 1,
+                    63 => 2,
+                    65 => 4,
+                    66 => 2,
+                    68 => 1,
+                    70 => 2,
+                    71 => 1,
+                    72 => 2,
+                    73 => 1,
+                    74 => 2,
+                    78 => 1,
+                ];
+
+            case 'KeywordSpacingUnitTest.2.inc':
+                if (\PHP_VERSION_ID >= 80000) {
+                    return [];
+                }
+
+                return [
+                    11 => 1,
+                ];
+
+            default:
+                return [];
+        }
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
New sniff to enforce the use of a single space after the `use`, `function`, `const` keywords and both before and after the `as` keyword in import `use` statements.

This sniff is complementary to the PHPCS native `Generic.WhiteSpace.LanguageConstructSpacing` sniff which only checks the spacing after the `use` keyword in an import `use statement.

The sniff has modular error codes to allow for disabling individual checks. The error codes are: `SpaceAfterUse`, `SpaceAfterFunction`, `SpaceAfterConst`, `SpaceBeforeAs` and `SpaceAfterAs`.

Includes fixer.
Includes unit tests.
Includes documentation.
Includes metrics.