### PR TITLE
:sparkles: New `Universal.WhiteSpace.CommaSpacing` sniff

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Minimum Requirements
 
 * PHP 5.4 or higher.
 * [PHP_CodeSniffer][phpcs-gh] version **3.7.1** or higher.
-* [PHPCSUtils][phpcsutils-gh] version **1.0.7** or higher.
+* [PHPCSUtils][phpcsutils-gh] version **1.0.8** or higher.
 
 
 Installation

--- a/Universal/Docs/WhiteSpace/CommaSpacingStandard.xml
+++ b/Universal/Docs/WhiteSpace/CommaSpacingStandard.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Comma Spacing"
+    >
+    <standard>
+    <![CDATA[
+    There should be no space before a comma and exactly one space, or a new line, after a comma.
+
+    The sniff makes the following exceptions to this rule:
+    1. A comma preceded or followed by a parenthesis, curly or square bracket.
+       These will not be flagged to prevent conflicts with sniffs handling spacing around braces.
+    2. A comma preceded or followed by another comma, like for skipping items in a list assignment.
+       These will not be flagged.
+    3. A comma preceded by a non-indented heredoc/nowdoc closer.
+       In that case, unless the `php_version` config directive is set to a version higher than PHP 7.3.0,
+       a new line before will be enforced to prevent parse errors on PHP < 7.3.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Correct spacing.">
+        <![CDATA[
+isset($param1<em>, </em>$param2<em>, </em>$param3);
+
+function_call(
+    $param1<em>,</em>
+    $param2<em>,</em>
+    $param3
+);
+
+$array = array($item1<em>, </em>$item2<em>, </em>$item3);
+$array = [
+    $item1<em>,</em>
+    $item2<em>,</em>
+];
+
+list(, $a<em>, </em>$b<em>,</em>,) = $array;
+list(
+    ,
+    $a<em>,</em>
+    $b<em>,</em>
+) = $array;
+        ]]>
+        </code>
+        <code title="Invalid: Incorrect spacing.">
+        <![CDATA[
+unset($param1<em>  ,   </em>$param2<em>,</em>$param3);
+
+function_call(
+    $a
+    <em>,</em>$b
+    <em>,</em>$c
+);
+
+$array = array($item1<em>,</em>$item2<em>  ,  </em>$item3);
+$array = [
+    $item1,
+    $item2<em>  ,</em>
+];
+
+list( ,$a, $b<em>  ,</em>,) = $array;
+list(
+    ,
+    $a,
+    $b<em>  ,</em>
+) = $array;
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    A comma should follow the code and not be placed after a trailing comment.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Comma after the code.">
+        <![CDATA[
+function_call(
+    $param1<em>,</em> // Comment.
+    $param2<em>,</em> /* Comment. */
+);
+        ]]>
+        </code>
+        <code title="Invalid: Comma after a trailing comment.">
+        <![CDATA[
+function_call(
+    $param1 // Comment.
+    <em>,</em>
+    $param2 /* Comment. */<em>,</em>
+);
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/WhiteSpace/CommaSpacingSniff.php
+++ b/Universal/Sniffs/WhiteSpace/CommaSpacingSniff.php
@@ -1,0 +1,408 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\Fixers\SpacesFixer;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\Parentheses;
+
+/**
+ * Check spacing around commas.
+ *
+ * - Demands there is no whitespace between the preceeding code and the comma.
+ * - Demands exactly one space or a new line after a comma.
+ * - Demands that when there is a trailing comment, the comma follows the code, not the comment.
+ *
+ * The following exclusions are in place:
+ * - A comma preceded or followed by a parenthesis, curly or square bracket.
+ *   These will not be flagged to prevent conflicts with sniffs handling spacing around braces.
+ * - A comma preceded or followed by another comma, like for skipping items in a list assignment.
+ *   These will not be flagged.
+ * - A comma preceded by a non-indented heredoc/nowdoc closer.
+ *   In that case, unless the `php_version` config directive is set to a version higher than PHP 7.3.0,
+ *   a new line before will be enforced to prevent parse errors on PHP < 7.3.
+ *
+ * The sniff has a separate error code for when a comma is found with more than one space after it, followed
+ * by a trailing comment. That way trailing comment alignment can be allowed by excluding that error code.
+ *
+ * The sniff uses modular error code suffixes for select situations, like `*InFunctionDeclaration`,
+ * `*InFunctionCall`, to allow for preventing duplicate messages if another sniff is already
+ * handling the comma spacing.
+ *
+ * @since 1.1.0
+ */
+final class CommaSpacingSniff implements Sniff
+{
+
+    /**
+     * Name of the "Spacing before" metric.
+     *
+     * @since 1.1.0
+     *
+     * @var string
+     */
+    const METRIC_NAME_BEFORE = 'Spaces found before comma';
+
+    /**
+     * Name of the "Spacing after" metric.
+     *
+     * @since 1.1.0
+     *
+     * @var string
+     */
+    const METRIC_NAME_AFTER = 'Spaces found after comma';
+
+    /**
+     * PHP version as configured or 0 if unknown.
+     *
+     * @since 1.1.0
+     *
+     * @var int
+     */
+    private $phpVersion;
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.1.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [\T_COMMA];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.1.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (isset($this->phpVersion) === false || \defined('PHP_CODESNIFFER_IN_TESTS')) {
+            // Set default value to prevent this code from running every time the sniff is triggered.
+            $this->phpVersion = 0;
+
+            $phpVersion = Helper::getConfigData('php_version');
+            if ($phpVersion !== null) {
+                $this->phpVersion = (int) $phpVersion;
+            }
+        }
+
+        $this->processSpacingBefore($phpcsFile, $stackPtr);
+        $this->processSpacingAfter($phpcsFile, $stackPtr);
+    }
+
+    /**
+     * Check the spacing before the comma.
+     *
+     * @since 1.1.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    protected function processSpacingBefore(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $prevNonWhitespace = $phpcsFile->findPrevious(\T_WHITESPACE, ($stackPtr - 1), null, true);
+        $prevNonEmpty      = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $nextNonEmpty      = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+
+        if ($prevNonWhitespace !== $prevNonEmpty
+            && $tokens[$prevNonEmpty]['code'] !== \T_COMMA
+            && $tokens[$prevNonEmpty]['line'] !== $tokens[$nextNonEmpty]['line']
+        ) {
+            // Special case: comma after a trailing comment - the comma should be moved to before the comment.
+            $fix = $phpcsFile->addFixableError(
+                'Comma found after comment, expected the comma after the end of the code',
+                $stackPtr,
+                'CommaAfterComment'
+            );
+
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+
+                $phpcsFile->fixer->replaceToken($stackPtr, '');
+                $phpcsFile->fixer->addContent($prevNonEmpty, ',');
+
+                // Clean up potential trailing whitespace left behind, but don't remove blank lines.
+                $nextNonWhitespace = $phpcsFile->findNext(\T_WHITESPACE, ($stackPtr + 1), null, true);
+                if ($tokens[($stackPtr - 1)]['code'] === \T_WHITESPACE
+                    && $tokens[($stackPtr - 1)]['line'] === $tokens[$stackPtr]['line']
+                    && $tokens[$stackPtr]['line'] !== $tokens[$nextNonWhitespace]['line']
+                ) {
+                    $phpcsFile->fixer->replaceToken(($stackPtr - 1), '');
+                }
+
+                $phpcsFile->fixer->endChangeset();
+            }
+            return;
+        }
+
+        if ($tokens[$prevNonWhitespace]['code'] === \T_COMMA) {
+            // This must be a list assignment with ignored items. Ignore.
+            return;
+        }
+
+        if (isset(Tokens::$blockOpeners[$tokens[$prevNonWhitespace]['code']]) === true
+            || $tokens[$prevNonWhitespace]['code'] === \T_OPEN_SHORT_ARRAY
+            || $tokens[$prevNonWhitespace]['code'] === \T_OPEN_USE_GROUP
+        ) {
+            // Should only realistically be possible for lists. Leave for a block brace spacing sniff to sort out.
+            return;
+        }
+
+        $expectedSpaces = 0;
+
+        if ($tokens[$prevNonEmpty]['code'] === \T_END_HEREDOC
+            || $tokens[$prevNonEmpty]['code'] === \T_END_NOWDOC
+        ) {
+            /*
+             * If php_version is explicitly set to PHP < 7.3, enforce a new line between the closer and the comma.
+             *
+             * If php_version is *not* explicitly set, let the indent be leading and only enforce
+             * a new line between the closer and the comma when this is an old-style heredoc/nowdoc.
+             */
+            if ($this->phpVersion !== 0 && $this->phpVersion < 70300) {
+                $expectedSpaces = 'newline';
+            }
+
+            if ($this->phpVersion === 0
+                && \ltrim($tokens[$prevNonEmpty]['content']) === $tokens[$prevNonEmpty]['content']
+            ) {
+                $expectedSpaces = 'newline';
+            }
+        }
+
+        $error        = 'Expected %1$s between "' . $this->escapePlaceholders($tokens[$prevNonWhitespace]['content'])
+            . '" and the comma. Found: %2$s';
+        $codeSuffix   = $this->getSuffix($phpcsFile, $stackPtr);
+        $metricSuffix = $this->codeSuffixToMetric($codeSuffix);
+
+        SpacesFixer::checkAndFix(
+            $phpcsFile,
+            $stackPtr,
+            $prevNonWhitespace,
+            $expectedSpaces,
+            $error,
+            'SpaceBefore' . $codeSuffix,
+            'error',
+            0,
+            self::METRIC_NAME_BEFORE . $metricSuffix
+        );
+    }
+
+    /**
+     * Check the spacing after the comma.
+     *
+     * @since 1.1.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    protected function processSpacingAfter(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $nextNonWhitespace = $phpcsFile->findNext(\T_WHITESPACE, ($stackPtr + 1), null, true);
+        if ($nextNonWhitespace === false) {
+            // Live coding/parse error. Ignore.
+            return;
+        }
+
+        if ($tokens[$nextNonWhitespace]['code'] === \T_COMMA) {
+            // This must be a list assignment with ignored items. Ignore.
+            return;
+        }
+
+        if ($tokens[$nextNonWhitespace]['code'] === \T_CLOSE_CURLY_BRACKET
+            || $tokens[$nextNonWhitespace]['code'] === \T_CLOSE_SQUARE_BRACKET
+            || $tokens[$nextNonWhitespace]['code'] === \T_CLOSE_PARENTHESIS
+            || $tokens[$nextNonWhitespace]['code'] === \T_CLOSE_SHORT_ARRAY
+            || $tokens[$nextNonWhitespace]['code'] === \T_CLOSE_USE_GROUP
+        ) {
+            // Ignore. Leave for a block spacing sniff to sort out.
+            return;
+        }
+
+        $nextToken = $tokens[($stackPtr + 1)];
+
+        $error = 'Expected %1$s between the comma and "'
+            . $this->escapePlaceholders($tokens[$nextNonWhitespace]['content']) . '". Found: %2$s';
+
+        $codeSuffix   = $this->getSuffix($phpcsFile, $stackPtr);
+        $metricSuffix = $this->codeSuffixToMetric($codeSuffix);
+
+        if ($nextToken['code'] === \T_WHITESPACE) {
+            if ($nextToken['content'] === ' ') {
+                $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME_AFTER . $metricSuffix, '1 space');
+                return;
+            }
+
+            // Note: this check allows for trailing whitespace between the comma and a new line char.
+            // The trailing whitespace is not the concern of this sniff.
+            if (\ltrim($nextToken['content'], ' ') === $phpcsFile->eolChar) {
+                $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME_AFTER . $metricSuffix, 'a new line');
+                return;
+            }
+
+            $errorCode = 'TooMuchSpaceAfter' . $codeSuffix;
+
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            if (isset(Tokens::$commentTokens[$tokens[$nextNonWhitespace]['code']]) === true
+                && ($nextNonEmpty === false || $tokens[$stackPtr]['line'] !== $tokens[$nextNonEmpty]['line'])
+            ) {
+                // Separate error code to allow for aligning trailing comments.
+                $errorCode = 'TooMuchSpaceAfterCommaBeforeTrailingComment';
+            }
+
+            SpacesFixer::checkAndFix(
+                $phpcsFile,
+                $stackPtr,
+                $nextNonWhitespace,
+                1,
+                $error,
+                $errorCode,
+                'error',
+                0,
+                self::METRIC_NAME_AFTER . $metricSuffix
+            );
+            return;
+        }
+
+        SpacesFixer::checkAndFix(
+            $phpcsFile,
+            $stackPtr,
+            $nextNonWhitespace,
+            1,
+            $error,
+            'NoSpaceAfter' . $codeSuffix,
+            'error',
+            0,
+            self::METRIC_NAME_AFTER . $metricSuffix
+        );
+    }
+
+    /**
+     * Escape arbitrary token content for *printf() placeholders.
+     *
+     * @since 1.1.0
+     *
+     * @param string $text Arbitrary text string.
+     *
+     * @return string
+     */
+    private function escapePlaceholders($text)
+    {
+        return \preg_replace('`(?:^|[^%])(%)(?:[^%]|$)`', '%%', \trim($text));
+    }
+
+    /**
+     * Retrieve a text string for use as a suffix to an error code.
+     *
+     * This allows for modular error codes, which in turn allow for selectively excluding
+     * error codes.
+     *
+     * {@internal Closure use will be parentheses owner in PHPCS 4.x, this code will
+     * need an update for that in due time.}
+     *
+     * @since 1.1.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return string
+     */
+    private function getSuffix($phpcsFile, $stackPtr)
+    {
+        $opener = Parentheses::getLastOpener($phpcsFile, $stackPtr);
+        if ($opener === false) {
+            return '';
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        $owner = Parentheses::getOwner($phpcsFile, $opener);
+        if ($owner !== false) {
+            switch ($tokens[$owner]['code']) {
+                case \T_FUNCTION:
+                case \T_CLOSURE:
+                case \T_FN:
+                    return 'InFunctionDeclaration';
+
+                case \T_DECLARE:
+                    return 'InDeclare';
+
+                case \T_ANON_CLASS:
+                case \T_ISSET:
+                case \T_UNSET:
+                    return 'InFunctionCall';
+
+                // Long array, long list, isset, unset, empty, exit, eval, control structures.
+                default:
+                    return '';
+            }
+        }
+
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($opener - 1), null, true);
+
+        if (isset(Collections::nameTokens()[$tokens[$prevNonEmpty]['code']]) === true) {
+            return 'InFunctionCall';
+        }
+
+        switch ($tokens[$prevNonEmpty]['code']) {
+            case \T_USE:
+                return 'InClosureUse';
+
+            case \T_VARIABLE:
+            case \T_SELF:
+            case \T_STATIC:
+            case \T_PARENT:
+                return 'InFunctionCall';
+
+            default:
+                return '';
+        }
+    }
+
+    /**
+     * Transform a suffix for an error code into a suffix for a metric.
+     *
+     * @since 1.1.0
+     *
+     * @param string $suffix Error code suffix.
+     *
+     * @return string
+     */
+    private function codeSuffixToMetric($suffix)
+    {
+        return \strtolower(\preg_replace('`([A-Z])`', ' $1', $suffix));
+    }
+}

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.1.inc
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.1.inc
@@ -1,0 +1,203 @@
+<?php
+
+/*
+ * Various parse errors.
+ * As the comma in each of these cases either is adjacent to another comma or to a brace, these should all be ignored.
+ */
+foo(,);
+foo('function', 'bar',,);
+foo('function',, 'bar');
+foo(, 'function', 'bar');
+
+$closure = function() {
+	typo_comma_not_semicolon(),
+};
+
+// Empty list, not allowed since PHP 7.0, but not our concern.
+list(,,) = $array;
+
+/*
+ * These should all be OK.
+ */
+$a = function_call( $a, $b, $c, $d );
+$a = function_call( $a, $b, /*comment*/ $c, $d );
+
+$a = function_call(
+    $a,
+    $bbb,
+    $ccccc
+);
+
+$a = function_call(
+    $a, // Comment.
+    $bbb, // Comment.
+    $ccccc // Comment.
+);
+
+$array = array('a', 'b', 'c');
+$array = ['a', 'b', 'c',];
+$array = [
+    $item1,
+    $item2,
+];
+
+list(, $a, , $b,,) = $array;
+list(, $a, /*ignored*/, $b, /*ignored*/,) = $array;
+[, $a, , $b,,] = $array;
+list(
+    ,
+    $a,
+    ,
+    $b,
+    ,
+) = $array;
+
+// Parse error in PHP < 7.2 (comma after last item in group use).
+use Vendor\Package\{NameA, NameB, NameC,};
+
+// Parse error in PHP < 7.3 (comma after last item in call).
+$a = function_call($a, $b, $c, $d,);
+$a = function_call(
+    $a,
+    $b,
+    $c,
+    $d,
+);
+
+// Parse error in PHP < 8.0 (comma after last item in param list and closure use).
+$closure = function ($param1, $param2, $param3,) use($use1, $use2, $use3,) {};
+$closure = function (
+    $param1,
+    $param2,
+    $param3,
+) use(
+    $use1,
+    $use2,
+    $use3,
+) {};
+
+
+/*
+ * Tests specific to creation of the error messages.
+ */
+
+// Allow for preceeding/following code - which is used in the error message - to have % signs in it.
+sprintf( 'my %s and %d' , 'my %s and %d' );
+define( 'START',   '%C!&bq' );
+define( 'MIDDLE',  '`cx]%1&K' );
+define( 'END',     '27t`cx]%' );
+
+// But don't double escape pre-escaped % signs.
+define( 'START',   '%%C!&bq' );
+define( 'MIDDLE',  '`cx]%%1&K' );
+define( 'END',     '27t`cx]%%' );
+
+/*
+ * Incorrect spacing errors.
+ */
+
+function_call($param1  ,   $param2,$param3);
+function_call(
+    $param1  ,
+    $param2,
+);
+
+$a = function_call(
+    $a,    // Comment.
+    $bbb,  // Comment.
+    $ccccc // Comment.
+);
+
+$a = commentsAreNotTrailing($a,    /*comment*/ $bbb,  /* Comment. */ $ccccc   /* Comment. */ );
+
+$a = function_call(
+    $a
+    ,$b // Comment.
+    ,$c /* Comment */
+    ,$d
+);
+
+$a = function_call(
+    $a
+    ,
+    $b
+    ,
+    $c
+    ,
+    $d
+);
+
+$a = function_call(
+    $a,// Comment.
+    $b,// Comment.
+    $c// Comment.
+);
+
+// Parse error in PHP < 7.3 (comma after last item in call).
+$a = function_call( $a  ,$b
+   ,    $c
+   ,$d   , );
+
+// Parse error in PHP < 7.3 (comma after last item in call).
+$a = function_call(
+    $a  ,
+    $b  ,
+    $c  ,
+    $d  ,
+);
+
+$array = array($item1,$item2  ,  $item3);
+$array = array('a'  ,   /*comment*/ 'b'   ,    'c');
+
+$array = [
+    $item1,
+    $item2  ,
+];
+$array = ['a'
+  ,'b'
+  ,'c'
+];
+
+list($a  ,$b,,$d   , ) = $array;
+list(, $a,/*ignored*/   , $b,/*ignored*/   ,) = $array;
+
+[
+    $a
+    ,
+    $b
+    ,
+    ,
+    $d
+] = $array;
+
+
+list( ,$a, $b  ,,) = $array;
+list(
+    ,
+    $a,
+    $b  ,,
+) = $array;
+
+// Allow for empty list item at start, middle and end of list.
+list( , $b, ,$d   , ) = $array;
+[
+    ,
+    $b
+    ,
+    ,
+    $d
+    ,
+] = $array;
+
+// Alignment of values within a multi-dimensional array is not allowed.
+return [
+    // github
+    ['https://github.com/foo/bar/zipball/abcd',      'https://api.github.com/repos/foo/bar/zipball/newref'],
+    ['https://www.github.com/foo/bar/zipball/abcd',  'https://api.github.com/repos/foo/bar/zipball/newref'],
+    ['https://github.com/foo/bar/archive/abcd.zip',  'https://api.github.com/repos/foo/bar/zipball/newref'],
+];
+
+// ... nor is alignment of array values in multi-statements.
+$provider[] = ['abc',             '0.10'];
+$provider[] = ['defghi',          '1.0.0BETA3'];
+$provider[] = ['jklmnopqrstuvwz', '2.2.0-DEV'];

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.1.inc.fixed
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.1.inc.fixed
@@ -1,0 +1,191 @@
+<?php
+
+/*
+ * Various parse errors.
+ * As the comma in each of these cases either is adjacent to another comma or to a brace, these should all be ignored.
+ */
+foo(,);
+foo('function', 'bar',,);
+foo('function',, 'bar');
+foo(, 'function', 'bar');
+
+$closure = function() {
+	typo_comma_not_semicolon(),
+};
+
+// Empty list, not allowed since PHP 7.0, but not our concern.
+list(,,) = $array;
+
+/*
+ * These should all be OK.
+ */
+$a = function_call( $a, $b, $c, $d );
+$a = function_call( $a, $b, /*comment*/ $c, $d );
+
+$a = function_call(
+    $a,
+    $bbb,
+    $ccccc
+);
+
+$a = function_call(
+    $a, // Comment.
+    $bbb, // Comment.
+    $ccccc // Comment.
+);
+
+$array = array('a', 'b', 'c');
+$array = ['a', 'b', 'c',];
+$array = [
+    $item1,
+    $item2,
+];
+
+list(, $a, , $b,,) = $array;
+list(, $a, /*ignored*/, $b, /*ignored*/,) = $array;
+[, $a, , $b,,] = $array;
+list(
+    ,
+    $a,
+    ,
+    $b,
+    ,
+) = $array;
+
+// Parse error in PHP < 7.2 (comma after last item in group use).
+use Vendor\Package\{NameA, NameB, NameC,};
+
+// Parse error in PHP < 7.3 (comma after last item in call).
+$a = function_call($a, $b, $c, $d,);
+$a = function_call(
+    $a,
+    $b,
+    $c,
+    $d,
+);
+
+// Parse error in PHP < 8.0 (comma after last item in param list and closure use).
+$closure = function ($param1, $param2, $param3,) use($use1, $use2, $use3,) {};
+$closure = function (
+    $param1,
+    $param2,
+    $param3,
+) use(
+    $use1,
+    $use2,
+    $use3,
+) {};
+
+
+/*
+ * Tests specific to creation of the error messages.
+ */
+
+// Allow for preceeding/following code - which is used in the error message - to have % signs in it.
+sprintf( 'my %s and %d', 'my %s and %d' );
+define( 'START', '%C!&bq' );
+define( 'MIDDLE', '`cx]%1&K' );
+define( 'END', '27t`cx]%' );
+
+// But don't double escape pre-escaped % signs.
+define( 'START', '%%C!&bq' );
+define( 'MIDDLE', '`cx]%%1&K' );
+define( 'END', '27t`cx]%%' );
+
+/*
+ * Incorrect spacing errors.
+ */
+
+function_call($param1, $param2, $param3);
+function_call(
+    $param1,
+    $param2,
+);
+
+$a = function_call(
+    $a, // Comment.
+    $bbb, // Comment.
+    $ccccc // Comment.
+);
+
+$a = commentsAreNotTrailing($a, /*comment*/ $bbb, /* Comment. */ $ccccc   /* Comment. */ );
+
+$a = function_call(
+    $a, $b, // Comment.
+    $c, /* Comment */
+    $d
+);
+
+$a = function_call(
+    $a,
+    $b,
+    $c,
+    $d
+);
+
+$a = function_call(
+    $a, // Comment.
+    $b, // Comment.
+    $c// Comment.
+);
+
+// Parse error in PHP < 7.3 (comma after last item in call).
+$a = function_call( $a, $b, $c, $d, );
+
+// Parse error in PHP < 7.3 (comma after last item in call).
+$a = function_call(
+    $a,
+    $b,
+    $c,
+    $d,
+);
+
+$array = array($item1, $item2, $item3);
+$array = array('a', /*comment*/ 'b', 'c');
+
+$array = [
+    $item1,
+    $item2,
+];
+$array = ['a', 'b', 'c'
+];
+
+list($a, $b,, $d, ) = $array;
+list(, $a, /*ignored*/, $b, /*ignored*/,) = $array;
+
+[
+    $a,
+    $b,
+    ,
+    $d
+] = $array;
+
+
+list( , $a, $b,,) = $array;
+list(
+    ,
+    $a,
+    $b,,
+) = $array;
+
+// Allow for empty list item at start, middle and end of list.
+list( , $b, , $d, ) = $array;
+[
+    ,
+    $b,
+    ,
+    $d,
+] = $array;
+
+// Alignment of values within a multi-dimensional array is not allowed.
+return [
+    // github
+    ['https://github.com/foo/bar/zipball/abcd', 'https://api.github.com/repos/foo/bar/zipball/newref'],
+    ['https://www.github.com/foo/bar/zipball/abcd', 'https://api.github.com/repos/foo/bar/zipball/newref'],
+    ['https://github.com/foo/bar/archive/abcd.zip', 'https://api.github.com/repos/foo/bar/zipball/newref'],
+];
+
+// ... nor is alignment of array values in multi-statements.
+$provider[] = ['abc', '0.10'];
+$provider[] = ['defghi', '1.0.0BETA3'];
+$provider[] = ['jklmnopqrstuvwz', '2.2.0-DEV'];

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.2.inc
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.2.inc
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * Tests specifically for the error code differentiation.
+ *
+ * Each line should yield one of each of these errors: SpaceBefore, TooMuchSpaceAfter, NoSpaceAfter.
+ */
+
+// *InDeclare suffix.
+declare(strict_types=1 ,  encoding='utf8',ticks=0);
+
+// *InFunctionDeclaration suffix.
+function name($param1 ,   $param2,$param3) {}
+$closure = function ($param1 ,   $param2,$param3) {};
+$arrow = fn ($param1 ,   $param2,$param3) => $param1 * $param2 + $param3;
+class Foo {
+    public function name($param1 ,   $param2,$param3) {}
+}
+
+// *InClosureUse suffix.
+$closure = function () use($param1 ,   $param2,$param3) {};
+
+// *InFunctionCall suffix.
+do_something($param1 ,   $param2,$param3);
+$obj = new Foo($param1 ,   $param2,$param3);
+$obj = new self($param1 ,   $param2,$param3);
+$obj = new parent($param1 ,   $param2,$param3);
+$obj = new static($param1 ,   $param2,$param3);
+$anonClass = new class($param1 ,   $param2,$param3) {};
+$var($param1 ,   $param2,$param3);
+#[MyAttribute(1 ,  'foo',false)]
+function name() {}
+isset($item1 ,   $item2,$item3);
+unset($item1 ,   $item2,$item3);
+
+// No suffix.
+$a = array($item1 ,   $item2,$item3);
+$a = [$item1 ,   $item2,$item3];
+
+list($item1 ,   $item2,$item3) = $array;
+[$item1 ,   $item2,$item3] = $array;
+
+for ($i = 0 ,  $j = 1,$k = 2; $i < $j && $j < $k; $i++ ,  $j++,$k++) {}
+
+echo $item1 ,   $item2,$item3;
+
+use Vendor\Package\{NameA ,   NameB,NameC};
+
+class Multi {
+    const CONST_A = 1 ,  CONST_B = 2,CONST_C = 3;
+    public $propA = 1 ,  $propB = 2,$propC = 3;
+
+    public function name() {
+        global $var1 ,   $var2,$var3;
+        static $localA = 1 ,   $localB,$localC = 'foo';
+    }
+}
+
+$value = match($value) {
+    1  ,   2,3 => 123,
+};
+
+// Parse error, but not our concern.
+print ($item1 ,   $item2,$item3);

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.2.inc.fixed
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.2.inc.fixed
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * Tests specifically for the error code differentiation.
+ *
+ * Each line should yield one of each of these errors: SpaceBefore, TooMuchSpaceAfter, NoSpaceAfter.
+ */
+
+// *InDeclare suffix.
+declare(strict_types=1, encoding='utf8', ticks=0);
+
+// *InFunctionDeclaration suffix.
+function name($param1, $param2, $param3) {}
+$closure = function ($param1, $param2, $param3) {};
+$arrow = fn ($param1, $param2, $param3) => $param1 * $param2 + $param3;
+class Foo {
+    public function name($param1, $param2, $param3) {}
+}
+
+// *InClosureUse suffix.
+$closure = function () use($param1, $param2, $param3) {};
+
+// *InFunctionCall suffix.
+do_something($param1, $param2, $param3);
+$obj = new Foo($param1, $param2, $param3);
+$obj = new self($param1, $param2, $param3);
+$obj = new parent($param1, $param2, $param3);
+$obj = new static($param1, $param2, $param3);
+$anonClass = new class($param1, $param2, $param3) {};
+$var($param1, $param2, $param3);
+#[MyAttribute(1, 'foo', false)]
+function name() {}
+isset($item1, $item2, $item3);
+unset($item1, $item2, $item3);
+
+// No suffix.
+$a = array($item1, $item2, $item3);
+$a = [$item1, $item2, $item3];
+
+list($item1, $item2, $item3) = $array;
+[$item1, $item2, $item3] = $array;
+
+for ($i = 0, $j = 1, $k = 2; $i < $j && $j < $k; $i++, $j++, $k++) {}
+
+echo $item1, $item2, $item3;
+
+use Vendor\Package\{NameA, NameB, NameC};
+
+class Multi {
+    const CONST_A = 1, CONST_B = 2, CONST_C = 3;
+    public $propA = 1, $propB = 2, $propC = 3;
+
+    public function name() {
+        global $var1, $var2, $var3;
+        static $localA = 1, $localB, $localC = 'foo';
+    }
+}
+
+$value = match($value) {
+    1, 2, 3 => 123,
+};
+
+// Parse error, but not our concern.
+print ($item1, $item2, $item3);

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.3.inc
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.3.inc
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * CommaAfterComment error - comma should be moved, but only when dealing with trailing comments.
+ */
+$a = array($a /* Comment.*/,   $bbb/* Comment. */, $ccccc /* Comment */  , $dddd);
+
+$a = array(
+    $a // Comment.
+    ,
+    $bbb/* Comment. */,
+    $ccccc /* multi
+    line */  ,
+    $dddd
+    /**
+     * Inline docblock.
+     */
+    ,
+    $eeee // phpcs:ignore Stnd.Cat.SniffName -- for reasons.
+    ,
+    $ff# phpcs:disable Stnd.Cat.SniffName -- for reasons.
+
+,
+    $ggg /* phpcs:ignore Stnd.Cat.SniffName -- for reasons. */,
+);

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.3.inc.fixed
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.3.inc.fixed
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * CommaAfterComment error - comma should be moved, but only when dealing with trailing comments.
+ */
+$a = array($a /* Comment.*/, $bbb/* Comment. */, $ccccc /* Comment */, $dddd);
+
+$a = array(
+    $a, // Comment.
+
+    $bbb, /* Comment. */
+    $ccccc, /* multi
+    line */
+    $dddd,
+    /**
+     * Inline docblock.
+     */
+
+    $eeee, // phpcs:ignore Stnd.Cat.SniffName -- for reasons.
+
+    $ff, # phpcs:disable Stnd.Cat.SniffName -- for reasons.
+
+
+    $ggg, /* phpcs:ignore Stnd.Cat.SniffName -- for reasons. */
+);

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.4.inc
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.4.inc
@@ -1,0 +1,12 @@
+<?php
+
+/*
+ * Separate test file as the risk of this test becoming invalid due to IDEs auto-trimming trailing spaces
+ * when the file is edited is large.
+ */
+
+// The sniff should ignore trailing whitespace after a comma, when the next code is on a new line.
+        $trailingWhiteSpaceAfterComma = sprintf(
+            str_replace( 'abc', 'def', $variable),    
+            $refs
+        );

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.4.inc.fixed
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.4.inc.fixed
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * Tests with PHP 7.3+ flexible heredoc/nowdoc.
+ * This must be a separate test case file as it is a parse error in PHP < 7.3.
+ *
+ * This test file is run with php_version set to a value of 70000 or higher, which means
+ * that all heredocs/nowdocs will be treated as traditional heredocs/nowdocs.
+ */
+
+/*
+ * OK.
+ */
+
+// Old-style heredoc/nowdoc.
+$array = [
+    <<<EOD
+    text
+EOD
+    , <<<'EOD'
+    text
+EOD
+    ,
+];
+
+// PHP 7.3+ flexible heredoc/nowdoc.
+$array = [
+    <<<EOD
+    text
+    EOD
+    , <<<'EOD'
+    text
+    EOD
+    ,
+];
+
+/*
+ * Incorrect spacing.
+ */
+
+// Old-style heredoc/nowdoc.
+$array = [
+    <<<EOD
+    text
+EOD
+,
+    <<<'EOD'
+    text
+EOD
+,
+];
+
+// PHP 7.3+ flexible heredoc/nowdoc.
+$array = [
+    <<<EOD
+    text
+    EOD
+, <<<'EOD'
+    text
+    EOD
+,
+];

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.5.inc
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.5.inc
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * Tests with PHP 7.3+ flexible heredoc/nowdoc.
+ * This must be a separate test case file as it is a parse error in PHP < 7.3.
+ *
+ * This test file is run with php_version set to a value of 70300 or higher, which means
+ * that the auto-fixer can safely move commas to directly after the closer,
+ * for both old-style as well as new-style here/nowdocs.
+ */
+
+/*
+ * OK.
+ */
+
+// Old-style heredoc/nowdoc.
+$array = [
+    <<<EOD
+    text
+EOD, <<<'EOD'
+    text
+EOD,
+];
+
+// PHP 7.3+ flexible heredoc/nowdoc.
+$array = [
+    <<<EOD
+    text
+    EOD, <<<'EOD'
+    text
+    EOD,
+];
+
+/*
+ * Incorrect spacing.
+ */
+
+// Old-style heredoc/nowdoc, but with what would be a parse error on PHP < 7.3.
+$array = [
+    <<<EOD
+    text
+EOD
+    ,
+    <<<'EOD'
+    text
+EOD   ,
+];
+
+// PHP 7.3+ flexible heredoc/nowdoc.
+$array = [
+    <<<EOD
+    text
+    EOD  ,   <<<'EOD'
+    text
+    EOD
+    ,
+];

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.5.inc.fixed
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.5.inc.fixed
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * Tests with PHP 7.3+ flexible heredoc/nowdoc.
+ * This must be a separate test case file as it is a parse error in PHP < 7.3.
+ *
+ * This test file is run with php_version set to a value of 70300 or higher, which means
+ * that the auto-fixer can safely move commas to directly after the closer,
+ * for both old-style as well as new-style here/nowdocs.
+ */
+
+/*
+ * OK.
+ */
+
+// Old-style heredoc/nowdoc.
+$array = [
+    <<<EOD
+    text
+EOD, <<<'EOD'
+    text
+EOD,
+];
+
+// PHP 7.3+ flexible heredoc/nowdoc.
+$array = [
+    <<<EOD
+    text
+    EOD, <<<'EOD'
+    text
+    EOD,
+];
+
+/*
+ * Incorrect spacing.
+ */
+
+// Old-style heredoc/nowdoc, but with what would be a parse error on PHP < 7.3.
+$array = [
+    <<<EOD
+    text
+EOD,
+    <<<'EOD'
+    text
+EOD,
+];
+
+// PHP 7.3+ flexible heredoc/nowdoc.
+$array = [
+    <<<EOD
+    text
+    EOD, <<<'EOD'
+    text
+    EOD,
+];

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.6.inc
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.6.inc
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * Tests with PHP 7.3+ flexible heredoc/nowdoc.
+ * This must be a separate test case file as it is a parse error in PHP < 7.3.
+ *
+ * This test file is run with php_version set to a value of 70000 or higher, which means
+ * that all heredocs/nowdocs will be treated as traditional heredocs/nowdocs and commas
+ * should be on the next line.
+ */
+
+/*
+ * OK.
+ */
+
+// Old-style heredoc/nowdoc.
+$array = [
+    <<<EOD
+    text
+EOD
+    , <<<'EOD'
+    text
+EOD
+    ,
+];
+
+// PHP 7.3+ flexible heredoc/nowdoc.
+$array = [
+    <<<EOD
+    text
+    EOD
+    , <<<'EOD'
+    text
+    EOD
+    ,
+];
+
+/*
+ * Incorrect spacing.
+ */
+
+// Old-style heredoc/nowdoc, but with what would be a parse error on PHP < 7.3.
+$array = [
+    <<<EOD
+    text
+EOD,
+    <<<'EOD'
+    text
+EOD    ,
+];
+
+// PHP 7.3+ flexible heredoc/nowdoc.
+$array = [
+    <<<EOD
+    text
+    EOD  ,   <<<'EOD'
+    text
+    EOD,
+];

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.6.inc.fixed
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.6.inc.fixed
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * Tests with PHP 7.3+ flexible heredoc/nowdoc.
+ * This must be a separate test case file as it is a parse error in PHP < 7.3.
+ *
+ * This test file is run with php_version set to a value of 70000 or higher, which means
+ * that all heredocs/nowdocs will be treated as traditional heredocs/nowdocs and commas
+ * should be on the next line.
+ */
+
+/*
+ * OK.
+ */
+
+// Old-style heredoc/nowdoc.
+$array = [
+    <<<EOD
+    text
+EOD
+    , <<<'EOD'
+    text
+EOD
+    ,
+];
+
+// PHP 7.3+ flexible heredoc/nowdoc.
+$array = [
+    <<<EOD
+    text
+    EOD
+    , <<<'EOD'
+    text
+    EOD
+    ,
+];
+
+/*
+ * Incorrect spacing.
+ */
+
+// Old-style heredoc/nowdoc, but with what would be a parse error on PHP < 7.3.
+$array = [
+    <<<EOD
+    text
+EOD
+,
+    <<<'EOD'
+    text
+EOD
+,
+];
+
+// PHP 7.3+ flexible heredoc/nowdoc.
+$array = [
+    <<<EOD
+    text
+    EOD
+, <<<'EOD'
+    text
+    EOD
+,
+];

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.7.inc
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.7.inc
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * Tests with PHP 7.3+ flexible heredoc/nowdoc.
+ * This must be a separate test case file as it is a parse error in PHP < 7.3.
+ *
+ * This test file is run without a php_version set, which means that the auto-fixer
+ * will kick in based on it detecting that whether something is a flexible heredoc/nowdoc.
+ *
+ * Old-style heredoo/nowdoc will be enforced to have a new line between the closer and
+ * the comma.
+ * New-style heredoc/nowdoc will be enforced to have no space between the closer and the comma.
+ */
+
+/*
+ * OK.
+ */
+
+// Old-style heredoc/nowdoc.
+$array = [
+    <<<EOD
+    text
+EOD
+    , <<<'EOD'
+    text
+EOD
+    ,
+];
+
+// PHP 7.3+ flexible heredoc/nowdoc.
+$array = [
+    <<<EOD
+    text
+    EOD, <<<'EOD'
+    text
+    EOD,
+];
+
+/*
+ * Incorrect spacing.
+ */
+
+// Old-style heredoc/nowdoc, but with what would be a parse error on PHP < 7.3.
+$array = [
+    <<<EOD
+    text
+EOD  ,  <<<'EOD'
+    text
+EOD,
+];
+
+// PHP 7.3+ flexible heredoc/nowdoc.
+$array = [
+    <<<EOD
+    text
+    EOD  ,   <<<'EOD'
+    text
+    EOD
+    ,
+];

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.7.inc.fixed
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.7.inc.fixed
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * Tests with PHP 7.3+ flexible heredoc/nowdoc.
+ * This must be a separate test case file as it is a parse error in PHP < 7.3.
+ *
+ * This test file is run without a php_version set, which means that the auto-fixer
+ * will kick in based on it detecting that whether something is a flexible heredoc/nowdoc.
+ *
+ * Old-style heredoo/nowdoc will be enforced to have a new line between the closer and
+ * the comma.
+ * New-style heredoc/nowdoc will be enforced to have no space between the closer and the comma.
+ */
+
+/*
+ * OK.
+ */
+
+// Old-style heredoc/nowdoc.
+$array = [
+    <<<EOD
+    text
+EOD
+    , <<<'EOD'
+    text
+EOD
+    ,
+];
+
+// PHP 7.3+ flexible heredoc/nowdoc.
+$array = [
+    <<<EOD
+    text
+    EOD, <<<'EOD'
+    text
+    EOD,
+];
+
+/*
+ * Incorrect spacing.
+ */
+
+// Old-style heredoc/nowdoc, but with what would be a parse error on PHP < 7.3.
+$array = [
+    <<<EOD
+    text
+EOD
+, <<<'EOD'
+    text
+EOD
+,
+];
+
+// PHP 7.3+ flexible heredoc/nowdoc.
+$array = [
+    <<<EOD
+    text
+    EOD, <<<'EOD'
+    text
+    EOD,
+];

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.8.inc
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.8.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Live coding/parse error test.
+// This has to be the last test in the file.
+echo $part1,

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.9.inc
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.9.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Live coding/parse error test.
+// This has to be the last test in the file.
+echo $part1,   // Comment.

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.9.inc.fixed
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.9.inc.fixed
@@ -1,0 +1,5 @@
+<?php
+
+// Live coding/parse error test.
+// This has to be the last test in the file.
+echo $part1, // Comment.

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.php
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\WhiteSpace;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHPCSUtils\BackCompat\Helper;
+
+/**
+ * Unit test class for the CommaSpacing sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\WhiteSpace\CommaSpacingSniff
+ *
+ * @since 1.1.0
+ */
+final class CommaSpacingUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Set CLI values before the file is tested.
+     *
+     * @param string                  $testFile The name of the file being tested.
+     * @param \PHP_CodeSniffer\Config $config   The config data for the test run.
+     *
+     * @return void
+     */
+    public function setCliValues($testFile, $config)
+    {
+        switch ($testFile) {
+            case 'CommaSpacingUnitTest.5.inc':
+                Helper::setConfigData('php_version', '70313', true, $config); // PHP 7.3.13.
+                break;
+
+            case 'CommaSpacingUnitTest.6.inc':
+                Helper::setConfigData('php_version', '70000', true, $config); // PHP 7.0.0.
+                break;
+
+            default:
+                Helper::setConfigData('php_version', null, true, $config); // No PHP version set.
+                break;
+        }
+    }
+
+    /**
+     * Filter PHP 7.3+ specific test case files out when the tests are run on PHP < 7.3.
+     *
+     * Remove the test files which include PHP 7.3+ flexible heredoc/nowdoc
+     * code when the tests are run on PHP < 7.3 as the results will never be correct
+     * and the fixed file will not match either.
+     *
+     * @param string $testFileBase The base path that the unit tests files will have.
+     *
+     * @return string[]
+     */
+    protected function getTestFiles($testFileBase)
+    {
+        $testFiles = parent::getTestFiles($testFileBase);
+
+        if (\PHP_VERSION_ID < 70300) {
+            foreach ($testFiles as $key => $path) {
+                if (\substr($path, -6) === '.5.inc'
+                    || \substr($path, -6) === '.6.inc'
+                    || \substr($path, -6) === '.7.inc'
+                ) {
+                    unset($testFiles[$key]);
+                }
+            }
+        }
+
+        return $testFiles;
+    }
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @param string $testFile The name of the file being tested.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList($testFile = '')
+    {
+        switch ($testFile) {
+            case 'CommaSpacingUnitTest.1.inc':
+                return [
+                    85  => 1,
+                    86  => 1,
+                    87  => 1,
+                    88  => 1,
+                    91  => 1,
+                    92  => 1,
+                    93  => 1,
+                    99  => 3,
+                    101 => 1,
+                    106 => 1,
+                    107 => 1,
+                    111 => 2,
+                    115 => 2,
+                    116 => 2,
+                    117 => 2,
+                    122 => 1,
+                    124 => 1,
+                    126 => 1,
+                    131 => 1,
+                    132 => 1,
+                    137 => 2,
+                    138 => 2,
+                    139 => 3,
+                    143 => 1,
+                    144 => 1,
+                    145 => 1,
+                    146 => 1,
+                    149 => 3,
+                    150 => 4,
+                    154 => 1,
+                    157 => 2,
+                    158 => 2,
+                    161 => 4,
+                    162 => 4,
+                    166 => 1,
+                    168 => 1,
+                    174 => 2,
+                    178 => 1,
+                    182 => 2,
+                    186 => 1,
+                    189 => 1,
+                    195 => 1,
+                    196 => 1,
+                    197 => 1,
+                    201 => 1,
+                    202 => 1,
+                ];
+
+            // Modular error code check.
+            case 'CommaSpacingUnitTest.2.inc':
+                return [
+                    10 => 3,
+                    13 => 3,
+                    14 => 3,
+                    15 => 3,
+                    17 => 3,
+                    21 => 3,
+                    24 => 3,
+                    25 => 3,
+                    26 => 3,
+                    27 => 3,
+                    28 => 3,
+                    29 => 3,
+                    30 => 3,
+                    31 => 3,
+                    33 => 3,
+                    34 => 3,
+                    37 => 3,
+                    38 => 3,
+                    40 => 3,
+                    41 => 3,
+                    43 => 6,
+                    45 => 3,
+                    47 => 3,
+                    50 => 3,
+                    51 => 3,
+                    54 => 3,
+                    55 => 3,
+                    60 => 3,
+                    64 => 3,
+                ];
+
+            // Comma before trailing comment.
+            case 'CommaSpacingUnitTest.3.inc':
+                return [
+                    6  => 2,
+                    10 => 1,
+                    11 => 1,
+                    13 => 1,
+                    18 => 1,
+                    20 => 1,
+                    23 => 1,
+                    24 => 1,
+                ];
+
+            /*
+             * PHP 7.3+ flexible heredoc/nowdoc tests.
+             * These tests will not be run on PHP < 7.3 as the results will be unreliable.
+             * The tests files will be removed from the tests to be run via the overloaded getTestFiles() method.
+             */
+            case 'CommaSpacingUnitTest.5.inc':
+                return [
+                    43 => 1,
+                    46 => 1,
+                    53 => 2,
+                    56 => 1,
+                ];
+
+            case 'CommaSpacingUnitTest.6.inc':
+                return [
+                    46 => 1,
+                    49 => 1,
+                    56 => 2,
+                    58 => 1,
+                ];
+
+            case 'CommaSpacingUnitTest.7.inc':
+                return [
+                    47 => 2,
+                    49 => 1,
+                    56 => 2,
+                    59 => 1,
+                ];
+
+            // Parse error test.
+            case 'CommaSpacingUnitTest.9.inc':
+                return [
+                    5 => 1,
+                ];
+
+            default:
+                return [];
+        }
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require" : {
         "php" : ">=5.4",
         "squizlabs/php_codesniffer" : "^3.7.1",
-        "phpcsstandards/phpcsutils" : "^1.0.7"
+        "phpcsstandards/phpcsutils" : "^1.0.8"
     },
     "require-dev" : {
         "php-parallel-lint/php-parallel-lint": "^1.3.2",


### PR DESCRIPTION
New sniff to enforce no space before a comma and exactly one space, or a new line, after a comma.
Additionally,  the sniff also enforces that the comma should follow the code and not be placed after a trailing comment.

For the spacing part, the sniff makes the following exceptions:
1. A comma preceded or followed by a parenthesis, curly or square bracket.
    These will not be flagged to prevent conflicts with sniffs handling spacing around braces.
2. A comma preceded or followed by another comma, like for skipping items in a list assignment.
    These will not be flagged.
3. A comma preceded by a non-indented heredoc/nowdoc closer.
    In that case, unless the `php_version` config directive is set to a version higher than PHP 7.3.0, a new line before will be enforced to prevent parse errors on PHP < 7.3.

The sniff has a separate error code for when a comma is found with more than one space after it, followed by a trailing comment.
That way trailing comment alignment can be allowed by excluding that error code.

Additionally, the sniff uses modular error code suffixes for select situations, like `*InFunctionDeclaration`, `*InFunctionCall`, to allow for preventing duplicate messages if another sniff is already handling the comma spacing.

Includes raising the minimum PHPCSUtils version to `1.0.8` to prevent running into a particular bug in the `SpacesFixer`.

Note: a few of the test files will only run when the tests are run on PHP 7.3+ as the tests involve PHP 7.3+ flexible heredoc/nowdoc tokens, which is the one syntax which PHPCS cannot polyfill in the Tokenizer.

Includes fixers.
Includes unit tests.
Includes documentation.
Includes metrics.