### PR TITLE
Fix typos

### DIFF
--- a/Modernize/ruleset.xml
+++ b/Modernize/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Modernize" namespace="PHPCSExtra\Modernize" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
 
-    <description>A collection of sniffs to detect code modernization opportunties.</description>
+    <description>A collection of sniffs to detect code modernization opportunities.</description>
 </ruleset>

--- a/Universal/Docs/CodeAnalysis/StaticInFinalClassStandard.xml
+++ b/Universal/Docs/CodeAnalysis/StaticInFinalClassStandard.xml
@@ -14,7 +14,7 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Using 'self' in a final OO constuct.">
+        <code title="Valid: Using 'self' in a final OO construct.">
         <![CDATA[
 final class Foo
 {
@@ -27,7 +27,7 @@ final class Foo
 }
         ]]>
         </code>
-        <code title="Invalid: Using 'static' in a final OO constuct.">
+        <code title="Invalid: Using 'static' in a final OO construct.">
         <![CDATA[
 $anon = new class {
     public function myMethod(

--- a/Universal/Tests/CodeAnalysis/StaticInFinalClassUnitTest.inc
+++ b/Universal/Tests/CodeAnalysis/StaticInFinalClassUnitTest.inc
@@ -26,11 +26,11 @@ trait UseContextUnknown {
     }
 }
 
-final class ClosuresAreNotTargettedByThisSniff {
+final class ClosuresAreNotTargetedByThisSniff {
     public static $className = 'Bar';
     public function foobar() {
         $closure = static function(): static {
-            // Returns new instance of Closure, not of ClosuresAreNotTargettedByThisSniff.
+            // Returns new instance of Closure, not of ClosuresAreNotTargetedByThisSniff.
             // Still unnecessary, but not the target of this sniff.
             // Should possibly get its own sniff.
             return new static();
@@ -97,7 +97,7 @@ class ValidUseOfStaticInConcrete extends Foo
 }
 
 interface NeverFinal {
-    public function typedMethod(): static|ArrrayAccess;
+    public function typedMethod(): static|ArrayAccess;
 }
 
 
@@ -156,7 +156,7 @@ class NonFinalClassWithNesting {
 }
 
 enum FinalByDesign {
-    public function typedMethod(): static|ArrrayAccess {
+    public function typedMethod(): static|ArrayAccess {
         $var = static::functionCall();
         $var = static::class;
 

--- a/Universal/Tests/CodeAnalysis/StaticInFinalClassUnitTest.inc.fixed
+++ b/Universal/Tests/CodeAnalysis/StaticInFinalClassUnitTest.inc.fixed
@@ -26,11 +26,11 @@ trait UseContextUnknown {
     }
 }
 
-final class ClosuresAreNotTargettedByThisSniff {
+final class ClosuresAreNotTargetedByThisSniff {
     public static $className = 'Bar';
     public function foobar() {
         $closure = static function(): static {
-            // Returns new instance of Closure, not of ClosuresAreNotTargettedByThisSniff.
+            // Returns new instance of Closure, not of ClosuresAreNotTargetedByThisSniff.
             // Still unnecessary, but not the target of this sniff.
             // Should possibly get its own sniff.
             return new static();
@@ -97,7 +97,7 @@ class ValidUseOfStaticInConcrete extends Foo
 }
 
 interface NeverFinal {
-    public function typedMethod(): static|ArrrayAccess;
+    public function typedMethod(): static|ArrayAccess;
 }
 
 
@@ -156,7 +156,7 @@ class NonFinalClassWithNesting {
 }
 
 enum FinalByDesign {
-    public function typedMethod(): self|ArrrayAccess {
+    public function typedMethod(): self|ArrayAccess {
         $var = self::functionCall();
         $var = self::class;
 


### PR DESCRIPTION
Found some misspellings with `typos`.
Code is changed in tests only.
