### PR TITLE
Documentation: minor consistency fixes

### DIFF
--- a/Modernize/Docs/FunctionCalls/DirnameStandard.xml
+++ b/Modernize/Docs/FunctionCalls/DirnameStandard.xml
@@ -14,7 +14,7 @@
 $path = <em>__DIR__</em>;
         ]]>
         </code>
-        <code title="Invalid: dirname(__FILE__).">
+        <code title="Invalid: Using dirname(__FILE__).">
         <![CDATA[
 $path = <em>dirname(__FILE__)</em>;
         ]]>

--- a/NormalizedArrays/Docs/Arrays/ArrayBraceSpacingStandard.xml
+++ b/NormalizedArrays/Docs/Arrays/ArrayBraceSpacingStandard.xml
@@ -5,7 +5,7 @@
     >
     <standard>
     <![CDATA[
-        There should be no space between the "array" keyword and the array open brace.
+    There should be no space between the "array" keyword and the array open brace.
     ]]>
     </standard>
     <code_comparison>
@@ -22,7 +22,7 @@ $args = array<em>  </em>(1, 2);
     </code_comparison>
     <standard>
     <![CDATA[
-        There should be no space between the array open brace and the array close brace for an empty array.
+    There should be no space between the array open brace and the array close brace for an empty array.
     ]]>
     </standard>
     <code_comparison>
@@ -43,7 +43,7 @@ $args = [<em>  </em>];
     </code_comparison>
     <standard>
     <![CDATA[
-        There should be no space after the array open brace and before the array close brace in a single-line array.
+    There should be no space after the array open brace and before the array close brace in a single-line array.
     ]]>
     </standard>
     <code_comparison>
@@ -64,7 +64,7 @@ $args = [<em>  </em>1, 2<em>  </em>];
     </code_comparison>
     <standard>
     <![CDATA[
-        There should be a new line after the array open brace and before the array close brace in a multi-line array.
+    There should be a new line after the array open brace and before the array close brace in a multi-line array.
     ]]>
     </standard>
     <code_comparison>

--- a/NormalizedArrays/Docs/Arrays/CommaAfterLastStandard.xml
+++ b/NormalizedArrays/Docs/Arrays/CommaAfterLastStandard.xml
@@ -5,25 +5,25 @@
     >
     <standard>
     <![CDATA[
-      For single-line arrays, there should be <em>no</em> comma after the last array item.
+    For single-line arrays, there should be <em>no</em> comma after the last array item.
 
-      However, for multi-line arrays, there <em>should</em> be a comma after the last array item.
+    However, for multi-line arrays, there <em>should</em> be a comma after the last array item.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Single-line array without a comma after the last item">
+        <code title="Valid: Single-line array without a comma after the last item.">
         <![CDATA[
 $args = array(1, 2, 3);
         ]]>
         </code>
-        <code title="Invalid: Single-line array with a comma after the last item">
+        <code title="Invalid: Single-line array with a comma after the last item.">
         <![CDATA[
 $args = array(1, 2, 3<em>,</em> );
         ]]>
         </code>
     </code_comparison>
     <code_comparison>
-        <code title="Valid: Multi-line array with a comma after the last item">
+        <code title="Valid: Multi-line array with a comma after the last item.">
         <![CDATA[
 $args = [
     1 => 'foo',
@@ -31,7 +31,7 @@ $args = [
 ];
         ]]>
         </code>
-        <code title="Invalid: Multi-line array without a comma after the last item">
+        <code title="Invalid: Multi-line array without a comma after the last item.">
         <![CDATA[
 $args = [
     1 => 'foo',

--- a/Universal/Docs/Arrays/DuplicateArrayKeyStandard.xml
+++ b/Universal/Docs/Arrays/DuplicateArrayKeyStandard.xml
@@ -5,8 +5,8 @@
     >
     <standard>
     <![CDATA[
-        When a second array item with the same key is declared, it will overwrite the first.
-        This sniff detects when this is happening in array declarations.
+    When a second array item with the same key is declared, it will overwrite the first.
+    This sniff detects when this is happening in array declarations.
     ]]>
     </standard>
     <code_comparison>

--- a/Universal/Docs/Arrays/MixedArrayKeyTypesStandard.xml
+++ b/Universal/Docs/Arrays/MixedArrayKeyTypesStandard.xml
@@ -5,7 +5,7 @@
     >
     <standard>
     <![CDATA[
-        In an array where the items have keys, all items should either have a numeric key assigned or a string key. A mix of numeric and string keys is not allowed.
+    In an array where the items have keys, all items should either have a numeric key assigned or a string key. A mix of numeric and string keys is not allowed.
     ]]>
     </standard>
     <code_comparison>

--- a/Universal/Docs/Arrays/MixedKeyedUnkeyedArrayStandard.xml
+++ b/Universal/Docs/Arrays/MixedKeyedUnkeyedArrayStandard.xml
@@ -5,7 +5,7 @@
     >
     <standard>
     <![CDATA[
-        All items in an array should either have an explicit key assigned or none. A mix of keyed and unkeyed items is not allowed.
+    All items in an array should either have an explicit key assigned or none. A mix of keyed and unkeyed items is not allowed.
     ]]>
     </standard>
     <code_comparison>

--- a/Universal/Docs/CodeAnalysis/ConstructorDestructorReturnStandard.xml
+++ b/Universal/Docs/CodeAnalysis/ConstructorDestructorReturnStandard.xml
@@ -9,14 +9,14 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: no return type declaration.">
+        <code title="Valid: No return type declaration.">
         <![CDATA[
 class Foo {
     public function __construct() {}
 }
         ]]>
         </code>
-        <code title="Invalid: return type declaration.">
+        <code title="Invalid: Return type declaration.">
         <![CDATA[
 class Foo {
     public function __construct()<em>: int</em> {}
@@ -31,7 +31,7 @@ class Foo {
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: class constructor/destructor doesn't return anything.">
+        <code title="Valid: Class constructor/destructor doesn't return anything.">
         <![CDATA[
 class Foo {
     public function __construct() {
@@ -45,7 +45,7 @@ class Foo {
 }
         ]]>
         </code>
-        <code title="Invalid: class constructor/destructor returns a value.">
+        <code title="Invalid: Class constructor/destructor returns a value.">
         <![CDATA[
 class Foo {
     public function __construct() {

--- a/Universal/Docs/CodeAnalysis/ForeachUniqueAssignmentStandard.xml
+++ b/Universal/Docs/CodeAnalysis/ForeachUniqueAssignmentStandard.xml
@@ -12,12 +12,12 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: using unique variables.">
+        <code title="Valid: Using unique variables.">
         <![CDATA[
 foreach ($array as $k => $v ) {}
         ]]>
         </code>
-        <code title="Invalid: using the same variable for both the key as well as the value.">
+        <code title="Invalid: Using the same variable for both the key as well as the value.">
         <![CDATA[
 foreach ($array as $k => $k ) {}
         ]]>

--- a/Universal/Docs/CodeAnalysis/NoDoubleNegativeStandard.xml
+++ b/Universal/Docs/CodeAnalysis/NoDoubleNegativeStandard.xml
@@ -9,14 +9,14 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: using singular negation or a boolean cast.">
+        <code title="Valid: Using singular negation or a boolean cast.">
         <![CDATA[
 $var = $a && <em>!</em> $b;
 
 if(<em>(bool)</em> callMe($a)) {}
         ]]>
         </code>
-        <code title="Invalid: using double negation (or more).">
+        <code title="Invalid: Using double negation (or more).">
         <![CDATA[
 $var = $a && <em>! !</em> $b;
 

--- a/Universal/Docs/CodeAnalysis/NoEchoSprintfStandard.xml
+++ b/Universal/Docs/CodeAnalysis/NoEchoSprintfStandard.xml
@@ -9,13 +9,13 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: using [v]printf() or echo with anything but [v]sprintf().">
+        <code title="Valid: Using [v]printf() or echo with anything but [v]sprintf().">
         <![CDATA[
 <em>printf</em>('text %s text', $var);
 <em>echo callMe</em>('text %s text', $var);
         ]]>
         </code>
-        <code title="Invalid: using echo [v]sprintf().">
+        <code title="Invalid: Using echo [v]sprintf().">
         <![CDATA[
 <em>echo sprintf</em>('text %s text', $var);
 <em>echo vsprintf</em>('text %s text', [$var]);

--- a/Universal/Docs/Constants/LowercaseClassResolutionKeywordStandard.xml
+++ b/Universal/Docs/Constants/LowercaseClassResolutionKeywordStandard.xml
@@ -9,12 +9,12 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: using lowercase.">
+        <code title="Valid: Using lowercase.">
         <![CDATA[
 echo MyClass::class;
         ]]>
         </code>
-        <code title="Invalid: using uppercase or mixed case.">
+        <code title="Invalid: Using uppercase or mixed case.">
         <![CDATA[
 echo <em>MyClass::CLASS</em>;
         ]]>

--- a/Universal/Docs/Constants/UppercaseMagicConstantsStandard.xml
+++ b/Universal/Docs/Constants/UppercaseMagicConstantsStandard.xml
@@ -9,13 +9,13 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: using uppercase.">
+        <code title="Valid: Using uppercase.">
         <![CDATA[
 echo <em>__LINE__</em>;
 include <em>__DIR__</em> . '/file.php';
         ]]>
         </code>
-        <code title="Invalid: using lowercase or mixed case.">
+        <code title="Invalid: Using lowercase or mixed case.">
         <![CDATA[
 echo <em>__NameSpace__</em>;
 include dirname(<em>__file__</em>) . '/file.php';

--- a/Universal/Docs/ControlStructures/DisallowAlternativeSyntaxStandard.xml
+++ b/Universal/Docs/ControlStructures/DisallowAlternativeSyntaxStandard.xml
@@ -9,7 +9,7 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: using curly brace syntax for control structures.">
+        <code title="Valid: Using curly brace syntax for control structures.">
         <![CDATA[
 if ($foo) <em>{</em>
     $var = 1;
@@ -20,7 +20,7 @@ while (++$i < 10) <em>{</em>
 <em>}</em>
         ]]>
         </code>
-        <code title="Invalid: using the alternative syntax for control structures.">
+        <code title="Invalid: Using the alternative syntax for control structures.">
         <![CDATA[
 if ($foo) <em>:</em>
     $var = 1;

--- a/Universal/Docs/ControlStructures/DisallowLonelyIfStandard.xml
+++ b/Universal/Docs/ControlStructures/DisallowLonelyIfStandard.xml
@@ -11,7 +11,7 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: use of elseif or if followed by another statement.">
+        <code title="Valid: Use of elseif or if followed by another statement.">
         <![CDATA[
 if ($foo) {
     // ...
@@ -32,7 +32,7 @@ if ($foo) {
 
         ]]>
         </code>
-        <code title="Invalid: lonely if in an else block.">
+        <code title="Invalid: Lonely if in an else block.">
         <![CDATA[
 if ($foo) {
     // ...

--- a/Universal/Docs/NamingConventions/NoReservedKeywordParameterNamesStandard.xml
+++ b/Universal/Docs/NamingConventions/NoReservedKeywordParameterNamesStandard.xml
@@ -9,12 +9,12 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: parameter names do not use reserved keywords.">
+        <code title="Valid: Parameter names do not use reserved keywords.">
         <![CDATA[
 function foo( $input, $description ) {}
         ]]>
         </code>
-        <code title="Invalid: parameter names use reserved keywords.">
+        <code title="Invalid: Parameter names use reserved keywords.">
         <![CDATA[
 function foo( $string, $echo = true ) {}
         ]]>

--- a/Universal/Docs/Operators/ConcatPositionStandard.xml
+++ b/Universal/Docs/Operators/ConcatPositionStandard.xml
@@ -13,14 +13,14 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: multi-line concatenation with the concatenation operator at the start of each line.">
+        <code title="Valid: Multi-line concatenation with the concatenation operator at the start of each line.">
         <![CDATA[
 $var = 'text' . $a
     <em>.</em> $b . 'text'
     <em>.</em> $c;
         ]]>
         </code>
-        <code title="Invalid: multi-line concatenation with the concatenation operator not consistently at the start of each line.">
+        <code title="Invalid: Multi-line concatenation with the concatenation operator not consistently at the start of each line.">
         <![CDATA[
 $var = 'text' . $a <em>.</em>
     $b . 'text'

--- a/Universal/Docs/UseStatements/DisallowUseConstStandard.xml
+++ b/Universal/Docs/UseStatements/DisallowUseConstStandard.xml
@@ -15,7 +15,7 @@ use Vendor\Sub\ClassName;
 use function Vendor\Sub\functionName;
         ]]>
         </code>
-        <code title="Invalid: use const import statements.">
+        <code title="Invalid: `use const` import statements.">
         <![CDATA[
 use const Vendor\Sub\CONST;
 use const Vendor\Sub\BAR as otherConst;

--- a/Universal/Docs/UseStatements/DisallowUseFunctionStandard.xml
+++ b/Universal/Docs/UseStatements/DisallowUseFunctionStandard.xml
@@ -15,7 +15,7 @@ use Vendor\Sub\ClassName;
 use const Vendor\Sub\CONST;
         ]]>
         </code>
-        <code title="Invalid: use function import statements.">
+        <code title="Invalid: `use function` import statements.">
         <![CDATA[
 use function Vendor\Sub\functionName;
 use function Vendor\Sub\functionName as other;

--- a/Universal/Docs/WhiteSpace/PrecisionAlignmentStandard.xml
+++ b/Universal/Docs/WhiteSpace/PrecisionAlignmentStandard.xml
@@ -9,7 +9,7 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: indentation equals (a multiple of) the tab width.">
+        <code title="Valid: Indentation equals (a multiple of) the tab width.">
         <![CDATA[
 // Code samples presume tab width = 4.
 <em>[space][space][space][space]</em>$foo = 'bar';
@@ -17,7 +17,7 @@
 <em>[tab]</em>$foo = 'bar';
         ]]>
         </code>
-        <code title="Invalid: precision alignment used, indentation does not equal (a multiple of) the tab width.">
+        <code title="Invalid: Precision alignment used, indentation does not equal (a multiple of) the tab width.">
         <![CDATA[
 // Code samples presume tab width = 4.
 <em>[space][space]</em>$foo = 'bar';


### PR DESCRIPTION
* Double checked that all existing XML docs have the `xsi` attributes and schema reference on the `<documentation>` element.
* Verified that the contents of `<standard>` elements is consistently indented (with four spaces).
* Verified that all `<code>` `title` attributes use proper capitalization and punctuation.