### PR TITLE
GH Actions: add new check for consistency in markdown files 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,7 @@
 ---
 name: "\U0001F41B Bug report for sniffs"
 about: I got unexpected behavior and think it is a bug.
+title: ''
 
 ---
 
@@ -73,4 +74,5 @@ You should be able to get the version numbers using the `composer info` command.
 
 
 ## Tested Against `develop` branch?
+
 - [ ] I have verified the issue still exists in the `develop` branch of PHPCSExtra.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,8 @@
 ---
 name: "\U0001F680 Feature request"
 about: I have a suggestion (and may want to implement it).
+title: ''
+
 ---
 
 ## Is your feature request related to a problem?

--- a/.github/release-checklist.md
+++ b/.github/release-checklist.md
@@ -24,5 +24,6 @@ PR for tracking changes for the x.x.x release. Target release date: **DOW MONTH 
 - [ ] Fast-forward `develop` to be equal to `stable`
 
 ### Publicize
+
 - [ ] Toot about the release.
 - [ ] Tweet about the release.

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -136,6 +136,10 @@ jobs:
     with:
       phpstanVersion: '2.x'
 
+  markdownlint:
+    name: 'Lint Markdown'
+    uses: PHPCSStandards/.github/.github/workflows/reusable-markdownlint.yml@main
+
   remark:
     name: 'QA Markdown'
     uses: PHPCSStandards/.github/.github/workflows/reusable-remark.yml@main

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+node_modules/
 vendor/
 /composer.lock
 /.phpcs.xml

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,114 @@
+#
+# Configuration file for MarkdownLint-CLI2.
+#
+# Example file with all options:
+# https://github.com/DavidAnson/markdownlint-cli2/blob/main/test/markdownlint-cli2-yaml-example/.markdownlint-cli2.yaml
+#
+
+# Do not fix any fixable errors.
+fix: false
+
+# Define glob expressions to use (only valid at root).
+globs:
+  - "**/*.md"
+  - ".github/**/*.md"
+
+# Show found files on stdout (only valid at root)
+showFound: true
+
+# Define glob expressions to ignore.
+ignores:
+  - "node_modules/"
+  - "vendor/"
+
+# Disable inline config comments.
+noInlineConfig: true
+
+# Disable progress on stdout (only valid at root).
+noProgress: false
+
+# Adjust the configuration for some built-in rules.
+# For full information on the options and defaults, see:
+# https://github.com/DavidAnson/markdownlint/blob/main/schema/.markdownlint.yaml
+config:
+  ######################
+  # Disable a few rules.
+  ######################
+  # MD031/blanks-around-fences - Fenced code blocks should be surrounded by blank lines.
+  MD031: false
+  # MD032/blanks-around-lists - Lists should be surrounded by blank lines.
+  MD032: false
+
+  ##############################
+  # Customize a few other rules.
+  ##############################
+  # MD003/heading-style/header-style - Heading style.
+  MD003:
+    # Heading style - Always use hashes.
+    style: "atx"
+
+  # MD004/ul-style - Unordered list style.
+  MD004:
+    # List style - each level has a different, but consistent symbol.
+    style: "sublist"
+
+  # MD007/ul-indent - Unordered list indentation.
+  MD007:
+    indent: 4
+    # Whether to indent the first level of the list.
+    start_indented: false
+
+  # MD012/no-multiple-blanks - Multiple consecutive blank lines.
+  MD012:
+    maximum: 2
+
+  # MD013/line-length - Line length.
+  MD013:
+    # Number of characters. No need for being too fussy.
+    line_length: 1000
+    # Number of characters for headings.
+    heading_line_length: 100
+    # Number of characters for code blocks.
+    code_block_line_length: 100
+    # Stern length checking (applies to tables, code blocks etc which have their own max line length).
+    stern: true
+
+  # MD024/no-duplicate-heading/no-duplicate-header - Multiple headings with the same content.
+  MD024:
+    # Only check sibling headings.
+    siblings_only: true
+
+  # MD033/no-inline-html - Inline HTML.
+  MD033:
+    # Allowed elements.
+    allowed_elements:
+      - div
+      - details
+      - summary
+      - b
+      - code
+      - ul
+      - li
+
+  # MD044/proper-names - Proper names should have the correct capitalization.
+  MD044:
+    # List of proper names.
+    names: ["PHPCSUtils", "PHP", "PHP_CodeSniffer", "CodeSniffer", "PHPUnit"]
+    # Include code blocks.
+    code_blocks: false
+
+  # MD046/code-block-style - Code block style
+  MD046:
+    style: "fenced"
+
+  # MD048/code-fence-style - Code fence style
+  MD048:
+    style: "backtick"
+
+  # MD049/emphasis-style - Emphasis style should be consistent
+  MD049:
+    style: "underscore"
+
+  # MD050/strong-style - Strong style should be consistent
+  MD050:
+    style: "asterisk"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -315,13 +315,14 @@ For the full list of features, please see the changelogs of the alpha/rc release
     - When using this sniff with tab-based standards, please ensure that the `tab-width` is set and either don't set the `$indent` property or set it to the tab-width (or a multiple thereof).
     - The fixer works based on "best guess" and may not always result in the desired indentation. Combine this sniff with the `Generic.WhiteSpace.ScopeIndent` sniff for more precise indentation fixes.
     - The behaviour of the sniff is customizable via the following properties:
-        - `indent`: the indent used for the codebase.
-        - `ignoreAlignmentBefore`: allows for providing a list of token names for which (preceding) precision alignment should be ignored.
-        - `ignoreBlankLines`: whether or not potential trailing whitespace on otherwise blank lines should be examined or ignored.
+        + `indent`: the indent used for the codebase.
+        + `ignoreAlignmentBefore`: allows for providing a list of token names for which (preceding) precision alignment should be ignored.
+        + `ignoreBlankLines`: whether or not potential trailing whitespace on otherwise blank lines should be examined or ignored.
 
 ### Changed
 
 #### Universal
+
 * `Universal.Arrays.DisallowShortArraySyntax`: the sniff will now record metrics about long vs short array usage. [#154]
 * `Universal.Arrays.DuplicateArrayKey`: where relevant, the sniff will now make a distinction between keys which will be duplicate in all PHP version and (numeric) keys which will only be a duplicate key in [PHP < 8.0 or PHP >= 8.0][php-rfc-negative_array_index]. [#177], [#178]
     If a [`php_version` configuration option][php_version-config] has been passed to PHPCS, it will be respected by the sniff and only report duplicate keys for the configured PHP version.
@@ -335,6 +336,7 @@ For the full list of features, please see the changelogs of the alpha/rc release
 * `Universal.UseStatements.NoLeadingBackslash`: the sniff will now also flag and auto-fix leading backslashes in group use statements. [#167]
 
 #### Other
+
 * Updated the sniffs for compatibility with PHPCSUtils 1.0.0-alpha4. [#134]
 * Updated the sniffs to correctly handle PHP 8.0/8.1/8.2 features whenever relevant.
 * Readme: Updated installation instructions for compatibility with Composer 2.2+. [#101]
@@ -349,11 +351,13 @@ For the full list of features, please see the changelogs of the alpha/rc release
 The upgrade to PHPCSUtils 1.0.0-alpha4 took care of a number of bugs, which potentially could have affected sniffs in this package.
 
 #### NormalizedArrays
+
 * `NormalizedArrays.Arrays.ArrayBraceSpacing`: the sniff now allows for trailing comments after the array opener in multi-line arrays. [#118]
 * `NormalizedArrays.Arrays.ArrayBraceSpacing`: trailing comments at the end of an array, but before the closer, in multi-line arrays will no longer confuse the sniff. [#135]
 * `NormalizedArrays.Arrays.CommaAfterLast`: the fixer will now recognize PHP 7.3+ flexible heredoc/nowdocs and in that case, will add the comma on the same line as the heredoc/nowdoc closer. [#144]
 
 #### Universal
+
 * `Universal.Arrays.DisallowShortArraySyntax`: nested short arrays in short lists will now be detected and fixed correctly. [#153]
 * `Universal.ControlStructures.DisallowAlternativeSyntax`: the sniff will no longer bow out indiscriminately when the `allowWithInlineHTML` property is set to `true`. [#90], [#161]
 * `Universal.ControlStructures.DisallowAlternativeSyntax`: when alternative control structure syntax is allowed in combination with inline HTML (`allowWithInlineHTML` property set to `true`), inline HTML in functions declared within the control structure body will no longer be taken into account for determining whether or not the control structure contains inline HTML. [#160]
@@ -452,19 +456,19 @@ The upgrade to PHPCSUtils 1.0.0-alpha4 took care of a number of bugs, which pote
 * :wrench: :bar_chart: :books: New `Universal.Operators.StrictComparisons` sniff to enforce the use of strict comparisons. [#48]
     Warning: the auto-fixer for this sniff _may_ cause bugs in applications and should be used with care! This is considered a _risky_ fixer.
 * :wrench: :bar_chart: :books: New `Universal.OOStructures.AlphabeticExtendsImplements` sniff to verify that the names used in a class "implements" statement or an interface "extends" statement are listed in alphabetic order. [#55]
-    * This sniff contains a public `orderby` property to determine the sort order to use for the statement.
+    - This sniff contains a public `orderby` property to determine the sort order to use for the statement.
         If all names used are unqualified, the sort order won't make a difference.
         However, if one or more of the names are partially or fully qualified, the chosen sort order will determine how the sorting between unqualified, partially and fully qualified names is handled.
         The sniff supports two sort order options:
-        - _'name'_ : sort by the interface name only (default);
-        - _'full'_ : sort by the full name as used in the statement (without leading backslash).
+        + _'name'_ : sort by the interface name only (default);
+        + _'full'_ : sort by the full name as used in the statement (without leading backslash).
         In both cases, the sorting will be done using natural sort, case-insensitive.
-    * The sniff has modular error codes to allow for selective inclusion/exclusion:
-        - `ImplementsWrongOrder` - for "class implements" statements.
-        - `ImplementsWrongOrderWithComments` - for "class implements" statements interlaced with comments. These will not be auto-fixed.
-        - `ExtendsWrongOrder` - for "interface extends" statements.
-        - `ExtendsWrongOrderWithComments` - for "interface extends" statements interlaced with comments. These will not be auto-fixed.
-    * When fixing, the existing spacing between the names in an `implements`/`extends` statement will not be maintained.
+    - The sniff has modular error codes to allow for selective inclusion/exclusion:
+        + `ImplementsWrongOrder` - for "class implements" statements.
+        + `ImplementsWrongOrderWithComments` - for "class implements" statements interlaced with comments. These will not be auto-fixed.
+        + `ExtendsWrongOrder` - for "interface extends" statements.
+        + `ExtendsWrongOrderWithComments` - for "interface extends" statements interlaced with comments. These will not be auto-fixed.
+    - When fixing, the existing spacing between the names in an `implements`/`extends` statement will not be maintained.
         The fixer will separate each name with a comma and one space.
         If alternative formatting is desired, a sniff which will check and fix the formatting should be added to the ruleset.
 * :wrench: :bar_chart: :books: New `Universal.UseStatements.LowercaseFunctionConst` sniff to enforce that `function` and `const` keywords when used in an import `use` statement are always lowercase. [#58]
@@ -476,6 +480,7 @@ The upgrade to PHPCSUtils 1.0.0-alpha4 took care of a number of bugs, which pote
 ### Changed
 
 #### Other
+
 * The `master` branch has been renamed to `stable`.
 * Composer: The version requirements for the [Composer PHPCS plugin] have been widened to allow for version 0.7.0 which supports Composer 2.0.0. [#62]
 * Various housekeeping.
@@ -501,17 +506,20 @@ The upgrade to PHPCSUtils 1.0.0-alpha4 took care of a number of bugs, which pote
 ### Added
 
 #### Universal
+
 * :wrench: :bar_chart: :books: New `Universal.ControlStructures.DisallowAlternativeSyntax` sniff to disallow using the alternative syntax for control structures. [#23]
     - This sniff contains a `allowWithInlineHTML` property to allow alternative syntax when inline HTML is used within the control structure. In all other cases, the use of the alternative syntax will still be disallowed.
     - The sniff has modular error codes to allow for making exceptions based on specific control structures and/or specific control structures in combination with inline HTML.
 * :bar_chart: `Universal.UseStatements.DisallowUseClass/Function/Const`: new, additional metrics about the import source will be shown in the `info` report. [#25]
 
 #### Other
+
 * Readme: installation instructions and sniff list. [#26]
 
 ### Changed
 
 #### Universal
+
 * `Universal.Arrays.DuplicateArrayKey`: wording of the error message. [#18]
 * `Universal.UseStatements.DisallowUseClass/Function/Const`: the error codes have been made more modular. [#25]
     Each of these sniffs now has four additional error codes:
@@ -522,12 +530,14 @@ The upgrade to PHPCSUtils 1.0.0-alpha4 took care of a number of bugs, which pote
     In all other circumstances, the existing error codes <code>FoundWithAlias</code> and <code>FoundWithoutAlias</code> will continue to be used.
 
 #### Other
+
 * Improved formatting of the CLI documentation which can be viewed using `--generator=text`. [#17]
 * Various housekeeping.
 
 ### Fixed
 
 #### Universal
+
 * `Universal.Arrays.DuplicateArrayKey`: improved handling of parse errors. [#34]
 * `Universal.ControlStructures.IfElseDeclaration`: the fixer will now respect tab indentation. [#19]
 * `Universal.UseStatements.DisallowUseClass/Function/Const`: the determination of whether a import is aliased in now done in a case-insensitive manner. [#25]
@@ -555,6 +565,7 @@ Initial alpha release containing:
 This initial alpha release contains the following sniffs:
 
 ### NormalizedArrays
+
 * :wrench: :bar_chart: :books: `NormalizedArrays.Arrays.ArrayBraceSpacing`: enforce consistent spacing for the open/close braces of array declarations.
     The sniff allows for having different settings for:
     - Space between the array keyword and the open parenthesis for long arrays via the `keywordSpacing` property.
@@ -576,6 +587,7 @@ This initial alpha release contains the following sniffs:
     The valid values are: <code>enforce</code>, <code>forbid</code> or <code>skip</code> to not check the comma after the last array item for a particular type of array.
 
 ### Universal
+
 * :books: `Universal.Arrays.DuplicateArrayKey`: detects duplicate array keys in array declarations.
 * :books: `Universal.Arrays.MixedArrayKeyTypes`: best practice sniff: don't use a mix of integer and numeric keys for array items.
 * :books: `Universal.Arrays.MixedKeyedUnkeyedArray`: best practice sniff: don't use a mix of keyed and unkeyed array items.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-PHPCSExtra
-=====================================================
+# PHPCSExtra
 
 <div aria-hidden="true">
 
@@ -24,34 +23,31 @@ PHPCSExtra
 * [Introduction](#introduction)
 * [Minimum Requirements](#minimum-requirements)
 * [Installation](#installation)
-    + [Composer Project-based Installation](#composer-project-based-installation)
-    + [Composer Global Installation](#composer-global-installation)
-    + [Updating to a newer version](#updating-to-a-newer-version)
+    - [Composer Project-based Installation](#composer-project-based-installation)
+    - [Composer Global Installation](#composer-global-installation)
+    - [Updating to a newer version](#updating-to-a-newer-version)
 * [Features](#features)
 * [Sniffs](#sniffs)
-    + [Modernize](#modernize)
-    + [NormalizedArrays](#normalizedarrays)
-    + [Universal](#universal)
+    - [Modernize](#modernize)
+    - [NormalizedArrays](#normalizedarrays)
+    - [Universal](#universal)
 * [Contributing](#contributing)
 * [License](#license)
 
 
-Introduction
--------------------------------------------
+## Introduction
 
 PHPCSExtra is a collection of sniffs and standards for use with [PHP_CodeSniffer][phpcs-gh].
 
 
-Minimum Requirements
--------------------------------------------
+## Minimum Requirements
 
 * PHP 5.4 or higher.
 * [PHP_CodeSniffer][phpcs-gh] version **3.12.1** or higher.
 * [PHPCSUtils][phpcsutils-gh] version **1.0.9** or higher.
 
 
-Installation
--------------------------------------------
+## Installation
 
 Installing via Composer is highly recommended.
 
@@ -93,8 +89,7 @@ composer global update phpcsstandards/phpcsextra --with-dependencies
 > (and potential other external PHPCS standards you use), manage the version requirements for these packages.
 
 
-Features
--------------------------------------------
+## Features
 
 Once this project is installed, you will see three new rulesets in the list of installed standards when you run `vendor/bin/phpcs -i`: `Modernize`, `NormalizedArrays` and `Universal`.
 
@@ -105,8 +100,7 @@ Once this project is installed, you will see three new rulesets in the list of i
     Instead include individual sniffs from this standard in a custom project/company ruleset to use them.
 
 
-Sniffs
--------------------------------------------
+## Sniffs
 
 **Legend**:
 * :wrench: = Includes auto-fixer.
@@ -138,13 +132,13 @@ In effect, this means that the sniff will only report on modernizations which ca
 Enforce consistent spacing for the open/close braces of array declarations.
 
 The sniff allows for having different settings for:
-- Space between the array keyword and the open parenthesis for long arrays via the `keywordSpacing` property.
+* Space between the array keyword and the open parenthesis for long arrays via the `keywordSpacing` property.
     Accepted values: (int) number of spaces or `false` to turn this check off. Defaults to `0` spaces.
-- Spaces on the inside of the braces for empty arrays via the `spacesWhenEmpty` property.
+* Spaces on the inside of the braces for empty arrays via the `spacesWhenEmpty` property.
     Accepted values: (string) `newline`, (int) number of spaces or `false` to turn this check off. Defaults to `0` spaces.
-- Spaces on the inside of the braces for single-line arrays via the `spacesSingleLine` property;
+* Spaces on the inside of the braces for single-line arrays via the `spacesSingleLine` property;
     Accepted values: (int) number of spaces or `false` to turn this check off. Defaults to `0` spaces.
-- Spaces on the inside of the braces for multi-line arrays via the `spacesMultiLine` property.
+* Spaces on the inside of the braces for multi-line arrays via the `spacesMultiLine` property.
     Accepted values: (string) `newline`, (int) number of spaces or `false` to turn this check off. Defaults to `newline`.
 
 Note: if any of the above properties are set to `newline`, it is recommended to also include an array indentation sniff. This sniff will not handle the indentation.
@@ -539,7 +533,7 @@ The behaviour of the sniff is customizable via the following properties:
     If this property is not set, the sniff will look to the `--tab-width` CLI value.
     If that also isn't set, the default tab-width of `4` will be used.
 * `ignoreAlignmentBefore`: allows for providing a list of token names for which (preceding) precision alignment should be ignored.
-    Accepted values: (array<string>) token constant names. Defaults to an empty array.
+    Accepted values: (`array<string>`) token constant names. Defaults to an empty array.
     Usage example:
     ```xml
     <rule ref="Universal.WhiteSpace.PrecisionAlignment">
@@ -559,14 +553,15 @@ The behaviour of the sniff is customizable via the following properties:
     Accepted values: (bool)`true`|`false`. Defaults to `true`.
 
 
-Contributing
--------
+## Contributing
+
 Contributions to this project are welcome. Clone the repo, branch off from `develop`, make your changes, commit them and send in a pull request.
 
 If unsure whether the changes you are proposing would be welcome, open an issue first to discuss your proposal.
 
-License
--------
+
+## License
+
 This code is released under the [GNU Lesser General Public License (LGPLv3)](LICENSE).
 
 


### PR DESCRIPTION
### GH Actions: add new check for consistency in markdown files 

This new check uses the NPM MarkdownLint package via the NPM MarkdownLint-CLI2 package.

It executes a loose check for consistency and some common errors.
Some of the more annoying rules/rules which could impact display of markdown files on GitHub have been disabled.

All necessary configuration is contained in the `.markdownlint-cli2.yaml` file.

To run locally, install via:
```bash
npm install -g markdownlint-cli2
```
... and then run via:
```bash
markdownlint-cli2
```

Includes a problem matcher which _should_ allow for displaying the results inline in GitHub PR code review view.

Includes adding `node_modules` to the `.gitignore` in case anyone would install these tools locally (to prevent them committing them).

Refs:
* https://github.com/DavidAnson/markdownlint
* https://github.com/DavidAnson/markdownlint-cli2

### Docs: various tweaks 

... to comply with the rules enforced via Markdownlint.