### PR TITLE
:sparkles: New Universal.PHP.NoFQNTrueFalseNull sniff

### DIFF
--- a/Universal/Docs/PHP/NoFQNTrueFalseNullStandard.xml
+++ b/Universal/Docs/PHP/NoFQNTrueFalseNullStandard.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="No FQN True False or Null"
+    >
+    <standard>
+    <![CDATA[
+    Forbids using `true`, `false` and `null` as fully qualified constants.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Using true/false/null without namespace separator prefix.">
+        <![CDATA[
+$a = <em>null</em>;
+
+if ($something === <em>false</em>) {}
+        ]]>
+        </code>
+        <code title="Invalid: Using true/false/null as fully qualified constants.">
+        <![CDATA[
+$a = <em>\</em>null;
+
+if ($something === <em>\</em>false) {}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/PHP/NoFQNTrueFalseNullSniff.php
+++ b/Universal/Sniffs/PHP/NoFQNTrueFalseNullSniff.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\PHP;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Forbids the use of `true`/`false`/`null` as fully qualified constants.
+ *
+ * @since 1.3.0
+ */
+final class NoFQNTrueFalseNullSniff implements Sniff
+{
+
+    /**
+     * Registers the tokens that this sniff wants to listen for.
+     *
+     * @since 1.3.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [
+            // PHP < 8.0.
+            \T_TRUE,
+            \T_FALSE,
+            \T_NULL,
+
+            // PHP >= 8.0.
+            \T_STRING,
+        ];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.3.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens    = $phpcsFile->getTokens();
+        $content   = $tokens[$stackPtr]['content'];
+        $contentLC = \strtolower($content);
+
+        if ($contentLC !== 'true' && $contentLC !== 'false' && $contentLC !== 'null') {
+            return;
+        }
+
+        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        if ($tokens[$prev]['code'] !== \T_NS_SEPARATOR) {
+            return;
+        }
+
+        $prevPrev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prev - 1), null, true);
+        if ($tokens[$prevPrev]['code'] === \T_STRING || $tokens[$prevPrev]['code'] === \T_NAMESPACE) {
+            return;
+        }
+
+        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($tokens[$next]['code'] === \T_NS_SEPARATOR) {
+            return;
+        }
+
+        $fix = $phpcsFile->addFixableError(
+            'The special PHP constant "%s" should not be fully qualified.',
+            $prev,
+            'Found',
+            [$contentLC]
+        );
+
+        if ($fix === true) {
+            $phpcsFile->fixer->replaceToken($prev, '');
+        }
+    }
+}

--- a/Universal/Tests/PHP/NoFQNTrueFalseNullUnitTest.inc
+++ b/Universal/Tests/PHP/NoFQNTrueFalseNullUnitTest.inc
@@ -1,0 +1,27 @@
+<?php
+
+$thisIsFine = true;
+$thisIsFine = False;
+$thisIsFine = NULL;
+
+// Namespaced names should be left alone.
+$fullyQualified = \Fully\True\Qualified;
+$nsRelative = namespace\Null;
+$partiallyQualified = False\Something\Something;
+
+/* These should all be flagged */
+$notOkay = \true;
+$notOkay = \false;
+$notOkay = \   null;
+
+$notOkay = \TRUE;
+$notOkay = \/*comment*/False;
+$notOkay = \nULl;
+
+class UseInTypes {
+    const MyClass|\TRUE CONSTANT_NAME = new MyClass;
+
+    public readonly \False|float|\null $property;
+
+    public function foo(string|\false $name) : \NULL|int {}
+}

--- a/Universal/Tests/PHP/NoFQNTrueFalseNullUnitTest.inc.fixed
+++ b/Universal/Tests/PHP/NoFQNTrueFalseNullUnitTest.inc.fixed
@@ -1,0 +1,27 @@
+<?php
+
+$thisIsFine = true;
+$thisIsFine = False;
+$thisIsFine = NULL;
+
+// Namespaced names should be left alone.
+$fullyQualified = \Fully\True\Qualified;
+$nsRelative = namespace\Null;
+$partiallyQualified = False\Something\Something;
+
+/* These should all be flagged */
+$notOkay = true;
+$notOkay = false;
+$notOkay =    null;
+
+$notOkay = TRUE;
+$notOkay = /*comment*/False;
+$notOkay = nULl;
+
+class UseInTypes {
+    const MyClass|TRUE CONSTANT_NAME = new MyClass;
+
+    public readonly False|float|null $property;
+
+    public function foo(string|false $name) : NULL|int {}
+}

--- a/Universal/Tests/PHP/NoFQNTrueFalseNullUnitTest.php
+++ b/Universal/Tests/PHP/NoFQNTrueFalseNullUnitTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\PHP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the NoFQNTrueFalseNull sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\PHP\NoFQNTrueFalseNullSniff
+ *
+ * @since 1.3.0
+ */
+final class NoFQNTrueFalseNullUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
+     */
+    public function getErrorList()
+    {
+        return [
+            13 => 1,
+            14 => 1,
+            15 => 1,
+            17 => 1,
+            18 => 1,
+            19 => 1,
+            22 => 1,
+            24 => 2,
+            26 => 2,
+        ];
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
... to forbid using `true`, `false` and `null` as fully qualified constants.

Includes fixer.
Includes unit tests.
Includes documentation.

_Note: yes, there is a related tokenizer issue in PHPCS where these tokens are not tokenized the same PHP cross-version, however, the tokenization will change in PHPCS 4.0 as well, so there isn't much point addressing that now as it would just make things even more complicated for sniffs come PHPCS 4.0._

_And yes, this does mean that this sniff will need adjusting for PHPCS 4.0._