### PR TITLE
Universal/KeywordSpacing: add some tests for unfixable errors

### DIFF
--- a/Universal/Tests/UseStatements/KeywordSpacingUnitTest.1.inc
+++ b/Universal/Tests/UseStatements/KeywordSpacingUnitTest.1.inc
@@ -56,7 +56,7 @@ use
 
    otherFunction;
 use FuncTion\Util\functionB;
-use  CONST  Vendor\Package\CONSTANT_NAME   as   OTHER_CONSTANT;
+use  CONST  Vendor\Package\CONSTANT_NAME   as  /*comment*/ OTHER_CONSTANT;
 use Const\Util\MyClass\CONSTANT_Y;
 
 use Vendor\Package\MultiStatement as   Multi,
@@ -67,8 +67,9 @@ Use  function   Vendor\Package\MultiFunction  as  MFunction,
 
 use   Some\NS\{
    ClassName
+     // phpcs:ignore Stnd.Cat.Sniff --for reasons.
      as  OtherClassName,
-   function   SubLevel\functionName
+   function/*comment*/  SubLevel\functionName
      as  OtherFunctionName,
    const   Constants\MYCONSTANT
      as  OTHERCONSTANT,

--- a/Universal/Tests/UseStatements/KeywordSpacingUnitTest.1.inc.fixed
+++ b/Universal/Tests/UseStatements/KeywordSpacingUnitTest.1.inc.fixed
@@ -48,7 +48,7 @@ use Vendor\Const\Name as CONSTANT_HANDLER;
 use Vendor\Package\Name as OtherName;
 use Function Vendor\Package\functionName as otherFunction;
 use FuncTion \Util\functionB;
-use CONST Vendor\Package\CONSTANT_NAME as OTHER_CONSTANT;
+use CONST Vendor\Package\CONSTANT_NAME as  /*comment*/ OTHER_CONSTANT;
 use Const \Util\MyClass\CONSTANT_Y;
 
 use Vendor\Package\MultiStatement as Multi,
@@ -58,8 +58,10 @@ Use function Vendor\Package\MultiFunction as MFunction,
     strpos as pos;
 
 use Some\NS\{
-   ClassName as OtherClassName,
-   function SubLevel\functionName as OtherFunctionName,
+   ClassName
+     // phpcs:ignore Stnd.Cat.Sniff --for reasons.
+     as OtherClassName,
+   function/*comment*/  SubLevel\functionName as OtherFunctionName,
    const Constants\MYCONSTANT as OTHERCONSTANT,
 };
 

--- a/Universal/Tests/UseStatements/KeywordSpacingUnitTest.php
+++ b/Universal/Tests/UseStatements/KeywordSpacingUnitTest.php
@@ -46,12 +46,12 @@ final class KeywordSpacingUnitTest extends AbstractSniffUnitTest
                     65 => 4,
                     66 => 2,
                     68 => 1,
-                    70 => 2,
-                    71 => 1,
-                    72 => 2,
-                    73 => 1,
-                    74 => 2,
-                    78 => 1,
+                    71 => 2,
+                    72 => 1,
+                    73 => 2,
+                    74 => 1,
+                    75 => 2,
+                    79 => 1,
                 ];
 
             case 'KeywordSpacingUnitTest.2.inc':


### PR DESCRIPTION
... where there is a comment between the keyword and the previous/next relevant token.