### PR TITLE
UseStatements/KeywordSpacing: add missing "fixed" test file

### DIFF
--- a/Universal/Tests/UseStatements/KeywordSpacingUnitTest.2.inc.fixed
+++ b/Universal/Tests/UseStatements/KeywordSpacingUnitTest.2.inc.fixed
@@ -1,0 +1,11 @@
+<?php
+
+/*
+ * The behaviour of the sniff for this code sample will be different depending on the PHP version.
+ * For PHP < 8.0, it will correctly flag this as "no space" after the `use` keyword.
+ * For PHP 8.0+, this will no longer be flagged as keywords are allowed in namespaced names,
+ * so the `use` is tokenized as `T_STRING` instead of `T_USE` and won't be flagged.
+ *
+ * For this reason, there is no "fixed" file included as the test would not be able to pass on PHP 8.0+.
+ */
+use \Util\MyOtherClass;

--- a/Universal/Tests/UseStatements/KeywordSpacingUnitTest.php
+++ b/Universal/Tests/UseStatements/KeywordSpacingUnitTest.php
@@ -23,6 +23,34 @@ final class KeywordSpacingUnitTest extends AbstractSniffUnitTest
 {
 
     /**
+     * Get a list of all test files to check.
+     *
+     * @param string $testFileBase The base path that the unit tests files will have.
+     *
+     * @return array<string>
+     */
+    protected function getTestFiles($testFileBase)
+    {
+        $testFiles = parent::getTestFiles($testFileBase);
+
+        if (\PHP_VERSION_ID < 80000) {
+            return $testFiles;
+        }
+
+        // The issue being tested in the "2" test case file cannot be flagged/fixed on PHP 8.0+.
+        $target = 'KeywordSpacingUnitTest.2.inc';
+        $length = \strlen($target);
+        foreach ($testFiles as $i => $fileName) {
+            if (\substr($fileName, -$length) === $target) {
+                unset($testFiles[$i]);
+                break;
+            }
+        }
+
+        return $testFiles;
+    }
+
+    /**
      * Returns the lines where errors should occur.
      *
      * @param string $testFile The name of the file being tested.
@@ -55,10 +83,6 @@ final class KeywordSpacingUnitTest extends AbstractSniffUnitTest
                 ];
 
             case 'KeywordSpacingUnitTest.2.inc':
-                if (\PHP_VERSION_ID >= 80000) {
-                    return [];
-                }
-
                 return [
                     11 => 1,
                 ];


### PR DESCRIPTION
The `Universal.UseStatement.KeywordSpacing` sniff has a difference in behaviour between PHP < 8.0 and PHP 8.0+ due to the change in how namespaced name tokens are tokenized in PHP 8.0+.

For that reason, the `KeywordSpacingUnitTest.2.inc` did not have a ".fixed" file as whether or not a fix would be made depends on which PHP version the tests are being run on.

As of PHPCS 3.9.0, PHPCS will throw a PHPUnit warning for missing "fixed" files and as of PHPCS 4.0.0, this will become an error.

With that in mind, this commit adds the missing "fixed" file, but excludes that test from being run on PHP 8.0+ by overloading the `getTestFiles()` method and selectively removing the test case file from the list of files to test.