### PR TITLE
Rulesets: update schema URL

### DIFF
--- a/Modernize/ruleset.xml
+++ b/Modernize/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Modernize" namespace="PHPCSExtra\Modernize" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Modernize" namespace="PHPCSExtra\Modernize" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
 
     <description>A collection of sniffs to detect code modernization opportunities.</description>
 </ruleset>

--- a/NormalizedArrays/ruleset.xml
+++ b/NormalizedArrays/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="NormalizedArrays" namespace="PHPCSExtra\NormalizedArrays" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="NormalizedArrays" namespace="PHPCSExtra\NormalizedArrays" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
 
     <description>A ruleset for PHP_CodeSniffer to check arrays for normalized format.</description>
 </ruleset>

--- a/Universal/ruleset.xml
+++ b/Universal/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Universal" namespace="PHPCSExtra\Universal" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Universal" namespace="PHPCSExtra\Universal" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
 
     <description>A collection of universal sniffs. This standard is not designed to be used to check code. Include individual sniffs from this standard in a custom ruleset instead.</description>
 </ruleset>


### PR DESCRIPTION
PHPCS now offers permalinks for the schema.

Refs:
* PHPCSStandards/PHP_CodeSniffer#1094
* https://github.com/PHPCSStandards/schema.phpcodesniffer.com