### PR TITLE
PHPStan 2.0: update configuration

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -103,7 +103,7 @@ jobs:
     name: "PHPStan"
     uses: PHPCSStandards/.github/.github/workflows/reusable-phpstan.yml@main
     with:
-      phpstanVersion: '1.x'
+      phpstanVersion: '2.x'
 
   remark:
     name: 'QA Markdown'

--- a/Universal/Sniffs/Operators/ConcatPositionSniff.php
+++ b/Universal/Sniffs/Operators/ConcatPositionSniff.php
@@ -96,8 +96,7 @@ final class ConcatPositionSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token
      *                                               in the stack passed in $tokens.
      *
-     * @return int|void Integer stack pointer to skip forward or void to continue
-     *                  normal file processing.
+     * @return void
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,36 +16,41 @@ parameters:
         # Keep to stay in line with parent class.
         -
             message: '`^Constructor of class PHPCSExtra\\Universal\\Helpers\\DummyTokenizer has an unused parameter \$content\.$`'
-            path: Universal\Helpers\DummyTokenizer.php
+            path: Universal/Helpers/DummyTokenizer.php
             count: 1
 
         # Level 4
         # PHPStan doesn't seem to like uninitialized properties...
+        # Ref: https://github.com/phpstan/phpstan/issues/10305
         -
             message: '`^Property \S+Sniff::\$(phpVersion|tabWidth) \(int\) in isset\(\) is not nullable\.$`'
             paths:
-                - Modernize\Sniffs\FunctionCalls\DirnameSniff.php
-                - Universal\Sniffs\Arrays\DuplicateArrayKeySniff.php
-                - Universal\Sniffs\CodeAnalysis\ConstructorDestructorReturnSniff.php
-                - Universal\Sniffs\WhiteSpace\CommaSpacingSniff.php
-                - Universal\Sniffs\WhiteSpace\DisallowInlineTabsSniff.php
-                - Universal\Sniffs\WhiteSpace\PrecisionAlignmentSniff.php
+                - Modernize/Sniffs/FunctionCalls/DirnameSniff.php
+                - Universal/Sniffs/Arrays/DuplicateArrayKeySniff.php
+                - Universal/Sniffs/CodeAnalysis/ConstructorDestructorReturnSniff.php
+                - Universal/Sniffs/WhiteSpace/CommaSpacingSniff.php
+                - Universal/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
+                - Universal/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
         -
             message: '`^Strict comparison using === between true and false will always evaluate to false\.$`'
             paths:
-                - Modernize\Sniffs\FunctionCalls\DirnameSniff.php
-                - Universal\Sniffs\Arrays\DuplicateArrayKeySniff.php
-                - Universal\Sniffs\CodeAnalysis\ConstructorDestructorReturnSniff.php
-                - Universal\Sniffs\WhiteSpace\CommaSpacingSniff.php
-                - Universal\Sniffs\WhiteSpace\DisallowInlineTabsSniff.php
-                - Universal\Sniffs\WhiteSpace\PrecisionAlignmentSniff.php
+                - Modernize/Sniffs/FunctionCalls/DirnameSniff.php
+                - Universal/Sniffs/Arrays/DuplicateArrayKeySniff.php
+                - Universal/Sniffs/CodeAnalysis/ConstructorDestructorReturnSniff.php
+                - Universal/Sniffs/WhiteSpace/CommaSpacingSniff.php
+                - Universal/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
+                - Universal/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
         -
             message: '`^Property PHPCSExtra\\Universal\\Sniffs\\Arrays\\DuplicateArrayKeySniff\:\:\$currentMaxIntKey[GL]t8 \(int\) in isset\(\) is not nullable\.$`'
-            path: Universal\Sniffs\Arrays\DuplicateArrayKeySniff.php
+            path: Universal/Sniffs/Arrays/DuplicateArrayKeySniff.php
             count: 5
         -
+            message: '`^Strict comparison using === between true and true will always evaluate to true\.$`'
+            path: Universal/Sniffs/Arrays/DuplicateArrayKeySniff.php
+            count: 1
+        -
             message: '`^Result of && is always false\.$`'
-            path: Universal\Sniffs\Arrays\DuplicateArrayKeySniff.php
+            path: Universal/Sniffs/Arrays/DuplicateArrayKeySniff.php
             count: 1
 
         # Level 5


### PR DESCRIPTION
PHPStan 2.0 has been released :tada:

This commit makes the necessary updates to switch to PHPStan 2.0.

Includes normalizing slashes in path references in the PHPStan config file.

Refs:
* https://phpstan.org/blog/phpstan-2-0-released-level-10-elephpants
* https://github.com/phpstan/phpstan/blob/2.0.x/UPGRADING.md
* https://github.com/phpstan/phpstan/releases/tag/2.0.0