### PR TITLE
Universal/DisallowInlineTabs: minor tweak to the tests

### DIFF
--- a/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
+++ b/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
@@ -76,7 +76,7 @@ final class DisallowInlineTabsUnitTest extends AbstractSniffUnitTest
     {
         // As of PHP 8.3, comments may be tokenized within a "yield from" token, but only for PHPCS < 3.11.0.
         $commentsInYieldFrom = false;
-        if (\PHP_VERSION_ID >= 80300 /*&& \version_compare(Config::VERSION, '3.11.0', '<')*/) {
+        if (\PHP_VERSION_ID >= 80300 && \version_compare(Config::VERSION, '3.11.0', '<')) {
             $commentsInYieldFrom = true;
         }
 


### PR DESCRIPTION
Follow up on #320

The Tokenizer changes related to `yield from` with comments, which were expected to go into PHPCS 3.11.0, have been merged.

This updates the condition used in the tests to reflect the upstream change.