### PR TITLE
Universal/TypeSeparatorSpacing: add support for PHP 8.2 DNF types

### DIFF
--- a/Universal/Docs/Operators/TypeSeparatorSpacingStandard.xml
+++ b/Universal/Docs/Operators/TypeSeparatorSpacingStandard.xml
@@ -5,25 +5,31 @@
     >
     <standard>
     <![CDATA[
-    There should be no spacing around the union type separator or the intersection type separator.
+    Enforce spacing rules around the union, intersection and DNF type operators.
+    - No space on either side of a union or intersection type operator.
+    - No space on the inside of DNF type parenthesis or before/after if the previous/next "thing" is part of the type.
+    - One space before a DNF open parenthesis when it is at the start of a type.
+    - One space after a DNF close parenthesis when it is at the end of a type.
 
-    This applies to all locations where type declarations can be used, i.e. property types, parameter types and return types.
+    This applies to all locations where type declarations can be used, i.e. property types, constant types, parameter types and return types.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: No space around the separators.">
+        <code title="Valid: Correct spacing around the separators.">
         <![CDATA[
 function foo(
     int<em>|</em>string $paramA,
-    TypeA<em>&</em>TypeB $paramB
+    TypeA<em>&</em>TypeB $paramB,
+    <em>(</em>TypeA&TypeB<em>)</em>|null $paramC
 ): int<em>|</em>false {}
         ]]>
         </code>
-        <code title="Invalid: Space around the separators.">
+        <code title="Invalid: Incorrect spacing around the separators.">
         <![CDATA[
 function foo(
     int<em> | </em>string $paramA,
-    TypeA<em> & </em>TypeB $paramB
+    TypeA<em> & </em>TypeB $paramB,
+    <em>( </em>TypeA&TypeB<em> ) </em>|null $paramC
 ): int<em>
    |
    </em>false {}

--- a/Universal/Sniffs/Operators/TypeSeparatorSpacingSniff.php
+++ b/Universal/Sniffs/Operators/TypeSeparatorSpacingSniff.php
@@ -14,14 +14,30 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Fixers\SpacesFixer;
+use PHPCSUtils\Tokens\Collections;
 
 /**
- * Enforce no space around union type and intersection type separators.
+ * Enforce spacing rules around union, intersection and DNF type separators.
  *
  * @since 1.0.0
+ * @since 1.3.0 Support for DNF types.
  */
 final class TypeSeparatorSpacingSniff implements Sniff
 {
+
+    /**
+     * Tokens this sniff targets.
+     *
+     * @since 1.3.0
+     *
+     * @var array<int|string, int|string>
+     */
+    private $targetTokens = [
+        \T_TYPE_UNION             => \T_TYPE_UNION,
+        \T_TYPE_INTERSECTION      => \T_TYPE_INTERSECTION,
+        \T_TYPE_OPEN_PARENTHESIS  => \T_TYPE_OPEN_PARENTHESIS,
+        \T_TYPE_CLOSE_PARENTHESIS => \T_TYPE_CLOSE_PARENTHESIS,
+    ];
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -32,10 +48,7 @@ final class TypeSeparatorSpacingSniff implements Sniff
      */
     public function register()
     {
-        return [
-            \T_TYPE_UNION,
-            \T_TYPE_INTERSECTION,
-        ];
+        return $this->targetTokens;
     }
 
     /**
@@ -53,28 +66,78 @@ final class TypeSeparatorSpacingSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $type = ($tokens[$stackPtr]['code'] === \T_TYPE_UNION) ? 'union' : 'intersection';
-        $code = \ucfirst($type) . 'Type';
+        $type = 'union';
+        $code = 'UnionType';
+        if ($tokens[$stackPtr]['code'] === \T_TYPE_INTERSECTION) {
+            $type = 'intersection';
+            $code = 'IntersectionType';
+        } elseif ($tokens[$stackPtr]['code'] === \T_TYPE_OPEN_PARENTHESIS) {
+            $type = 'DNF parenthesis open';
+            $code = 'DNFOpen';
+        } elseif ($tokens[$stackPtr]['code'] === \T_TYPE_CLOSE_PARENTHESIS) {
+            $type = 'DNF parenthesis close';
+            $code = 'DNFClose';
+        }
 
-        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
-        SpacesFixer::checkAndFix(
-            $phpcsFile,
-            $stackPtr,
-            $prevNonEmpty,
-            0, // Expected spaces.
-            'Expected %s before the ' . $type . ' type separator. Found: %s',
-            $code . 'SpacesBefore',
-            'error',
-            0, // Severity.
-            'Space before ' . $type . ' type separator'
-        );
+        $expectedSpaces = 0;
+        $prevNonEmpty   = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        if ($tokens[$stackPtr]['code'] === \T_TYPE_OPEN_PARENTHESIS) {
+            if ($tokens[$prevNonEmpty]['code'] === \T_COLON
+                || $tokens[$prevNonEmpty]['code'] === \T_CONST
+                || isset(Collections::propertyModifierKeywords()[$tokens[$prevNonEmpty]['code']]) === true
+            ) {
+                // Start of return type or property/const type. Always demand 1 space.
+                $expectedSpaces = 1;
+            }
 
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            if ($tokens[$prevNonEmpty]['code'] === \T_OPEN_PARENTHESIS
+                || $tokens[$prevNonEmpty]['code'] === \T_COMMA
+            ) {
+                // Start of parameter type. Allow new line/indent before.
+                if ($tokens[$prevNonEmpty]['line'] === $tokens[$stackPtr]['line']) {
+                    $expectedSpaces = 1;
+                } else {
+                    $expectedSpaces = 'skip';
+                }
+            }
+        }
+
+        if (isset($this->targetTokens[$tokens[$prevNonEmpty]['code']]) === true) {
+            // Prevent duplicate errors when there are two adjacent operators.
+            $expectedSpaces = 'skip';
+        }
+
+        if ($expectedSpaces !== 'skip') {
+            SpacesFixer::checkAndFix(
+                $phpcsFile,
+                $stackPtr,
+                $prevNonEmpty,
+                $expectedSpaces,
+                'Expected %s before the ' . $type . ' type separator. Found: %s',
+                $code . 'SpacesBefore',
+                'error',
+                0, // Severity.
+                'Space before ' . $type . ' type separator'
+            );
+        }
+
+        $expectedSpaces = 0;
+        $nextNonEmpty   = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($tokens[$stackPtr]['code'] === \T_TYPE_CLOSE_PARENTHESIS) {
+            if ($tokens[$nextNonEmpty]['code'] === \T_OPEN_CURLY_BRACKET
+                || $tokens[$nextNonEmpty]['code'] === \T_VARIABLE
+                || $tokens[$nextNonEmpty]['code'] === \T_STRING
+            ) {
+                // End of return type, parameter or property/const type. Always demand 1 space.
+                $expectedSpaces = 1;
+            }
+        }
+
         SpacesFixer::checkAndFix(
             $phpcsFile,
             $stackPtr,
             $nextNonEmpty,
-            0, // Expected spaces.
+            $expectedSpaces,
             'Expected %s after the ' . $type . ' type separator. Found: %s',
             $code . 'SpacesAfter',
             'error',

--- a/Universal/Tests/Operators/TypeSeparatorSpacingUnitTest.inc
+++ b/Universal/Tests/Operators/TypeSeparatorSpacingUnitTest.inc
@@ -36,6 +36,38 @@ $closure = function (TypeA      |       TypeB $p, TypeA  &namespace\TypeB $q): \
 
 $arrow = fn (TypeA | TypeB $p, TypeA &  namespace\TypeB $q): string  |  int => $p * $q;
 
+/*
+ * PHP 8.2 DNF types.
+ */
+class DNFTypes {
+    private const (A&B)|false DNF_CORRECT_START = false;
+    protected const false|(A&B) DNF_CORRECT_END = false;
+    public const   ( A&B ) |false DNF_INCORRECT_START = false;
+    final const false|   ( A&B )  DNF_INCORRECT_END = false;
+
+    private (A&B)|false $dnfCorrectStart = false;
+    readonly false|(A&B) $dnfCorrectEnd = false;
+    static   ( A&B ) |false $dnfIncorrectStart = false;
+    final false|   ( A&B )  $dnfIncorrectEnd = false;
+
+    public function DNFCorrect(
+        (A&B)|false $paramA, (A&B)|false $paramB,
+        null|(\FQN&\Partially\Qualified) $paramC,
+    ): (A&B)|(C&D) {
+    }
+
+    public function DNFIncorrect(
+        (  A&B  )  |  false $paramA,  (A&B) |false $paramB,
+        null| ( \FQN&\Partially\Qualified )
+           $paramC,
+    ):   ( A &B )
+         |
+         ( C&D  )   {
+    }
+
+    public function DNFIncorrectReturnTypeNoSpace():(A&B)|(C&D){}
+}
+
 // Live coding.
 // This test should be the last test in the file.
 function foo(int|

--- a/Universal/Tests/Operators/TypeSeparatorSpacingUnitTest.inc.fixed
+++ b/Universal/Tests/Operators/TypeSeparatorSpacingUnitTest.inc.fixed
@@ -32,6 +32,35 @@ $closure = function (TypeA|TypeB $p, TypeA&namespace\TypeB $q): \Fully\Qualified
 
 $arrow = fn (TypeA|TypeB $p, TypeA&namespace\TypeB $q): string|int => $p * $q;
 
+/*
+ * PHP 8.2 DNF types.
+ */
+class DNFTypes {
+    private const (A&B)|false DNF_CORRECT_START = false;
+    protected const false|(A&B) DNF_CORRECT_END = false;
+    public const (A&B)|false DNF_INCORRECT_START = false;
+    final const false|(A&B) DNF_INCORRECT_END = false;
+
+    private (A&B)|false $dnfCorrectStart = false;
+    readonly false|(A&B) $dnfCorrectEnd = false;
+    static (A&B)|false $dnfIncorrectStart = false;
+    final false|(A&B) $dnfIncorrectEnd = false;
+
+    public function DNFCorrect(
+        (A&B)|false $paramA, (A&B)|false $paramB,
+        null|(\FQN&\Partially\Qualified) $paramC,
+    ): (A&B)|(C&D) {
+    }
+
+    public function DNFIncorrect(
+        (A&B)|false $paramA, (A&B)|false $paramB,
+        null|(\FQN&\Partially\Qualified) $paramC,
+    ): (A&B)|(C&D) {
+    }
+
+    public function DNFIncorrectReturnTypeNoSpace(): (A&B)|(C&D) {}
+}
+
 // Live coding.
 // This test should be the last test in the file.
 function foo(int|

--- a/Universal/Tests/Operators/TypeSeparatorSpacingUnitTest.php
+++ b/Universal/Tests/Operators/TypeSeparatorSpacingUnitTest.php
@@ -38,6 +38,16 @@ final class TypeSeparatorSpacingUnitTest extends AbstractSniffUnitTest
             33 => 1,
             35 => 5,
             37 => 6,
+            45 => 4,
+            46 => 4,
+            50 => 4,
+            51 => 4,
+            60 => 6,
+            61 => 4,
+            63 => 5,
+            64 => 1,
+            65 => 3,
+            68 => 2,
         ];
     }
 


### PR DESCRIPTION
PHP 8.2 introduced DNF types, which use parenthesis.

This commit adds support to the `Universal.Operators.TypeSeparatorSpacing` sniff to also check the spacing around the parenthesis for DNF types.

Notes:
* Allows for a new line before the start of a type for function parameters.
* Expects one space before the type operator if the type starts with a DNF open parenthesis.
* Expects one space after the type operator if the type ends on a DNF close parenthesis.
* Includes protection against throwing two errors for the same issue, like when a DNF close parenthesis if followed by a union type operator and there is whitespace between these.

Includes tests.
Includes updated documentation.