### PR TITLE
Switch to PHPCSStandards/PHP_CodeSniffer & raise minimum supported version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -550,7 +550,7 @@ This initial alpha release contains the following sniffs:
     Individual sub-types can be allowed by excluding specific error codes.
 
 [Composer PHPCS plugin]: https://github.com/PHPCSStandards/composer-installer
-[php_version-config]:    https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-php-version
+[php_version-config]:    https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-php-version
 
 [Unreleased]: https://github.com/PHPCSStandards/PHPCSExtra/compare/stable...HEAD
 [1.2.0]: https://github.com/PHPCSStandards/PHPCSExtra/compare/1.1.2...1.2.0

--- a/Modernize/ruleset.xml
+++ b/Modernize/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Modernize" namespace="PHPCSExtra\Modernize" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Modernize" namespace="PHPCSExtra\Modernize" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
     <description>A collection of sniffs to detect code modernization opportunities.</description>
 </ruleset>

--- a/NormalizedArrays/ruleset.xml
+++ b/NormalizedArrays/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="NormalizedArrays" namespace="PHPCSExtra\NormalizedArrays" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="NormalizedArrays" namespace="PHPCSExtra\NormalizedArrays" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
     <description>A ruleset for PHP_CodeSniffer to check arrays for normalized format.</description>
 </ruleset>

--- a/README.md
+++ b/README.md
@@ -566,8 +566,8 @@ This code is released under the [GNU Lesser General Public License (LGPLv3)](LIC
 [gha-qa-results]:        https://github.com/PHPCSStandards/PHPCSExtra/actions/workflows/basics.yml
 [gha-test-results]:      https://github.com/PHPCSStandards/PHPCSExtra/actions/workflows/test.yml
 
-[phpcs-gh]:              https://github.com/squizlabs/PHP_CodeSniffer
+[phpcs-gh]:              https://github.com/PHPCSStandards/PHP_CodeSniffer
 [phpcsutils-gh]:         https://github.com/PHPCSStandards/PHPCSUtils
 [composer-installer-gh]: https://github.com/PHPCSStandards/composer-installer
 
-[php_version-config]:    https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-php-version
+[php_version-config]:    https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-php-version

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Minimum Requirements
 -------------------------------------------
 
 * PHP 5.4 or higher.
-* [PHP_CodeSniffer][phpcs-gh] version **3.7.1** or higher.
-* [PHPCSUtils][phpcsutils-gh] version **1.0.8** or higher.
+* [PHP_CodeSniffer][phpcs-gh] version **3.8.0** or higher.
+* [PHPCSUtils][phpcsutils-gh] version **1.0.9** or higher.
 
 
 Installation

--- a/Universal/ruleset.xml
+++ b/Universal/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Universal" namespace="PHPCSExtra\Universal" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Universal" namespace="PHPCSExtra\Universal" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
     <description>A collection of universal sniffs. This standard is not designed to be used to check code. Include individual sniffs from this standard in a custom ruleset instead.</description>
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     },
     "require" : {
         "php" : ">=5.4",
-        "squizlabs/php_codesniffer" : "^3.7.1",
-        "phpcsstandards/phpcsutils" : "^1.0.8"
+        "squizlabs/php_codesniffer" : "^3.8.0",
+        "phpcsstandards/phpcsutils" : "^1.0.9"
     },
     "require-dev" : {
         "php-parallel-lint/php-parallel-lint": "^1.3.2",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,7 +5,7 @@
     <!--
     #############################################################################
     COMMAND LINE ARGUMENTS
-    https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+    https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
     #############################################################################
     -->
 


### PR DESCRIPTION
⚠️  **_This is a DRAFT PR on purpose as it references releases which have not yet been tagged. Once the PHPCS 3.8.0 tag is available ~~(which contains the Composer `replace` directive)~~, this can/should be merged ~~and released ASAP~~._** ⚠️ 

---

### Switch to PHPCSStandards/PHP_CodeSniffer

The Squizlabs repo has been abandoned. The project continues in a fork in the PHPCSStandards organisation.

Ref:
* squizlabs/PHP_CodeSniffer#3932

### Composer: raise the minimum supported PHPCS + PHPCSUtils versions

PHPCSUtils 1.0.9 has been released and raises the minimum supported PHPCS version to 3.8.0 for improved PHP 8.2 support.

Ref:
* https://github.com/PHPCSStandards/PHPCSUtils/releases/tag/1.0.9
* https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/tag/3.8.0