### PR TITLE
Split the errors, adding the *CloserSameLine ones

### DIFF
--- a/NormalizedArrays/Sniffs/Arrays/CommaAfterLastSniff.php
+++ b/NormalizedArrays/Sniffs/Arrays/CommaAfterLastSniff.php
@@ -145,6 +145,13 @@ final class CommaAfterLastSniff implements Sniff
             return;
         }
 
+        // If the closer is on the same line as the last element, change the error code for multi-line arrays.
+        if ($errorCode === 'MultiLine'
+            && $tokens[$lastNonEmpty]['line'] === $tokens[$closer]['line']
+        ) {
+            $errorCode .= 'CloserSameLine';
+        }
+
         $isComma = ($tokens[$lastNonEmpty]['code'] === \T_COMMA);
 
         $phpcsFile->recordMetric(

--- a/NormalizedArrays/Tests/Arrays/CommaAfterLastUnitTest.1.inc
+++ b/NormalizedArrays/Tests/Arrays/CommaAfterLastUnitTest.1.inc
@@ -166,6 +166,56 @@ EOD
 , /*comment*/
 ) );
 
+/**
+ * Tests enforcing a comma after the last array item when the closer is in the same line. See #283.
+ */
+// phpcs:set NormalizedArrays.Arrays.CommaAfterLast multiLine enforce
+
+$missing = array(
+    1, 2,
+    3, 4);
+
+$missing = [
+    '1', '2',
+    '3', '4'];
+
+$missing_but_good = [
+    '1', '2',
+    '3', '4']; // phpcs:ignore NormalizedArrays.Arrays.CommaAfterLast.MissingMultiLineCloserSameLine
+
+$good = array(
+    1, 2,
+    3, 4,);
+
+$good = [
+    '1', '2',
+    '3', '4',];
+
+/**
+ * Tests forbidding a comma after the last array item when the closer is in the same line. See #283.
+ */
+// phpcs:set NormalizedArrays.Arrays.CommaAfterLast multiLine forbid
+
+$found = array(
+    1, 2,
+    3, 4,);
+
+$found = [
+    '1', '2',
+    '3', '4',];
+
+$found_but_good = [
+    '1', '2',
+    '3', '4',]; // phpcs:ignore NormalizedArrays.Arrays.CommaAfterLast.FoundMultiLineCloserSameLine
+
+$good = array(
+    1, 2,
+    3, 4);
+
+$good = [
+    '1', '2',
+    '3', '4'];
+
 // Reset the properties to the defaults.
 // phpcs:set NormalizedArrays.Arrays.CommaAfterLast singleLine forbid
 // phpcs:set NormalizedArrays.Arrays.CommaAfterLast multiLine enforce

--- a/NormalizedArrays/Tests/Arrays/CommaAfterLastUnitTest.1.inc.fixed
+++ b/NormalizedArrays/Tests/Arrays/CommaAfterLastUnitTest.1.inc.fixed
@@ -166,6 +166,56 @@ EOD
  /*comment*/
 ) );
 
+/**
+ * Tests enforcing a comma after the last array item when the closer is in the same line. See #283.
+ */
+// phpcs:set NormalizedArrays.Arrays.CommaAfterLast multiLine enforce
+
+$missing = array(
+    1, 2,
+    3, 4,);
+
+$missing = [
+    '1', '2',
+    '3', '4',];
+
+$missing_but_good = [
+    '1', '2',
+    '3', '4']; // phpcs:ignore NormalizedArrays.Arrays.CommaAfterLast.MissingMultiLineCloserSameLine
+
+$good = array(
+    1, 2,
+    3, 4,);
+
+$good = [
+    '1', '2',
+    '3', '4',];
+
+/**
+ * Tests forbidding a comma after the last array item when the closer is in the same line. See #283.
+ */
+// phpcs:set NormalizedArrays.Arrays.CommaAfterLast multiLine forbid
+
+$found = array(
+    1, 2,
+    3, 4);
+
+$found = [
+    '1', '2',
+    '3', '4'];
+
+$found_but_good = [
+    '1', '2',
+    '3', '4',]; // phpcs:ignore NormalizedArrays.Arrays.CommaAfterLast.FoundMultiLineCloserSameLine
+
+$good = array(
+    1, 2,
+    3, 4);
+
+$good = [
+    '1', '2',
+    '3', '4'];
+
 // Reset the properties to the defaults.
 // phpcs:set NormalizedArrays.Arrays.CommaAfterLast singleLine forbid
 // phpcs:set NormalizedArrays.Arrays.CommaAfterLast multiLine enforce

--- a/NormalizedArrays/Tests/Arrays/CommaAfterLastUnitTest.php
+++ b/NormalizedArrays/Tests/Arrays/CommaAfterLastUnitTest.php
@@ -52,6 +52,10 @@ final class CommaAfterLastUnitTest extends AbstractSniffUnitTest
                     152 => 1,
                     159 => 1,
                     166 => 1,
+                    176 => 1,
+                    180 => 1,
+                    201 => 1,
+                    205 => 1,
                 ];
 
             case 'CommaAfterLastUnitTest.2.inc':


### PR DESCRIPTION
Some standards may want to have different rules when the array closer is in the same line than the last element.

When that happens, the new *CloserSameLine errors are emitted, allowing to disable them via ruleset.

For testing, a couple of cases have been added to CommaAfterLastUnitTest.1.inc and then, the fixtures have been 100% duplicated into CommaAfterLastUnitTest.3.inc that runs with the *CloserSameLine errors disabled.

A simple diff shows the 8 cases in which the outcome is different, as expected.

Fixes #283.