### PR TITLE
GH Actions: minor tweaks

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -70,8 +70,9 @@ jobs:
       - name: "Composer: set PHPCS/PHPCSUtils version for tests (lowest)"
         if: ${{ matrix.phpcs_version == 'lowest' }}
         run: >
-          composer update squizlabs/php_codesniffer phpcsstandards/phpcsutils
-          --prefer-lowest --ignore-platform-req=php+ --no-scripts --no-interaction
+          composer update --prefer-lowest --no-scripts --no-interaction
+          squizlabs/php_codesniffer
+          phpcsstandards/phpcsutils
 
       - name: Lint against parse errors
         if: matrix.phpcs_version == 'dev-master'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,8 +76,9 @@ jobs:
       - name: "Composer: set PHPCS/PHPCSUtils version for tests (lowest)"
         if: ${{ matrix.phpcs_version == 'lowest' }}
         run: >
-          composer update squizlabs/php_codesniffer phpcsstandards/phpcsutils
-          --prefer-lowest --ignore-platform-req=php+ --no-scripts --no-interaction
+          composer update --prefer-lowest --no-scripts --no-interaction
+          squizlabs/php_codesniffer
+          phpcsstandards/phpcsutils
 
       - name: Lint against parse errors
         if: matrix.phpcs_version == 'dev-master'
@@ -143,8 +144,9 @@ jobs:
       - name: "Composer: set PHPCS/PHPCSUtils version for tests (lowest)"
         if: ${{ matrix.phpcs_version == 'lowest' }}
         run: >
-          composer update squizlabs/php_codesniffer phpcsstandards/phpcsutils
-          --prefer-lowest --ignore-platform-req=php+ --no-scripts --no-interaction
+          composer update --prefer-lowest --no-scripts --no-interaction
+          squizlabs/php_codesniffer
+          phpcsstandards/phpcsutils
 
       - name: Lint against parse errors
         if: matrix.phpcs_version == 'dev-master'


### PR DESCRIPTION
* The `--ignore-platform-req=php+` is no longer needed now PHPUnit 8 and 9 are supported (since PR #299 / PHPCS 3.8.0).
* Minor readability improvement of the script snippet.