### PR TITLE
Universal/NoUselessAliases: make variable name more descriptive

### DIFF
--- a/Universal/Sniffs/UseStatements/NoUselessAliasesSniff.php
+++ b/Universal/Sniffs/UseStatements/NoUselessAliasesSniff.php
@@ -92,8 +92,8 @@ final class NoUselessAliasesSniff implements Sniff
 
         // Now check the names in each use statement for useless aliases.
         foreach ($useStatements as $type => $statements) {
-            foreach ($statements as $alias => $fqName) {
-                $unqualifiedName = \ltrim(\substr($fqName, \strrpos($fqName, '\\')), '\\');
+            foreach ($statements as $alias => $qualifiedName) {
+                $unqualifiedName = \ltrim(\substr($qualifiedName, (int) \strrpos($qualifiedName, '\\')), '\\');
 
                 $uselessAlias = false;
                 if ($type === 'const') {
@@ -125,7 +125,7 @@ final class NoUselessAliasesSniff implements Sniff
 
                     $error = 'Useless alias "%s" found for import of "%s"';
                     $code  = 'Found';
-                    $data  = [$alias, $fqName];
+                    $data  = [$alias, $qualifiedName];
 
                     // Okay, so this is the one which should be flagged.
                     $hasComments = $phpcsFile->findNext(Tokens::$commentTokens, ($prev + 1), $aliasPtr);


### PR DESCRIPTION
As of PHPCSUtils 1.0.12, the values in the return array from the `UseStatements::splitImportUseStatement()` method will now never include a leading backslash.

This commit improves the variable name used when walking the return value to make it abundantly clear that the "full name" in the return value from the method, is what PHP calls a "qualified name", i.e. without leading backslash.

Ref: PHPCSStandards/PHPCSUtils#590