### PR TITLE
CodeAnalysis/ConstructorDestructorReturn: correctly ignore PHP-4-style constructors in namespaced classes

### DIFF
--- a/Universal/Sniffs/CodeAnalysis/ConstructorDestructorReturnSniff.php
+++ b/Universal/Sniffs/CodeAnalysis/ConstructorDestructorReturnSniff.php
@@ -18,6 +18,7 @@ use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\GetTokensAsString;
+use PHPCSUtils\Utils\Namespaces;
 use PHPCSUtils\Utils\NamingConventions;
 use PHPCSUtils\Utils\ObjectDeclarations;
 use PHPCSUtils\Utils\Scopes;
@@ -102,6 +103,17 @@ final class ConstructorDestructorReturnSniff implements Sniff
 
             if (NamingConventions::isEqual($functionName, $OOName) === false) {
                 // Class and function name not the same, so not a PHP 4-style constructor.
+                return;
+            }
+
+            if (Namespaces::determineNamespace($phpcsFile, $stackPtr) !== '') {
+                /*
+                 * Namespaced methods with the same name as the class are treated as
+                 * regular methods, so we can bow out if we're in a namespace.
+                 *
+                 * Note: the exception to this is PHP 5.3.0-5.3.2. This is currently
+                 * not dealt with.
+                 */
                 return;
             }
 

--- a/Universal/Tests/CodeAnalysis/ConstructorDestructorReturnUnitTest.5.inc
+++ b/Universal/Tests/CodeAnalysis/ConstructorDestructorReturnUnitTest.5.inc
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * The PHP4-style constructors are not constructors in namespaced files.
+ * No errors should be thrown for it, nor any auto-fixes made.
+ */
+namespace Some\Name;
+
+class ReturnsAValue {
+    function returnsAValue(): string
+    {
+        return 'php4style';
+    }
+}


### PR DESCRIPTION
Methods with the same name as a class are not recognized as PHP4-style constructors in namespaced classes.

This was so far not taken into account in this sniff, leading to false positives.

A better solution, with a lower performance impact is expected at a later point in time (namespace tracker), however, as my time is limited, it may still be a while before that solution is available.

In the mean time, let's just fix it.

Includes test.

Related to #207