### PR TITLE
Composer.json: add link to security policy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     ],
     "support" : {
         "issues" : "https://github.com/PHPCSStandards/PHPCSExtra/issues",
-        "source" : "https://github.com/PHPCSStandards/PHPCSExtra"
+        "source" : "https://github.com/PHPCSStandards/PHPCSExtra",
+        "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy"
     },
     "require" : {
         "php" : ">=5.4",


### PR DESCRIPTION
This is a new feature available since Composer 2.6.0, which was released a little while ago.

When this key is added, it will also show a link to the security policy on Packagist.

The security policy itself has been added to the organisation `.github` repository and can be accessed via the `security/policy` link on each repo.

Refs:
* https://github.com/composer/composer/releases/tag/2.6.0
* https://github.com/composer/composer/pull/11271
* https://github.com/composer/packagist/pull/1353