### PR TITLE
Partially revert "README/Changelog: fix a few URLs which have changed"

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -13,8 +13,12 @@
         {
             "skipUrlPatterns": [
                 "https://www.php.net/",
-                "^https?://github\\.com/PHPCSStandards/PHPCSExtra/compare/[0-9\\.]+?\\.{3}[0-9\\.]+"
-            ]
+                "^https?://github\\.com/PHPCSStandards/PHPCSExtra/compare/[0-9\\.]+?\\.{3}[0-9\\.]+",
+                "https://packagist.org/packages/phpcsstandards/phpcsextra#dev-develop"
+            ],
+            "deadOrAliveOptions": {
+                "maxRetries": 3
+            }
         }
     ],
     "remark-lint-no-duplicate-defined-urls",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-This projects adheres to [Keep a CHANGELOG](https://keepachangelog.com/en/1.1.0/) and uses [Semantic Versioning](https://semver.org/).
+This projects adheres to [Keep a CHANGELOG](https://keepachangelog.com/) and uses [Semantic Versioning](https://semver.org/).
 
 **Legend**:
 :wrench: = Includes auto-fixer.

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ PHPCSExtra
 [![Latest Stable Version](https://img.shields.io/packagist/v/phpcsstandards/phpcsextra?label=stable)][phpcsextra-packagist]
 [![Release Date of the Latest Version](https://img.shields.io/github/release-date/PHPCSStandards/PHPCSExtra.svg?maxAge=1800)](https://github.com/PHPCSStandards/PHPCSExtra/releases)
 :construction:
-[![Latest Unstable Version](https://img.shields.io/badge/unstable-dev--develop-e68718.svg?maxAge=2419200)][phpcsextra-packagist]
+[![Latest Unstable Version](https://img.shields.io/badge/unstable-dev--develop-e68718.svg?maxAge=2419200)](https://packagist.org/packages/phpcsstandards/phpcsextra#dev-develop)
 [![Last Commit to Unstable](https://img.shields.io/github/last-commit/PHPCSStandards/PHPCSExtra/develop.svg)](https://github.com/PHPCSStandards/PHPCSExtra/commits/develop)
 
 [![CS Build Status](https://github.com/PHPCSStandards/PHPCSExtra/actions/workflows/basics.yml/badge.svg?branch=develop)][gha-qa-results]
 [![Test Build Status](https://github.com/PHPCSStandards/PHPCSExtra/actions/workflows/test.yml/badge.svg?branch=develop)][gha-test-results]
-[![Coverage Status](https://img.shields.io/coverallsCoverage/github/PHPCSStandards/PHPCSExtra)](https://coveralls.io/github/PHPCSStandards/PHPCSExtra)
+[![Coverage Status](https://coveralls.io/repos/github/PHPCSStandards/PHPCSExtra/badge.svg)](https://coveralls.io/github/PHPCSStandards/PHPCSExtra)
 
 [![Minimum PHP Version](https://img.shields.io/packagist/dependency-v/phpcsstandards/phpcsextra/php.svg)][phpcsextra-packagist]
 [![Tested on PHP 5.4 to 8.3](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4%20|%208.0%20|%208.1%20|%208.2%20|%208.3-brightgreen.svg?maxAge=2419200)][gha-test-results]


### PR DESCRIPTION
This partially reverts commit f0f9421ac8789de07eaa78acc7bb838292ced766 (PR #317) after improvements upstream in the Remark no-dead-urls module.

Ref: remarkjs/remark-lint-no-dead-urls#54