### PR TITLE
GH Actions: use explicit PHPStan major

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -102,6 +102,8 @@ jobs:
   phpstan:
     name: "PHPStan"
     uses: PHPCSStandards/.github/.github/workflows/reusable-phpstan.yml@main
+    with:
+      phpstanVersion: '1.x'
 
   remark:
     name: 'QA Markdown'


### PR DESCRIPTION
This Monday, [PHPStan 2.0 will be released](https://phpc.social/@OndrejMirtes/113441109253809720).

I've done some preliminary scans with PHPStan 2.0-dev to check if this would have an impact on this codebase and as things are, this would mean the build would start to fail.

For now, I'm proposing to make a small change in the GH Actions workflow to explicitly use PHPStan 1.x.

This buys us some time to evaluate PHPStan 2.0 properly and to make any changes needed to make the codebase compatible with PHPStan 2.x when we're ready for it.

Note:
At least one of the new issues reported has been identified as a bug and reported to PHPStan: https://github.com/phpstan/phpstan/issues/11980