### PR TITLE
Various sniffs: set redundant default values

### DIFF
--- a/Modernize/Sniffs/FunctionCalls/DirnameSniff.php
+++ b/Modernize/Sniffs/FunctionCalls/DirnameSniff.php
@@ -150,6 +150,8 @@ final class DirnameSniff implements Sniff
          * PHP 5.3+: Detect use of dirname(__FILE__).
          */
         if (\strtoupper($pathParam['clean']) === '__FILE__') {
+            $levelsValue = false;
+
             // Determine if the issue is auto-fixable.
             $hasComment = $phpcsFile->findNext(Tokens::$commentTokens, ($opener + 1), $closer);
             $fixable    = ($hasComment === false);
@@ -248,7 +250,12 @@ final class DirnameSniff implements Sniff
          */
 
         // Step 1: Are there comments ? If so, not auto-fixable as we don't want to remove comments.
-        $fixable = true;
+        $fixable          = true;
+        $outerLevelsValue = false;
+        $innerParameters  = [];
+        $innerLevelsParam = false;
+        $innerLevelsValue = false;
+
         for ($i = ($opener + 1); $i < $closer; $i++) {
             if (isset(Tokens::$commentTokens[$tokens[$i]['code']])) {
                 $fixable = false;

--- a/Universal/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
+++ b/Universal/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
@@ -127,6 +127,7 @@ final class DisallowInlineTabsSniff implements Sniff
              * so from here on out, we **know** there will be tabs in the content.
              */
             $origContent = $token['orig_content'];
+            $commentOnly = '';
 
             $multiLineComment = false;
             if (($tokens[$i]['code'] === \T_COMMENT

--- a/Universal/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
+++ b/Universal/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
@@ -208,7 +208,11 @@ final class PrecisionAlignmentSniff implements Sniff
                 $origContent = $tokens[$i]['orig_content'];
             }
 
-            $spaces = 0;
+            $spaces  = 0;
+            $length  = 0;
+            $content = '';
+            $closer  = '';
+
             switch ($tokens[$i]['code']) {
                 case \T_WHITESPACE:
                     if ($this->ignoreBlankLines === true


### PR DESCRIPTION
### Modernize/Dirname: set redundant default values

### Universal/DisallowInlineTabs: set redundant default values

### Universal/PrecisionAlignment: set redundant default values

These variables are only accessed within conditions and those conditions already sufficiently ensure that the variables will be set for the conditions path.

Even so, PHPStan cannot handle this, so we may as well declare sensible defaults for each of those variables to make things more explicit.