### PR TITLE
Universal/NoEchoSprintf: bug fix

### DIFF
--- a/Universal/Sniffs/CodeAnalysis/NoEchoSprintfSniff.php
+++ b/Universal/Sniffs/CodeAnalysis/NoEchoSprintfSniff.php
@@ -81,7 +81,7 @@ final class NoEchoSprintfSniff implements Sniff
         $detectedFunction = \strtolower($tokens[$next]['content']);
 
         $openParens = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
-        if ($next === false
+        if ($openParens === false
             || $tokens[$openParens]['code'] !== \T_OPEN_PARENTHESIS
             || isset($tokens[$openParens]['parenthesis_closer']) === false
         ) {


### PR DESCRIPTION
The condition was checking the wrong variable against `false`.

This wasn't leading to any issues, but should still be fixed.