### PR TITLE
:sparkles: New `Universal.PHP.LowercasePHPTag` sniff

### DIFF
--- a/Universal/Docs/PHP/LowercasePHPTagStandard.xml
+++ b/Universal/Docs/PHP/LowercasePHPTagStandard.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Lowercase PHP Tag"
+    >
+    <standard>
+    <![CDATA[
+    Enforces that the PHP open tag is lowercase.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Lowercase open tag.">
+        <![CDATA[
+<?php
+echo 'hello!';
+        ]]>
+        </code>
+        <code title="Invalid: Uppercase open tag.">
+        <![CDATA[
+<?PHP
+echo 'hello!';
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/PHP/LowercasePHPTagSniff.php
+++ b/Universal/Sniffs/PHP/LowercasePHPTagSniff.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\PHP;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Enforce that the "PHP" in a PHP open tag is lowercase.
+ *
+ * @since 1.2.0
+ */
+final class LowercasePHPTagSniff implements Sniff
+{
+
+    /**
+     * Name of the metric.
+     *
+     * @since 1.2.0
+     *
+     * @var string
+     */
+    const METRIC_NAME = 'PHP open tag case';
+
+    /**
+     * Registers the tokens that this sniff wants to listen for.
+     *
+     * @since 1.2.0
+     *
+     * @return array<int>
+     */
+    public function register()
+    {
+        return [\T_OPEN_TAG];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.2.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens    = $phpcsFile->getTokens();
+        $content   = $tokens[$stackPtr]['content'];
+        $contentLC = \strtolower($content);
+
+        if ($contentLC === $content) {
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'lowercase');
+            return;
+        }
+
+        $errorCode = '';
+        if (\strtoupper($content) === $content) {
+            $errorCode = 'Uppercase';
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'uppercase');
+        } else {
+            $errorCode = 'Mixedcase';
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'mixed case');
+        }
+
+        $fix = $phpcsFile->addFixableError(
+            'The php open tag should be in lowercase. Found: %s',
+            $stackPtr,
+            $errorCode,
+            [\trim($content)]
+        );
+
+        if ($fix === true) {
+            $phpcsFile->fixer->replaceToken($stackPtr, $contentLC);
+        }
+    }
+}

--- a/Universal/Tests/PHP/LowercasePHPTagUnitTest.inc
+++ b/Universal/Tests/PHP/LowercasePHPTagUnitTest.inc
@@ -1,0 +1,8 @@
+<?php
+echo 'The above is fine';
+?>
+<?PHP
+echo 'The above is incorrect';
+?>
+<?PhP echo 'This is incorrect'; ?>
+<?Php echo 'This is incorrect'; ?>

--- a/Universal/Tests/PHP/LowercasePHPTagUnitTest.inc.fixed
+++ b/Universal/Tests/PHP/LowercasePHPTagUnitTest.inc.fixed
@@ -1,0 +1,8 @@
+<?php
+echo 'The above is fine';
+?>
+<?php
+echo 'The above is incorrect';
+?>
+<?php echo 'This is incorrect'; ?>
+<?php echo 'This is incorrect'; ?>

--- a/Universal/Tests/PHP/LowercasePHPTagUnitTest.php
+++ b/Universal/Tests/PHP/LowercasePHPTagUnitTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\PHP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the LowercasePHPTag sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\PHP\LowercasePHPTagSniff
+ *
+ * @since 1.2.0
+ */
+final class LowercasePHPTagUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
+     */
+    public function getErrorList()
+    {
+        return [
+            4 => 1,
+            7 => 1,
+            8 => 1,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
... to enforce that the "PHP" in a PHP open tag is lowercase.

Includes fixer.
Includes unit tests.
Includes documentation.
Includes metrics.