### PR TITLE
Composer: raise the minimum supported PHPCSUtils version to 1.0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ PHPCSExtra is a collection of sniffs and standards for use with [PHP_CodeSniffer
 
 * PHP 5.4 or higher.
 * [PHP_CodeSniffer][phpcs-gh] version **3.12.1** or higher.
-* [PHPCSUtils][phpcsutils-gh] version **1.0.9** or higher.
+* [PHPCSUtils][phpcsutils-gh] version **1.0.12** or higher.
 
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require" : {
         "php" : ">=5.4",
         "squizlabs/php_codesniffer" : "^3.12.1",
-        "phpcsstandards/phpcsutils" : "^1.0.9"
+        "phpcsstandards/phpcsutils" : "^1.0.12"
     },
     "require-dev" : {
         "php-parallel-lint/php-parallel-lint": "^1.4.0",


### PR DESCRIPTION
... to benefit from a particular bug fix related to import use statements and other improved functionality.

Ref: https://github.com/PHPCSStandards/PHPCSUtils/releases/tag/1.0.12