### PR TITLE
Add PHPStan to QA checks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,7 @@
 .remarkrc                export-ignore
 .yamllint.yml            export-ignore
 phpcs.xml.dist           export-ignore
+phpstan.neon.dist        export-ignore
 phpunit.xml.dist         export-ignore
 phpunit-bootstrap.php    export-ignore
 /.github/                export-ignore

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -95,6 +95,33 @@ jobs:
       - name: Check sniff feature completeness
         run: composer check-complete
 
+  phpstan:
+    name: "PHPStan"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: none
+          tools: phpstan
+
+      # Install dependencies and handle caching in one go.
+      # Dependencies need to be installed to make sure the PHPCS and PHPUnit classes are recognized.
+      # @link https://github.com/marketplace/actions/install-composer-dependencies
+      - name: Install Composer dependencies
+        uses: "ramsey/composer-install@v2"
+        with:
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
+
+      - name: Run PHPStan
+        run: phpstan analyse
+
   remark:
     name: 'QA Markdown'
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor/
 /phpcs.xml
 /phpunit.xml
 /.phpunit.result.cache
+phpstan.neon

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,52 @@
+parameters:
+    #phpVersion: 50400 # Needs to be 70100 or higher... sigh...
+    level: 6
+    paths:
+        - Modernize
+        - NormalizedArrays
+        - Universal
+    bootstrapFiles:
+        - phpunit-bootstrap.php
+    treatPhpDocTypesAsCertain: false
+
+    ignoreErrors:
+        # Level 1
+        # Keep to stay in line with parent class.
+        -
+            message: '`^Constructor of class PHPCSExtra\\Universal\\Helpers\\DummyTokenizer has an unused parameter \$content\.$`'
+            path: Universal\Helpers\DummyTokenizer.php
+            count: 1
+
+        # Level 4
+        # PHPStan doesn't seem to like uninitialized properties...
+        -
+            message: '`^Property \S+Sniff::\$(phpVersion|tabWidth) \(int\) in isset\(\) is not nullable\.$`'
+            paths:
+              - Modernize\Sniffs\FunctionCalls\DirnameSniff.php
+              - Universal\Sniffs\Arrays\DuplicateArrayKeySniff.php
+              - Universal\Sniffs\CodeAnalysis\ConstructorDestructorReturnSniff.php
+              - Universal\Sniffs\WhiteSpace\CommaSpacingSniff.php
+              - Universal\Sniffs\WhiteSpace\DisallowInlineTabsSniff.php
+              - Universal\Sniffs\WhiteSpace\PrecisionAlignmentSniff.php
+        -
+            message: '`^Strict comparison using === between true and false will always evaluate to false\.$`'
+            paths:
+              - Modernize\Sniffs\FunctionCalls\DirnameSniff.php
+              - Universal\Sniffs\Arrays\DuplicateArrayKeySniff.php
+              - Universal\Sniffs\CodeAnalysis\ConstructorDestructorReturnSniff.php
+              - Universal\Sniffs\WhiteSpace\CommaSpacingSniff.php
+              - Universal\Sniffs\WhiteSpace\DisallowInlineTabsSniff.php
+              - Universal\Sniffs\WhiteSpace\PrecisionAlignmentSniff.php
+        -
+            message: '`^Property PHPCSExtra\\Universal\\Sniffs\\Arrays\\DuplicateArrayKeySniff\:\:\$currentMaxIntKey[GL]t8 \(int\) in isset\(\) is not nullable\.$`'
+            path: Universal\Sniffs\Arrays\DuplicateArrayKeySniff.php
+            count: 5
+        -
+            message: '`^Result of && is always false\.$`'
+            path: Universal\Sniffs\Arrays\DuplicateArrayKeySniff.php
+            count: 1
+
+        # Level 5
+        # We're not using strict types, so this will be juggled without any issues.
+        - '#^Parameter \#3 \$value of method \S+File::recordMetric\(\) expects string, \(?(float|int|bool)(<[^>]+>)?(\|(float|int|bool)(<[^>]+>)?)*\)? given\.$#'
+        - '#^Parameter \#2 \$content of method \S+Fixer::replaceToken\(\) expects string, \(?(float|int|bool)(<[^>]+>)?(\|(float|int|bool)(<[^>]+>)?)*\)? given\.$#'


### PR DESCRIPTION
PHPStan is a good addition to our QA toolkit and with improvements PHPStan has made over the years is now a viable tool for us to use (previously it would give way too many false positives).

This commit:
* Adds a separate job to the `basics` workflow in GH Actions.
    Notes:
    - I've **not** added PHPStan to the Composer dependencies for two reasons:
        1. It doesn't allow for installation on PHP < 7.2, which would break/block the `composer install` for our test runs.
        2. It would add dependencies which could conflict/cause problems for our test runs due to those defining token constants too.
    - [Phive](https://phar.io/) could potentially be used to still have a setup which can be used locally, but just running locally from a PHPStan PHAR file should work just fine.
    - For CI, PHPStan will be installed as a PHAR file by `setup-php` now.
        This does carry a risk _if_ PHPStan would make breaking changes or if a new release adds rules for the levels being scanned as, in that case, builds could unexpectedly start failing.
        Fixing the version for the `setup-php` action installs to the current release `1.10.32` could prevent that, but that adds an additional maintenance burden of having to keep updating the version as PHPStan releases pretty often.
        So, for now, I've elected to run the risk of random failures. If and when those start happening, this should be re-evaluated.
    - The PHP version for the CI run is set to PHP 7.4 to prevent PHPStan throwing some errors/notices related to the outdated PHPUnit version being used.
* Adds a configuration file for PHPStan.
    Notes:
    - PHPStan needs to know about the dependencies (PHPCS et al), so I'm (re-)using the bootstrap file for the tests to load the PHPCS autoloader and register the standard with the PHPCS autoloader as adding an `autoload` directive to the `composer.json` file would cause problems with the PHPCS autoloader.
    - PHPStan flags type checks on properties with a documented type, while without `strict_types` we cannot always be sure the properties set will be of the correct type. For that reason, I've set `treatPhpDocTypesAsCertain` to `false` (which silences those notices).
    - I've gone through the scan results up to level 6 with a fine toothcomb and fixed what was reasonable to fix and ignored those things which should *not* be fixed.
* Adds the configuration file to `.gitattributes` and the typical overload file for the configuration file to `.gitignore`.

Refs:
* https://phpstan.org/
* https://phpstan.org/config-reference