### PR TITLE
Universal/SeparateFunctionsFromOO: simplify skipping the rest of the file

### DIFF
--- a/Universal/Sniffs/Files/SeparateFunctionsFromOOSniff.php
+++ b/Universal/Sniffs/Files/SeparateFunctionsFromOOSniff.php
@@ -81,8 +81,7 @@ final class SeparateFunctionsFromOOSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token
      *                                               in the stack passed in $tokens.
      *
-     * @return int|void Integer stack pointer to skip forward or void to continue
-     *                  normal file processing.
+     * @return int Integer stack pointer to skip forward.
      */
     public function process(File $phpcsFile, $stackPtr)
     {
@@ -185,6 +184,6 @@ final class SeparateFunctionsFromOOSniff implements Sniff
         }
 
         // Ignore the rest of the file.
-        return ($phpcsFile->numTokens + 1);
+        return $phpcsFile->numTokens;
     }
 }


### PR DESCRIPTION
This commit updates the sniff to use `return $phpcsFile->numTokens` instead of `return ($phpcsFile->numTokens + 1)`.

If a sniff file contains 50 tokens, the last `$stackPtr` will be 49, so returning `50` will already get us passed the end of the token stack and the `+ 1` is redundant.

Includes minor fix to the return type as the method never returns `void`.