### PR TITLE
Tests: allow for PHPUnit 8/9

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -42,8 +42,6 @@ jobs:
 
       - name: 'Composer: adjust dependencies'
         run: |
-          # The sniff stage doesn't run the unit tests, so no need for PHPUnit.
-          composer remove --no-update --dev phpunit/phpunit --no-scripts --no-interaction
           # Using PHPCS `master` as an early detection system for bugs upstream.
           composer require --no-update squizlabs/php_codesniffer:"dev-master" --no-interaction
 
@@ -107,7 +105,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: 'latest'
           coverage: none
           tools: phpstan
 

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -61,19 +61,10 @@ jobs:
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
-      - name: Install Composer dependencies - normal
-        if: matrix.php != 'latest'
+      - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
-          custom-cache-suffix: $(date -u "+%Y-%m")
-
-      # For PHP "latest", we need to install with ignore platform reqs as not all PHPUnit 7.x dependencies allow it.
-      - name: Install Composer dependencies - with ignore platform
-        if: matrix.php == 'latest'
-        uses: "ramsey/composer-install@v2"
-        with:
-          composer-options: --ignore-platform-req=php+
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: "Composer: set PHPCS/PHPCSUtils version for tests (lowest)"
@@ -86,10 +77,5 @@ jobs:
         if: matrix.phpcs_version == 'dev-master'
         run: composer lint
 
-      - name: Run the unit tests - PHP 5.4 - 8.0
-        if: matrix.php != 'latest'
+      - name: Run the unit tests
         run: composer test
-
-      - name: Run the unit tests - PHP > 8.1
-        if: matrix.php == 'latest'
-        run: composer test -- --no-configuration --bootstrap=phpunit-bootstrap.php --dont-report-useless-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         # @link https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
-        php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.4']
         phpcs_version: ['lowest', 'dev-master']
 
     name: "Test${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
@@ -67,19 +67,10 @@ jobs:
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
-      - name: Install Composer dependencies - normal
-        if: ${{ startsWith( matrix.php, '8' ) == false }}
+      - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
-          custom-cache-suffix: $(date -u "+%Y-%m")
-
-      # For the PHP 8/"nightly", we need to install with ignore platform reqs as we're still using PHPUnit 7.
-      - name: Install Composer dependencies - with ignore platform
-        if: ${{ startsWith( matrix.php, '8' ) }}
-        uses: "ramsey/composer-install@v2"
-        with:
-          composer-options: --ignore-platform-req=php+
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: "Composer: set PHPCS/PHPCSUtils version for tests (lowest)"
@@ -92,13 +83,8 @@ jobs:
         if: matrix.phpcs_version == 'dev-master'
         run: composer lint
 
-      - name: Run the unit tests - PHP 5.4 - 8.0
-        if: ${{ matrix.php < '8.1' }}
+      - name: Run the unit tests
         run: composer test
-
-      - name: Run the unit tests - PHP > 8.1
-        if: ${{ matrix.php >= '8.1' }}
-        run: composer test -- --no-configuration --bootstrap=phpunit-bootstrap.php --dont-report-useless-tests
 
   #### CODE COVERAGE STAGE ####
   # N.B.: Coverage is only checked on the lowest and highest stable PHP versions
@@ -114,8 +100,7 @@ jobs:
 
     strategy:
       matrix:
-        # 7.4 should be updated to 8.2 when higher PHPUnit versions can be supported.
-        php: ['5.4', '7.4']
+        php: ['5.4', '8.3']
         phpcs_version: ['lowest', 'dev-master']
 
     name: "Coverage${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "php-parallel-lint/php-console-highlighter": "^1.0",
         "phpcsstandards/phpcsdevcs": "^1.1.6",
         "phpcsstandards/phpcsdevtools": "^1.2.1",
-        "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0"
+        "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
PHP_CodeSniffer 3.8.0 now allows for running the tests, which are based on the PHPCS native test suite, with PHPUnit 8 and 9.

This commit updates the package to take advantage of that.

Includes:
* Widening the PHPUnit version requirements.
* Simplifications to the `quicktest` and `test` workflows. Also, the code coverage "high" run can now be run against PHP 8.3.
* Running PHPStan against PHP `latest` (couldn't previously be done due to the old PHPUnit version).

Not included as this was already handled in this repo:
* Adding the PHPUnit cache file to `.gitignore`.
* Adding various PHPUnit config attributes to ensure deprecation notices and such still show on PHPUnit 9.

Ref:
* https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/59