### PR TITLE
Composer: raise the minimum supported PHPCS version to 3.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Minimum Requirements
 -------------------------------------------
 
 * PHP 5.4 or higher.
-* [PHP_CodeSniffer][phpcs-gh] version **3.8.0** or higher.
+* [PHP_CodeSniffer][phpcs-gh] version **3.12.1** or higher.
 * [PHPCSUtils][phpcsutils-gh] version **1.0.9** or higher.
 
 

--- a/Universal/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
+++ b/Universal/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
@@ -150,16 +150,6 @@ final class DisallowInlineTabsSniff implements Sniff
                 }
             }
 
-            /*
-             * For "yield from", we should only handle tabs _between_ the keywords (single token),
-             * not indentation for those situations where the keyword is split in multiple tokens.
-             */
-            if ($tokens[$i]['code'] === \T_YIELD_FROM
-                && \preg_match('`^yield.+from$`i', $tokens[$i]['content']) !== 1
-            ) {
-                continue;
-            }
-
             $fix = $phpcsFile->addFixableError(
                 'Spaces must be used for mid-line alignment; tabs are not allowed',
                 $i,

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require" : {
         "php" : ">=5.4",
-        "squizlabs/php_codesniffer" : "^3.8.0",
+        "squizlabs/php_codesniffer" : "^3.12.1",
         "phpcsstandards/phpcsutils" : "^1.0.9"
     },
     "require-dev" : {


### PR DESCRIPTION
... which is the latest release containing tokenizer changes.

Includes removing some code which has become redundant after upstream PR PHPCSStandards/PHP_CodeSniffer#647 was merged (included in 3.11.0).