### PR TITLE
Docs: various improvements

### DIFF
--- a/Modernize/Sniffs/FunctionCalls/DirnameSniff.php
+++ b/Modernize/Sniffs/FunctionCalls/DirnameSniff.php
@@ -40,7 +40,7 @@ final class DirnameSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return int|string[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Modernize/Sniffs/FunctionCalls/DirnameSniff.php
+++ b/Modernize/Sniffs/FunctionCalls/DirnameSniff.php
@@ -357,9 +357,9 @@ final class DirnameSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being scanned.
-     * @param array|false                 $levelsParam The information about the parameter as retrieved
-     *                                                 via PassedParameters::getParameterFromStack().
+     * @param \PHP_CodeSniffer\Files\File     $phpcsFile   The file being scanned.
+     * @param array<string, int|string>|false $levelsParam The information about the parameter as retrieved
+     *                                                     via PassedParameters::getParameterFromStack().
      *
      * @return int|false Integer levels value or FALSE if the levels value couldn't be determined.
      */

--- a/Modernize/Tests/FunctionCalls/DirnameUnitTest.php
+++ b/Modernize/Tests/FunctionCalls/DirnameUnitTest.php
@@ -55,12 +55,9 @@ final class DirnameUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * The key of the array should represent the line number and the value
-     * should represent the number of errors that should occur on that line.
-     *
      * @param string $testFile The name of the file being tested.
      *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList($testFile = '')
     {
@@ -119,10 +116,7 @@ final class DirnameUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * The key of the array should represent the line number and the value
-     * should represent the number of warnings that should occur on that line.
-     *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/NormalizedArrays/Sniffs/Arrays/ArrayBraceSpacingSniff.php
+++ b/NormalizedArrays/Sniffs/Arrays/ArrayBraceSpacingSniff.php
@@ -102,7 +102,7 @@ final class ArrayBraceSpacingSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/NormalizedArrays/Sniffs/Arrays/CommaAfterLastSniff.php
+++ b/NormalizedArrays/Sniffs/Arrays/CommaAfterLastSniff.php
@@ -87,7 +87,7 @@ final class CommaAfterLastSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/NormalizedArrays/Sniffs/Arrays/CommaAfterLastSniff.php
+++ b/NormalizedArrays/Sniffs/Arrays/CommaAfterLastSniff.php
@@ -74,7 +74,7 @@ final class CommaAfterLastSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @var array
+     * @var array<string, true>
      */
     private $validValues = [
         'enforce' => true,

--- a/NormalizedArrays/Tests/Arrays/ArrayBraceSpacingUnitTest.php
+++ b/NormalizedArrays/Tests/Arrays/ArrayBraceSpacingUnitTest.php
@@ -25,7 +25,7 @@ final class ArrayBraceSpacingUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -82,7 +82,7 @@ final class ArrayBraceSpacingUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/NormalizedArrays/Tests/Arrays/CommaAfterLastUnitTest.php
+++ b/NormalizedArrays/Tests/Arrays/CommaAfterLastUnitTest.php
@@ -27,7 +27,7 @@ final class CommaAfterLastUnitTest extends AbstractSniffUnitTest
      *
      * @param string $testFile The name of the file being tested.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList($testFile = '')
     {
@@ -74,7 +74,7 @@ final class CommaAfterLastUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Helpers/DummyTokenizer.php
+++ b/Universal/Helpers/DummyTokenizer.php
@@ -42,10 +42,11 @@ final class DummyTokenizer extends Tokenizer
      *
      * @param string $string The string to tokenize.
      *
-     * @return array
+     * @return array<int, array<string, mixed>>
      */
     protected function tokenize($string)
     {
+        return [];
     }
 
     /**

--- a/Universal/Sniffs/Arrays/DisallowShortArraySyntaxSniff.php
+++ b/Universal/Sniffs/Arrays/DisallowShortArraySyntaxSniff.php
@@ -42,7 +42,7 @@ final class DisallowShortArraySyntaxSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return int|string[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/Arrays/DuplicateArrayKeySniff.php
+++ b/Universal/Sniffs/Arrays/DuplicateArrayKeySniff.php
@@ -35,7 +35,7 @@ final class DuplicateArrayKeySniff extends AbstractArrayDeclarationSniff
      *
      * @since 1.0.0
      *
-     * @var array
+     * @var array<int, array<string, int>>
      */
     private $keysSeenLt8 = [];
 
@@ -44,7 +44,7 @@ final class DuplicateArrayKeySniff extends AbstractArrayDeclarationSniff
      *
      * @since 1.0.0
      *
-     * @var array
+     * @var array<int, array<string, int>>
      */
     private $keysSeenGt8 = [];
 

--- a/Universal/Sniffs/Arrays/MixedArrayKeyTypesSniff.php
+++ b/Universal/Sniffs/Arrays/MixedArrayKeyTypesSniff.php
@@ -68,7 +68,9 @@ final class MixedArrayKeyTypesSniff extends AbstractArrayDeclarationSniff
      *                                               an array item.
      * @param int                         $itemNr    Which item in the array is being handled.
      *
-     * @return void
+     * @return true|void Returning `TRUE` will short-circuit the array item loop and stop processing.
+     *                   In effect, this means that the sniff will not examine the double arrow, the array
+     *                   value or comma for this array item and will not process any array items after this one.
      */
     public function processKey(File $phpcsFile, $startPtr, $endPtr, $itemNr)
     {
@@ -141,7 +143,9 @@ final class MixedArrayKeyTypesSniff extends AbstractArrayDeclarationSniff
      *                                               value part of the array item.
      * @param int                         $itemNr    Which item in the array is being handled.
      *
-     * @return void
+     * @return true|void Returning `TRUE` will short-circuit the array item loop and stop processing.
+     *                   In effect, this means that the sniff will not examine the array value or
+     *                   comma for this array item and will not process any array items after this one.
      */
     public function processNoKey(File $phpcsFile, $startPtr, $itemNr)
     {

--- a/Universal/Sniffs/Arrays/MixedKeyedUnkeyedArraySniff.php
+++ b/Universal/Sniffs/Arrays/MixedKeyedUnkeyedArraySniff.php
@@ -36,7 +36,7 @@ final class MixedKeyedUnkeyedArraySniff extends AbstractArrayDeclarationSniff
      *
      * @since 1.0.0
      *
-     * @var array <int item number> => <int stack point to the first non empty token in the item>
+     * @var array<int, int> Key is the item number; value the stack point to the first non empty token in the item.
      */
     private $itemsWithoutKey = [];
 

--- a/Universal/Sniffs/Classes/DisallowAnonClassParenthesesSniff.php
+++ b/Universal/Sniffs/Classes/DisallowAnonClassParenthesesSniff.php
@@ -37,7 +37,7 @@ final class DisallowAnonClassParenthesesSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/Classes/DisallowFinalClassSniff.php
+++ b/Universal/Sniffs/Classes/DisallowFinalClassSniff.php
@@ -38,7 +38,7 @@ final class DisallowFinalClassSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/Classes/ModifierKeywordOrderSniff.php
+++ b/Universal/Sniffs/Classes/ModifierKeywordOrderSniff.php
@@ -69,7 +69,7 @@ final class ModifierKeywordOrderSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/Classes/RequireAnonClassParenthesesSniff.php
+++ b/Universal/Sniffs/Classes/RequireAnonClassParenthesesSniff.php
@@ -36,7 +36,7 @@ final class RequireAnonClassParenthesesSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/Classes/RequireFinalClassSniff.php
+++ b/Universal/Sniffs/Classes/RequireFinalClassSniff.php
@@ -38,7 +38,7 @@ final class RequireFinalClassSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/CodeAnalysis/ConstructorDestructorReturnSniff.php
+++ b/Universal/Sniffs/CodeAnalysis/ConstructorDestructorReturnSniff.php
@@ -45,7 +45,7 @@ final class ConstructorDestructorReturnSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/CodeAnalysis/ForeachUniqueAssignmentSniff.php
+++ b/Universal/Sniffs/CodeAnalysis/ForeachUniqueAssignmentSniff.php
@@ -33,7 +33,7 @@ final class ForeachUniqueAssignmentSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/CodeAnalysis/NoEchoSprintfSniff.php
+++ b/Universal/Sniffs/CodeAnalysis/NoEchoSprintfSniff.php
@@ -44,7 +44,7 @@ final class NoEchoSprintfSniff implements Sniff
      *
      * @since 1.1.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/CodeAnalysis/StaticInFinalClassSniff.php
+++ b/Universal/Sniffs/CodeAnalysis/StaticInFinalClassSniff.php
@@ -43,7 +43,7 @@ final class StaticInFinalClassSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/CodeAnalysis/StaticInFinalClassSniff.php
+++ b/Universal/Sniffs/CodeAnalysis/StaticInFinalClassSniff.php
@@ -30,7 +30,7 @@ final class StaticInFinalClassSniff implements Sniff
     /**
      * OO Scopes in which late static binding is useless.
      *
-     * @var int|string[]
+     * @var array<int|string>
      */
     private $validOOScopes = [
         \T_CLASS,      // Only if final.

--- a/Universal/Sniffs/Constants/LowercaseClassResolutionKeywordSniff.php
+++ b/Universal/Sniffs/Constants/LowercaseClassResolutionKeywordSniff.php
@@ -39,7 +39,7 @@ final class LowercaseClassResolutionKeywordSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/Constants/ModifierKeywordOrderSniff.php
+++ b/Universal/Sniffs/Constants/ModifierKeywordOrderSniff.php
@@ -71,7 +71,7 @@ final class ModifierKeywordOrderSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/Constants/UppercaseMagicConstantsSniff.php
+++ b/Universal/Sniffs/Constants/UppercaseMagicConstantsSniff.php
@@ -38,7 +38,7 @@ final class UppercaseMagicConstantsSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/ControlStructures/DisallowAlternativeSyntaxSniff.php
+++ b/Universal/Sniffs/ControlStructures/DisallowAlternativeSyntaxSniff.php
@@ -51,7 +51,7 @@ final class DisallowAlternativeSyntaxSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/ControlStructures/DisallowLonelyIfSniff.php
+++ b/Universal/Sniffs/ControlStructures/DisallowLonelyIfSniff.php
@@ -35,7 +35,7 @@ final class DisallowLonelyIfSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/ControlStructures/IfElseDeclarationSniff.php
+++ b/Universal/Sniffs/ControlStructures/IfElseDeclarationSniff.php
@@ -45,7 +45,7 @@ final class IfElseDeclarationSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/Files/SeparateFunctionsFromOOSniff.php
+++ b/Universal/Sniffs/Files/SeparateFunctionsFromOOSniff.php
@@ -49,7 +49,7 @@ final class SeparateFunctionsFromOOSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @var array
+     * @var array<int|string>
      */
     private $search = [
         // Some tokens to help skip over structures we're not interested in.
@@ -81,7 +81,8 @@ final class SeparateFunctionsFromOOSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token
      *                                               in the stack passed in $tokens.
      *
-     * @return void
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/Universal/Sniffs/Files/SeparateFunctionsFromOOSniff.php
+++ b/Universal/Sniffs/Files/SeparateFunctionsFromOOSniff.php
@@ -62,7 +62,7 @@ final class SeparateFunctionsFromOOSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/FunctionDeclarations/NoLongClosuresSniff.php
+++ b/Universal/Sniffs/FunctionDeclarations/NoLongClosuresSniff.php
@@ -98,7 +98,7 @@ final class NoLongClosuresSniff implements Sniff
      *
      * @since 1.1.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/FunctionDeclarations/RequireFinalMethodsInTraitsSniff.php
+++ b/Universal/Sniffs/FunctionDeclarations/RequireFinalMethodsInTraitsSniff.php
@@ -38,7 +38,7 @@ final class RequireFinalMethodsInTraitsSniff implements Sniff
      *
      * @since 1.1.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/Lists/DisallowLongListSyntaxSniff.php
+++ b/Universal/Sniffs/Lists/DisallowLongListSyntaxSniff.php
@@ -27,7 +27,7 @@ final class DisallowLongListSyntaxSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/Lists/DisallowShortListSyntaxSniff.php
+++ b/Universal/Sniffs/Lists/DisallowShortListSyntaxSniff.php
@@ -35,7 +35,7 @@ final class DisallowShortListSyntaxSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/Namespaces/DisallowCurlyBraceSyntaxSniff.php
+++ b/Universal/Sniffs/Namespaces/DisallowCurlyBraceSyntaxSniff.php
@@ -36,7 +36,7 @@ final class DisallowCurlyBraceSyntaxSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/Namespaces/DisallowDeclarationWithoutNameSniff.php
+++ b/Universal/Sniffs/Namespaces/DisallowDeclarationWithoutNameSniff.php
@@ -36,7 +36,7 @@ final class DisallowDeclarationWithoutNameSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/Namespaces/EnforceCurlyBraceSyntaxSniff.php
+++ b/Universal/Sniffs/Namespaces/EnforceCurlyBraceSyntaxSniff.php
@@ -36,7 +36,7 @@ final class EnforceCurlyBraceSyntaxSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/Namespaces/OneDeclarationPerFileSniff.php
+++ b/Universal/Sniffs/Namespaces/OneDeclarationPerFileSniff.php
@@ -45,7 +45,7 @@ final class OneDeclarationPerFileSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/NamingConventions/NoReservedKeywordParameterNamesSniff.php
+++ b/Universal/Sniffs/NamingConventions/NoReservedKeywordParameterNamesSniff.php
@@ -36,7 +36,7 @@ final class NoReservedKeywordParameterNamesSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @var array<string => string> Key is the lowercased keyword, value the "proper" cased keyword.
+     * @var array<string, string> Key is the lowercased keyword, value the "proper" cased keyword.
      */
     private $reservedNames = [
         'abstract'      => 'abstract',

--- a/Universal/Sniffs/NamingConventions/NoReservedKeywordParameterNamesSniff.php
+++ b/Universal/Sniffs/NamingConventions/NoReservedKeywordParameterNamesSniff.php
@@ -145,7 +145,7 @@ final class NoReservedKeywordParameterNamesSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/OOStructures/AlphabeticExtendsImplementsSniff.php
+++ b/Universal/Sniffs/OOStructures/AlphabeticExtendsImplementsSniff.php
@@ -82,7 +82,7 @@ final class AlphabeticExtendsImplementsSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/Operators/DisallowLogicalAndOrSniff.php
+++ b/Universal/Sniffs/Operators/DisallowLogicalAndOrSniff.php
@@ -39,7 +39,7 @@ final class DisallowLogicalAndOrSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @var array
+     * @var array<int|string, string>
      */
     private $metricType = [
         \T_LOGICAL_AND => 'logical (and/or)',
@@ -53,7 +53,7 @@ final class DisallowLogicalAndOrSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @var array
+     * @var array<int|string, array<string, string>>
      */
     private $targetTokenInfo = [
         \T_LOGICAL_AND => [

--- a/Universal/Sniffs/Operators/DisallowLogicalAndOrSniff.php
+++ b/Universal/Sniffs/Operators/DisallowLogicalAndOrSniff.php
@@ -71,7 +71,7 @@ final class DisallowLogicalAndOrSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/Operators/DisallowShortTernarySniff.php
+++ b/Universal/Sniffs/Operators/DisallowShortTernarySniff.php
@@ -40,7 +40,7 @@ final class DisallowShortTernarySniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/Operators/DisallowStandalonePostIncrementDecrementSniff.php
+++ b/Universal/Sniffs/Operators/DisallowStandalonePostIncrementDecrementSniff.php
@@ -47,7 +47,7 @@ final class DisallowStandalonePostIncrementDecrementSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @var array
+     * @var array<int|string>
      */
     private $allowedTokens = [
         \T_VARIABLE => \T_VARIABLE,
@@ -84,7 +84,8 @@ final class DisallowStandalonePostIncrementDecrementSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token
      *                                               in the stack passed in $tokens.
      *
-     * @return void
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/Universal/Sniffs/Operators/DisallowStandalonePostIncrementDecrementSniff.php
+++ b/Universal/Sniffs/Operators/DisallowStandalonePostIncrementDecrementSniff.php
@@ -58,7 +58,7 @@ final class DisallowStandalonePostIncrementDecrementSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/Operators/StrictComparisonsSniff.php
+++ b/Universal/Sniffs/Operators/StrictComparisonsSniff.php
@@ -70,7 +70,7 @@ final class StrictComparisonsSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/Operators/StrictComparisonsSniff.php
+++ b/Universal/Sniffs/Operators/StrictComparisonsSniff.php
@@ -38,7 +38,7 @@ final class StrictComparisonsSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @var array
+     * @var array<int|string, string>
      */
     private $metricType = [
         \T_IS_EQUAL         => 'loose',
@@ -52,7 +52,7 @@ final class StrictComparisonsSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @var array
+     * @var array<int|string, array<string, string>>
      */
     private $targetTokenInfo = [
         \T_IS_EQUAL     => [

--- a/Universal/Sniffs/Operators/TypeSeparatorSpacingSniff.php
+++ b/Universal/Sniffs/Operators/TypeSeparatorSpacingSniff.php
@@ -28,7 +28,7 @@ final class TypeSeparatorSpacingSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/PHP/OneStatementInShortEchoTagSniff.php
+++ b/Universal/Sniffs/PHP/OneStatementInShortEchoTagSniff.php
@@ -32,7 +32,7 @@ final class OneStatementInShortEchoTagSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/PHP/OneStatementInShortEchoTagSniff.php
+++ b/Universal/Sniffs/PHP/OneStatementInShortEchoTagSniff.php
@@ -48,7 +48,7 @@ final class OneStatementInShortEchoTagSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token
      *                                               in the stack passed in $tokens.
      *
-     * @return int Integer stack pointer to skip the rest of the file.
+     * @return void
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/Universal/Sniffs/UseStatements/DisallowMixedGroupUseSniff.php
+++ b/Universal/Sniffs/UseStatements/DisallowMixedGroupUseSniff.php
@@ -44,7 +44,7 @@ final class DisallowMixedGroupUseSniff implements Sniff
      *
      * @since 1.1.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/UseStatements/DisallowUseClassSniff.php
+++ b/Universal/Sniffs/UseStatements/DisallowUseClassSniff.php
@@ -70,7 +70,7 @@ final class DisallowUseClassSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/UseStatements/DisallowUseConstSniff.php
+++ b/Universal/Sniffs/UseStatements/DisallowUseConstSniff.php
@@ -70,7 +70,7 @@ final class DisallowUseConstSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/UseStatements/DisallowUseFunctionSniff.php
+++ b/Universal/Sniffs/UseStatements/DisallowUseFunctionSniff.php
@@ -70,7 +70,7 @@ final class DisallowUseFunctionSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/UseStatements/KeywordSpacingSniff.php
+++ b/Universal/Sniffs/UseStatements/KeywordSpacingSniff.php
@@ -50,7 +50,7 @@ final class KeywordSpacingSniff implements Sniff
      *
      * @since 1.1.0
      *
-     * @var array(string => string)
+     * @var array<string, true>
      */
     protected $keywords = [
         'const'    => true,

--- a/Universal/Sniffs/UseStatements/KeywordSpacingSniff.php
+++ b/Universal/Sniffs/UseStatements/KeywordSpacingSniff.php
@@ -62,7 +62,7 @@ final class KeywordSpacingSniff implements Sniff
      *
      * @since 1.1.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/UseStatements/LowercaseFunctionConstSniff.php
+++ b/Universal/Sniffs/UseStatements/LowercaseFunctionConstSniff.php
@@ -40,7 +40,7 @@ final class LowercaseFunctionConstSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @var array(string => string)
+     * @var array<string, true>
      */
     protected $keywords = [
         'const'    => true,

--- a/Universal/Sniffs/UseStatements/LowercaseFunctionConstSniff.php
+++ b/Universal/Sniffs/UseStatements/LowercaseFunctionConstSniff.php
@@ -52,7 +52,7 @@ final class LowercaseFunctionConstSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/UseStatements/NoLeadingBackslashSniff.php
+++ b/Universal/Sniffs/UseStatements/NoLeadingBackslashSniff.php
@@ -41,7 +41,7 @@ final class NoLeadingBackslashSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/UseStatements/NoUselessAliasesSniff.php
+++ b/Universal/Sniffs/UseStatements/NoUselessAliasesSniff.php
@@ -42,7 +42,7 @@ final class NoUselessAliasesSniff implements Sniff
      *
      * @since 1.1.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/WhiteSpace/AnonClassKeywordSpacingSniff.php
+++ b/Universal/Sniffs/WhiteSpace/AnonClassKeywordSpacingSniff.php
@@ -37,7 +37,7 @@ final class AnonClassKeywordSpacingSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/WhiteSpace/CommaSpacingSniff.php
+++ b/Universal/Sniffs/WhiteSpace/CommaSpacingSniff.php
@@ -78,7 +78,7 @@ final class CommaSpacingSniff implements Sniff
      *
      * @since 1.1.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
+++ b/Universal/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
@@ -70,7 +70,7 @@ final class DisallowInlineTabsSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
+++ b/Universal/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
@@ -56,7 +56,7 @@ final class DisallowInlineTabsSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @var array
+     * @var array<int|string, true>
      */
     private $find = [
         \T_WHITESPACE             => true,

--- a/Universal/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
+++ b/Universal/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
@@ -42,7 +42,7 @@ final class PrecisionAlignmentSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @var array
+     * @var string[]
      */
     public $supportedTokenizers = [
         'PHP',
@@ -84,7 +84,7 @@ final class PrecisionAlignmentSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @var array
+     * @var string[]
      */
     public $ignoreAlignmentBefore = [];
 

--- a/Universal/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
+++ b/Universal/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
@@ -134,7 +134,7 @@ final class PrecisionAlignmentSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/Universal/Tests/Arrays/DisallowShortArraySyntaxUnitTest.php
+++ b/Universal/Tests/Arrays/DisallowShortArraySyntaxUnitTest.php
@@ -25,10 +25,7 @@ final class DisallowShortArraySyntaxUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * The key of the array should represent the line number and the value
-     * should represent the number of errors that should occur on that line.
-     *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -45,10 +42,7 @@ final class DisallowShortArraySyntaxUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * The key of the array should represent the line number and the value
-     * should represent the number of warnings that should occur on that line.
-     *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/Arrays/DuplicateArrayKeyUnitTest.php
+++ b/Universal/Tests/Arrays/DuplicateArrayKeyUnitTest.php
@@ -25,7 +25,7 @@ final class DuplicateArrayKeyUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -121,7 +121,7 @@ final class DuplicateArrayKeyUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/Arrays/MixedArrayKeyTypesUnitTest.php
+++ b/Universal/Tests/Arrays/MixedArrayKeyTypesUnitTest.php
@@ -25,7 +25,7 @@ final class MixedArrayKeyTypesUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -39,7 +39,7 @@ final class MixedArrayKeyTypesUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/Arrays/MixedKeyedUnkeyedArrayUnitTest.php
+++ b/Universal/Tests/Arrays/MixedKeyedUnkeyedArrayUnitTest.php
@@ -25,7 +25,7 @@ final class MixedKeyedUnkeyedArrayUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -38,7 +38,7 @@ final class MixedKeyedUnkeyedArrayUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/Classes/DisallowAnonClassParenthesesUnitTest.php
+++ b/Universal/Tests/Classes/DisallowAnonClassParenthesesUnitTest.php
@@ -27,7 +27,7 @@ final class DisallowAnonClassParenthesesUnitTest extends AbstractSniffUnitTest
      *
      * @param string $testFile The name of the file being tested.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList($testFile = '')
     {
@@ -49,7 +49,7 @@ final class DisallowAnonClassParenthesesUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/Classes/DisallowFinalClassUnitTest.php
+++ b/Universal/Tests/Classes/DisallowFinalClassUnitTest.php
@@ -25,7 +25,7 @@ final class DisallowFinalClassUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -44,7 +44,7 @@ final class DisallowFinalClassUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/Classes/ModifierKeywordOrderUnitTest.php
+++ b/Universal/Tests/Classes/ModifierKeywordOrderUnitTest.php
@@ -25,7 +25,7 @@ final class ModifierKeywordOrderUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -43,7 +43,7 @@ final class ModifierKeywordOrderUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/Classes/RequireAnonClassParenthesesUnitTest.php
+++ b/Universal/Tests/Classes/RequireAnonClassParenthesesUnitTest.php
@@ -25,7 +25,7 @@ final class RequireAnonClassParenthesesUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -39,7 +39,7 @@ final class RequireAnonClassParenthesesUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/Classes/RequireFinalClassUnitTest.php
+++ b/Universal/Tests/Classes/RequireFinalClassUnitTest.php
@@ -25,7 +25,7 @@ final class RequireFinalClassUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -41,7 +41,7 @@ final class RequireFinalClassUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/CodeAnalysis/ConstructorDestructorReturnUnitTest.php
+++ b/Universal/Tests/CodeAnalysis/ConstructorDestructorReturnUnitTest.php
@@ -53,7 +53,7 @@ final class ConstructorDestructorReturnUnitTest extends AbstractSniffUnitTest
      *
      * @param string $testFile The name of the file being tested.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList($testFile = '')
     {
@@ -97,7 +97,7 @@ final class ConstructorDestructorReturnUnitTest extends AbstractSniffUnitTest
      *
      * @param string $testFile The name of the file being tested.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList($testFile = '')
     {

--- a/Universal/Tests/CodeAnalysis/ForeachUniqueAssignmentUnitTest.php
+++ b/Universal/Tests/CodeAnalysis/ForeachUniqueAssignmentUnitTest.php
@@ -25,7 +25,7 @@ final class ForeachUniqueAssignmentUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -44,7 +44,7 @@ final class ForeachUniqueAssignmentUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/CodeAnalysis/NoEchoSprintfUnitTest.php
+++ b/Universal/Tests/CodeAnalysis/NoEchoSprintfUnitTest.php
@@ -27,7 +27,7 @@ final class NoEchoSprintfUnitTest extends AbstractSniffUnitTest
      *
      * @param string $testFile The name of the file being tested.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList($testFile = '')
     {
@@ -50,7 +50,7 @@ final class NoEchoSprintfUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/CodeAnalysis/StaticInFinalClassUnitTest.php
+++ b/Universal/Tests/CodeAnalysis/StaticInFinalClassUnitTest.php
@@ -25,7 +25,7 @@ final class StaticInFinalClassUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -57,7 +57,7 @@ final class StaticInFinalClassUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/Constants/LowercaseClassResolutionKeywordUnitTest.php
+++ b/Universal/Tests/Constants/LowercaseClassResolutionKeywordUnitTest.php
@@ -25,7 +25,7 @@ final class LowercaseClassResolutionKeywordUnitTest extends AbstractSniffUnitTes
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -38,7 +38,7 @@ final class LowercaseClassResolutionKeywordUnitTest extends AbstractSniffUnitTes
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/Constants/ModifierKeywordOrderUnitTest.php
+++ b/Universal/Tests/Constants/ModifierKeywordOrderUnitTest.php
@@ -25,7 +25,7 @@ final class ModifierKeywordOrderUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -43,7 +43,7 @@ final class ModifierKeywordOrderUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/Constants/UppercaseMagicConstantsUnitTest.php
+++ b/Universal/Tests/Constants/UppercaseMagicConstantsUnitTest.php
@@ -25,7 +25,7 @@ final class UppercaseMagicConstantsUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -52,7 +52,7 @@ final class UppercaseMagicConstantsUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.php
+++ b/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.php
@@ -27,7 +27,7 @@ final class DisallowAlternativeSyntaxUnitTest extends AbstractSniffUnitTest
      *
      * @param string $testFile The name of the file being tested.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList($testFile = '')
     {
@@ -78,7 +78,7 @@ final class DisallowAlternativeSyntaxUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/ControlStructures/DisallowLonelyIfUnitTest.php
+++ b/Universal/Tests/ControlStructures/DisallowLonelyIfUnitTest.php
@@ -25,7 +25,7 @@ final class DisallowLonelyIfUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -60,7 +60,7 @@ final class DisallowLonelyIfUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/ControlStructures/IfElseDeclarationUnitTest.php
+++ b/Universal/Tests/ControlStructures/IfElseDeclarationUnitTest.php
@@ -38,7 +38,7 @@ final class IfElseDeclarationUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -62,7 +62,7 @@ final class IfElseDeclarationUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.php
+++ b/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.php
@@ -27,7 +27,7 @@ final class SeparateFunctionsFromOOUnitTest extends AbstractSniffUnitTest
      *
      * @param string $testFile The name of the file being tested.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList($testFile = '')
     {
@@ -55,7 +55,7 @@ final class SeparateFunctionsFromOOUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.php
+++ b/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.php
@@ -27,7 +27,7 @@ final class NoLongClosuresUnitTest extends AbstractSniffUnitTest
      *
      * @param string $testFile The name of the file being tested.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList($testFile = '')
     {
@@ -84,7 +84,7 @@ final class NoLongClosuresUnitTest extends AbstractSniffUnitTest
      *
      * @param string $testFile The name of the file being tested.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList($testFile = '')
     {

--- a/Universal/Tests/FunctionDeclarations/RequireFinalMethodsInTraitsUnitTest.php
+++ b/Universal/Tests/FunctionDeclarations/RequireFinalMethodsInTraitsUnitTest.php
@@ -25,7 +25,7 @@ final class RequireFinalMethodsInTraitsUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -60,7 +60,7 @@ final class RequireFinalMethodsInTraitsUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/Lists/DisallowLongListSyntaxUnitTest.php
+++ b/Universal/Tests/Lists/DisallowLongListSyntaxUnitTest.php
@@ -25,10 +25,7 @@ final class DisallowLongListSyntaxUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * The key of the array should represent the line number and the value
-     * should represent the number of errors that should occur on that line.
-     *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -45,10 +42,7 @@ final class DisallowLongListSyntaxUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * The key of the array should represent the line number and the value
-     * should represent the number of warnings that should occur on that line.
-     *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.php
+++ b/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.php
@@ -25,10 +25,7 @@ final class DisallowShortListSyntaxUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * The key of the array should represent the line number and the value
-     * should represent the number of errors that should occur on that line.
-     *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -46,10 +43,7 @@ final class DisallowShortListSyntaxUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * The key of the array should represent the line number and the value
-     * should represent the number of warnings that should occur on that line.
-     *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/Namespaces/DisallowCurlyBraceSyntaxUnitTest.php
+++ b/Universal/Tests/Namespaces/DisallowCurlyBraceSyntaxUnitTest.php
@@ -25,7 +25,7 @@ final class DisallowCurlyBraceSyntaxUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -39,7 +39,7 @@ final class DisallowCurlyBraceSyntaxUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/Namespaces/DisallowDeclarationWithoutNameUnitTest.php
+++ b/Universal/Tests/Namespaces/DisallowDeclarationWithoutNameUnitTest.php
@@ -27,7 +27,7 @@ final class DisallowDeclarationWithoutNameUnitTest extends AbstractSniffUnitTest
      *
      * @param string $testFile The name of the file being tested.
      *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList($testFile = '')
     {
@@ -46,7 +46,7 @@ final class DisallowDeclarationWithoutNameUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/Namespaces/EnforceCurlyBraceSyntaxUnitTest.php
+++ b/Universal/Tests/Namespaces/EnforceCurlyBraceSyntaxUnitTest.php
@@ -25,7 +25,7 @@ final class EnforceCurlyBraceSyntaxUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -38,7 +38,7 @@ final class EnforceCurlyBraceSyntaxUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/Namespaces/OneDeclarationPerFileUnitTest.php
+++ b/Universal/Tests/Namespaces/OneDeclarationPerFileUnitTest.php
@@ -27,7 +27,7 @@ final class OneDeclarationPerFileUnitTest extends AbstractSniffUnitTest
      *
      * @param string $testFile The name of the file being tested.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList($testFile = '')
     {
@@ -55,7 +55,7 @@ final class OneDeclarationPerFileUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.php
+++ b/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.php
@@ -25,7 +25,7 @@ final class NoReservedKeywordParameterNamesUnitTest extends AbstractSniffUnitTes
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -35,7 +35,7 @@ final class NoReservedKeywordParameterNamesUnitTest extends AbstractSniffUnitTes
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/OOStructures/AlphabeticExtendsImplementsUnitTest.php
+++ b/Universal/Tests/OOStructures/AlphabeticExtendsImplementsUnitTest.php
@@ -25,7 +25,7 @@ final class AlphabeticExtendsImplementsUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -48,7 +48,7 @@ final class AlphabeticExtendsImplementsUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/Operators/DisallowLogicalAndOrUnitTest.php
+++ b/Universal/Tests/Operators/DisallowLogicalAndOrUnitTest.php
@@ -25,7 +25,7 @@ final class DisallowLogicalAndOrUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -38,7 +38,7 @@ final class DisallowLogicalAndOrUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/Operators/DisallowShortTernaryUnitTest.php
+++ b/Universal/Tests/Operators/DisallowShortTernaryUnitTest.php
@@ -25,10 +25,7 @@ final class DisallowShortTernaryUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * The key of the array should represent the line number and the value
-     * should represent the number of errors that should occur on that line.
-     *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -42,10 +39,7 @@ final class DisallowShortTernaryUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * The key of the array should represent the line number and the value
-     * should represent the number of warnings that should occur on that line.
-     *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/Operators/DisallowStandalonePostIncrementDecrementUnitTest.php
+++ b/Universal/Tests/Operators/DisallowStandalonePostIncrementDecrementUnitTest.php
@@ -25,7 +25,7 @@ final class DisallowStandalonePostIncrementDecrementUnitTest extends AbstractSni
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -51,7 +51,7 @@ final class DisallowStandalonePostIncrementDecrementUnitTest extends AbstractSni
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/Operators/StrictComparisonsUnitTest.php
+++ b/Universal/Tests/Operators/StrictComparisonsUnitTest.php
@@ -25,7 +25,7 @@ final class StrictComparisonsUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -39,7 +39,7 @@ final class StrictComparisonsUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/Operators/TypeSeparatorSpacingUnitTest.php
+++ b/Universal/Tests/Operators/TypeSeparatorSpacingUnitTest.php
@@ -25,7 +25,7 @@ final class TypeSeparatorSpacingUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -44,7 +44,7 @@ final class TypeSeparatorSpacingUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/PHP/OneStatementInShortEchoTagUnitTest.php
+++ b/Universal/Tests/PHP/OneStatementInShortEchoTagUnitTest.php
@@ -27,7 +27,7 @@ final class OneStatementInShortEchoTagUnitTest extends AbstractSniffUnitTest
      *
      * @param string $testFile The name of the file being tested.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList($testFile = '')
     {
@@ -53,7 +53,7 @@ final class OneStatementInShortEchoTagUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/UseStatements/DisallowMixedGroupUseUnitTest.php
+++ b/Universal/Tests/UseStatements/DisallowMixedGroupUseUnitTest.php
@@ -38,7 +38,7 @@ final class DisallowMixedGroupUseUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -58,7 +58,7 @@ final class DisallowMixedGroupUseUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/UseStatements/DisallowUseClassUnitTest.php
+++ b/Universal/Tests/UseStatements/DisallowUseClassUnitTest.php
@@ -30,7 +30,7 @@ final class DisallowUseClassUnitTest extends AbstractSniffUnitTest
      *
      * @param string $testFile The name of the file being tested.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList($testFile = '')
     {
@@ -112,7 +112,7 @@ final class DisallowUseClassUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/UseStatements/DisallowUseConstUnitTest.php
+++ b/Universal/Tests/UseStatements/DisallowUseConstUnitTest.php
@@ -30,7 +30,7 @@ final class DisallowUseConstUnitTest extends AbstractSniffUnitTest
      *
      * @param string $testFile The name of the file being tested.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList($testFile = '')
     {
@@ -108,7 +108,7 @@ final class DisallowUseConstUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/UseStatements/DisallowUseFunctionUnitTest.php
+++ b/Universal/Tests/UseStatements/DisallowUseFunctionUnitTest.php
@@ -30,7 +30,7 @@ final class DisallowUseFunctionUnitTest extends AbstractSniffUnitTest
      *
      * @param string $testFile The name of the file being tested.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList($testFile = '')
     {
@@ -113,7 +113,7 @@ final class DisallowUseFunctionUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/UseStatements/KeywordSpacingUnitTest.php
+++ b/Universal/Tests/UseStatements/KeywordSpacingUnitTest.php
@@ -27,7 +27,7 @@ final class KeywordSpacingUnitTest extends AbstractSniffUnitTest
      *
      * @param string $testFile The name of the file being tested.
      *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList($testFile = '')
     {
@@ -71,7 +71,7 @@ final class KeywordSpacingUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/UseStatements/LowercaseFunctionConstUnitTest.php
+++ b/Universal/Tests/UseStatements/LowercaseFunctionConstUnitTest.php
@@ -25,7 +25,7 @@ final class LowercaseFunctionConstUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -42,7 +42,7 @@ final class LowercaseFunctionConstUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.php
+++ b/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.php
@@ -27,7 +27,7 @@ final class NoLeadingBackslashUnitTest extends AbstractSniffUnitTest
      *
      * @param string $testFile The name of the file being tested.
      *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList($testFile = '')
     {
@@ -53,7 +53,7 @@ final class NoLeadingBackslashUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/UseStatements/NoUselessAliasesUnitTest.php
+++ b/Universal/Tests/UseStatements/NoUselessAliasesUnitTest.php
@@ -25,7 +25,7 @@ final class NoUselessAliasesUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -54,7 +54,7 @@ final class NoUselessAliasesUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of warnings>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/WhiteSpace/AnonClassKeywordSpacingUnitTest.php
+++ b/Universal/Tests/WhiteSpace/AnonClassKeywordSpacingUnitTest.php
@@ -25,7 +25,7 @@ final class AnonClassKeywordSpacingUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -54,7 +54,7 @@ final class AnonClassKeywordSpacingUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.php
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.php
@@ -82,7 +82,7 @@ final class CommaSpacingUnitTest extends AbstractSniffUnitTest
      *
      * @param string $testFile The name of the file being tested.
      *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList($testFile = '')
     {
@@ -227,7 +227,7 @@ final class CommaSpacingUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
+++ b/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
@@ -69,7 +69,7 @@ final class DisallowInlineTabsUnitTest extends AbstractSniffUnitTest
      *
      * @param string $testFile The name of the file being tested.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList($testFile = '')
     {
@@ -155,7 +155,7 @@ final class DisallowInlineTabsUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * @return array <int line number> => <int number of errors>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getWarningList()
     {

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.php
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.php
@@ -68,7 +68,7 @@ final class PrecisionAlignmentUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where errors should occur.
      *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
     public function getErrorList()
     {
@@ -80,7 +80,7 @@ final class PrecisionAlignmentUnitTest extends AbstractSniffUnitTest
      *
      * @param string $testFile The name of the file being tested.
      *
-     * @return array<int, int>
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
      */
     public function getWarningList($testFile = '')
     {


### PR DESCRIPTION
### Docs: improve test @return tags

... and make these docblocks a little more consistent.

### Docs: improve @return tags for register() methods

... and make them more consistent across the sniffs.

### Docs: various @var/@param/@return tag improvements

Definitely not claiming completeness. This is just another iteration step in improving the documented types.