### PR TITLE
GH Actions/Basics: use reusable workflow & fix some URLs

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -101,105 +101,14 @@ jobs:
 
   phpstan:
     name: "PHPStan"
-    runs-on: "ubuntu-latest"
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 'latest'
-          coverage: none
-          tools: phpstan
-
-      # Install dependencies and handle caching in one go.
-      # Dependencies need to be installed to make sure the PHPCS and PHPUnit classes are recognized.
-      # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
-      - name: Install Composer dependencies
-        uses: "ramsey/composer-install@v3"
-        with:
-          # Bust the cache at least once a month - output format: YYYY-MM.
-          custom-cache-suffix: $(date -u "+%Y-%m")
-
-      - name: Run PHPStan
-        run: phpstan analyse
+    uses: PHPCSStandards/.github/.github/workflows/reusable-phpstan.yml@main
 
   remark:
     name: 'QA Markdown'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up node and enable caching of dependencies
-        uses: actions/setup-node@v4
-        with:
-          node-version: '16'
-
-      # To make the command available on CLI, it needs to be installed globally.
-      - name: Install Remark CLI globally
-        run: npm install --global remark-cli --foreground-scripts true --fund false
-
-      # To allow for creating a custom config which references rules which are included
-      # in the presets, without having to install all rules individually, a local install
-      # works best (and installing the presets in the first place, of course).
-      #
-      # Note: the first group of packages are all part of the mono "Remark lint" repo.
-      # The second group of packages (heading-whitespace and down) are additional
-      # "external" rules/plugins.
-      - name: Install Remark rules locally
-        run: >
-          npm install --foreground-scripts true --fund false
-          remark-lint
-          remark-gfm
-          remark-preset-lint-consistent
-          remark-preset-lint-recommended
-          remark-preset-lint-markdown-style-guide
-          remark-lint-checkbox-content-indent
-          remark-lint-linebreak-style
-          remark-lint-no-duplicate-defined-urls
-          remark-lint-no-empty-url
-          remark-lint-no-heading-like-paragraph
-          remark-lint-no-reference-like-url
-          remark-lint-no-unneeded-full-reference-image
-          remark-lint-no-unneeded-full-reference-link
-          remark-lint-strikethrough-marker
-          remark-lint-heading-whitespace
-          remark-lint-list-item-punctuation
-          remark-lint-match-punctuation
-          remark-lint-no-dead-urls
-          remark-lint-no-hr-after-heading
-          remark-lint-are-links-valid-duplicate
-          remark-validate-links
-
-      - name: Run Remark-lint
-        run: remark . --frail
-
-      # @link https://github.com/reviewdog/action-remark-lint
-      - name: Show Remark-lint annotations in PR
-        if: ${{ failure() && github.event_name == 'pull_request' }}
-        uses: reviewdog/action-remark-lint@v5
-        with:
-          fail_on_error: true
-          install_deps: false
-          level: info
-          reporter: github-pr-check
+    uses: PHPCSStandards/.github/.github/workflows/reusable-remark.yml@main
 
   yamllint:
     name: 'Lint Yaml'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      # Ref: https://yamllint.readthedocs.io/en/stable/
-      - name: Run Yamllint on all yaml files in repo
-        run: yamllint . --format colored
-
-      - name: Pipe Yamllint results on to GH for inline display
-        if: ${{ failure() }}
-        run: yamllint . --format github
+    uses: PHPCSStandards/.github/.github/workflows/reusable-yamllint.yml@main
+    with:
+      strict: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-This projects adheres to [Keep a CHANGELOG](http://keepachangelog.com/) and uses [Semantic Versioning](http://semver.org/).
+This projects adheres to [Keep a CHANGELOG](https://keepachangelog.com/en/1.1.0/) and uses [Semantic Versioning](https://semver.org/).
 
 **Legend**:
 :wrench: = Includes auto-fixer.
@@ -401,7 +401,7 @@ The upgrade to PHPCSUtils 1.0.0-alpha4 took care of a number of bugs, which pote
 
 [php-manual-dirname]:           https://www.php.net/function.dirname
 [php-rfc-negative_array_index]: https://wiki.php.net/rfc/negative_array_index
-[ESLint "no lonely if"]:        https://eslint.org/docs/rules/no-lonely-if
+[ESLint "no lonely if"]:        https://eslint.org/docs/latest/rules/no-lonely-if
 [PHPCSUtils 1.0.0-alpha4]:      https://github.com/PHPCSStandards/PHPCSUtils/releases/tag/1.0.0-alpha4
 
 

--- a/README.md
+++ b/README.md
@@ -3,20 +3,20 @@ PHPCSExtra
 
 <div aria-hidden="true">
 
-[![Latest Stable Version](https://poser.pugx.org/phpcsstandards/phpcsextra/v/stable)][phpcsextra-packagist]
+[![Latest Stable Version](https://img.shields.io/packagist/v/phpcsstandards/phpcsextra?label=stable)][phpcsextra-packagist]
 [![Release Date of the Latest Version](https://img.shields.io/github/release-date/PHPCSStandards/PHPCSExtra.svg?maxAge=1800)](https://github.com/PHPCSStandards/PHPCSExtra/releases)
 :construction:
-[![Latest Unstable Version](https://img.shields.io/badge/unstable-dev--develop-e68718.svg?maxAge=2419200)](https://packagist.org/packages/phpcsstandards/phpcsextra#dev-develop)
+[![Latest Unstable Version](https://img.shields.io/badge/unstable-dev--develop-e68718.svg?maxAge=2419200)][phpcsextra-packagist]
 [![Last Commit to Unstable](https://img.shields.io/github/last-commit/PHPCSStandards/PHPCSExtra/develop.svg)](https://github.com/PHPCSStandards/PHPCSExtra/commits/develop)
 
 [![CS Build Status](https://github.com/PHPCSStandards/PHPCSExtra/actions/workflows/basics.yml/badge.svg?branch=develop)][gha-qa-results]
 [![Test Build Status](https://github.com/PHPCSStandards/PHPCSExtra/actions/workflows/test.yml/badge.svg?branch=develop)][gha-test-results]
-[![Coverage Status](https://coveralls.io/repos/github/PHPCSStandards/PHPCSExtra/badge.svg)](https://coveralls.io/github/PHPCSStandards/PHPCSExtra)
+[![Coverage Status](https://img.shields.io/coverallsCoverage/github/PHPCSStandards/PHPCSExtra)](https://coveralls.io/github/PHPCSStandards/PHPCSExtra)
 
-[![Minimum PHP Version](https://img.shields.io/packagist/php-v/phpcsstandards/phpcsextra.svg?maxAge=3600)][phpcsextra-packagist]
+[![Minimum PHP Version](https://img.shields.io/packagist/dependency-v/phpcsstandards/phpcsextra/php.svg)][phpcsextra-packagist]
 [![Tested on PHP 5.4 to 8.3](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4%20|%208.0%20|%208.1%20|%208.2%20|%208.3-brightgreen.svg?maxAge=2419200)][gha-test-results]
 
-[![License: LGPLv3](https://poser.pugx.org/phpcsstandards/phpcsextra/license)](https://github.com/PHPCSStandards/PHPCSExtra/blob/stable/LICENSE)
+[![License: LGPLv3](https://img.shields.io/github/license/PHPCSStandards/PHPCSExtra)](https://github.com/PHPCSStandards/PHPCSExtra/blob/stable/LICENSE)
 ![Awesome](https://img.shields.io/badge/awesome%3F-yes!-brightgreen.svg)
 
 </div>
@@ -55,7 +55,7 @@ Installation
 
 Installing via Composer is highly recommended.
 
-[Composer](http://getcomposer.org/) will automatically install the project dependencies and register the rulesets from PHPCSExtra and other external standards with PHP_CodeSniffer using the [Composer PHPCS plugin][composer-installer-gh].
+[Composer](https://getcomposer.org/) will automatically install the project dependencies and register the rulesets from PHPCSExtra and other external standards with PHP_CodeSniffer using the [Composer PHPCS plugin][composer-installer-gh].
 
 ### Composer Project-based Installation
 


### PR DESCRIPTION
### GH Actions/Basics: use reusable workflow

A number of reusable workflows have been introduced in the `PHPCSStandards/.github` repository for workflows used in multiple repos in this organisation, for which the steps are basically the same everywhere.

This will make maintenance of these workflows more straight-forward.

This commit switches a number of the basic QA workflows over to start using the reusable workflows.

### README/Changelog: fix a few URLs which have changed

Fix a few URLs which were being redirected.

Includes:
* Replacing badges from poser.pugx.org with badges using img.shields.io.