### PR TITLE
Universal/DisallowUse* sniffs: minor simplifications + more descriptive variable name

### DIFF
--- a/Universal/Sniffs/UseStatements/DisallowUseClassSniff.php
+++ b/Universal/Sniffs/UseStatements/DisallowUseClassSniff.php
@@ -127,7 +127,7 @@ final class DisallowUseClassSniff implements Sniff
 
         $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($stackPtr + 1));
 
-        foreach ($statements['name'] as $alias => $fullName) {
+        foreach ($statements['name'] as $alias => $qualifiedName) {
             $reportPtr = $stackPtr;
             do {
                 $reportPtr = $phpcsFile->findNext(\T_STRING, ($reportPtr + 1), $endOfStatement, false, $alias);
@@ -163,20 +163,19 @@ final class DisallowUseClassSniff implements Sniff
             $errorCode = 'Found';
             $data      = [
                 '',
-                $fullName,
+                $qualifiedName,
             ];
 
             $globalNamespace = false;
             $sameNamespace   = false;
-            if (\strpos($fullName, '\\', 1) === false) {
+            if (\strpos($qualifiedName, '\\') === false) {
                 $globalNamespace = true;
                 $errorCode       = 'FromGlobalNamespace';
                 $data[0]         = ' from the global namespace';
 
                 $phpcsFile->recordMetric($reportPtr, self::METRIC_NAME_SRC, 'global namespace');
             } elseif ($this->currentNamespace !== ''
-                && (\stripos($fullName, $this->currentNamespace . '\\') === 0
-                    || \stripos($fullName, '\\' . $this->currentNamespace . '\\') === 0)
+                && \stripos($qualifiedName, $this->currentNamespace . '\\') === 0
             ) {
                 $sameNamespace = true;
                 $errorCode     = 'FromSameNamespace';
@@ -188,7 +187,7 @@ final class DisallowUseClassSniff implements Sniff
             }
 
             $hasAlias = false;
-            $lastLeaf = \strtolower(\substr($fullName, -(\strlen($alias) + 1)));
+            $lastLeaf = \strtolower(\substr($qualifiedName, -(\strlen($alias) + 1)));
             $aliasLC  = \strtolower($alias);
             if ($lastLeaf !== $aliasLC && $lastLeaf !== '\\' . $aliasLC) {
                 $hasAlias   = true;

--- a/Universal/Sniffs/UseStatements/DisallowUseConstSniff.php
+++ b/Universal/Sniffs/UseStatements/DisallowUseConstSniff.php
@@ -127,7 +127,7 @@ final class DisallowUseConstSniff implements Sniff
 
         $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($stackPtr + 1));
 
-        foreach ($statements['const'] as $alias => $fullName) {
+        foreach ($statements['const'] as $alias => $qualifiedName) {
             $reportPtr = $stackPtr;
             do {
                 $reportPtr = $phpcsFile->findNext(\T_STRING, ($reportPtr + 1), $endOfStatement, false, $alias);
@@ -163,20 +163,19 @@ final class DisallowUseConstSniff implements Sniff
             $errorCode = 'Found';
             $data      = [
                 '',
-                $fullName,
+                $qualifiedName,
             ];
 
             $globalNamespace = false;
             $sameNamespace   = false;
-            if (\strpos($fullName, '\\', 1) === false) {
+            if (\strpos($qualifiedName, '\\') === false) {
                 $globalNamespace = true;
                 $errorCode       = 'FromGlobalNamespace';
                 $data[0]         = ' from the global namespace';
 
                 $phpcsFile->recordMetric($reportPtr, self::METRIC_NAME_SRC, 'global namespace');
             } elseif ($this->currentNamespace !== ''
-                && (\stripos($fullName, $this->currentNamespace . '\\') === 0
-                    || \stripos($fullName, '\\' . $this->currentNamespace . '\\') === 0)
+                && \stripos($qualifiedName, $this->currentNamespace . '\\') === 0
             ) {
                 $sameNamespace = true;
                 $errorCode     = 'FromSameNamespace';
@@ -188,7 +187,7 @@ final class DisallowUseConstSniff implements Sniff
             }
 
             $hasAlias = false;
-            $lastLeaf = \strtolower(\substr($fullName, -(\strlen($alias) + 1)));
+            $lastLeaf = \strtolower(\substr($qualifiedName, -(\strlen($alias) + 1)));
             $aliasLC  = \strtolower($alias);
             if ($lastLeaf !== $aliasLC && $lastLeaf !== '\\' . $aliasLC) {
                 $hasAlias   = true;

--- a/Universal/Sniffs/UseStatements/DisallowUseFunctionSniff.php
+++ b/Universal/Sniffs/UseStatements/DisallowUseFunctionSniff.php
@@ -127,7 +127,7 @@ final class DisallowUseFunctionSniff implements Sniff
 
         $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($stackPtr + 1));
 
-        foreach ($statements['function'] as $alias => $fullName) {
+        foreach ($statements['function'] as $alias => $qualifiedName) {
             $reportPtr = $stackPtr;
             do {
                 $reportPtr = $phpcsFile->findNext(\T_STRING, ($reportPtr + 1), $endOfStatement, false, $alias);
@@ -163,20 +163,19 @@ final class DisallowUseFunctionSniff implements Sniff
             $errorCode = 'Found';
             $data      = [
                 '',
-                $fullName,
+                $qualifiedName,
             ];
 
             $globalNamespace = false;
             $sameNamespace   = false;
-            if (\strpos($fullName, '\\', 1) === false) {
+            if (\strpos($qualifiedName, '\\') === false) {
                 $globalNamespace = true;
                 $errorCode       = 'FromGlobalNamespace';
                 $data[0]         = ' from the global namespace';
 
                 $phpcsFile->recordMetric($reportPtr, self::METRIC_NAME_SRC, 'global namespace');
             } elseif ($this->currentNamespace !== ''
-                && (\stripos($fullName, $this->currentNamespace . '\\') === 0
-                    || \stripos($fullName, '\\' . $this->currentNamespace . '\\') === 0)
+                && \stripos($qualifiedName, $this->currentNamespace . '\\') === 0
             ) {
                 $sameNamespace = true;
                 $errorCode     = 'FromSameNamespace';
@@ -188,7 +187,7 @@ final class DisallowUseFunctionSniff implements Sniff
             }
 
             $hasAlias = false;
-            $lastLeaf = \strtolower(\substr($fullName, -(\strlen($alias) + 1)));
+            $lastLeaf = \strtolower(\substr($qualifiedName, -(\strlen($alias) + 1)));
             $aliasLC  = \strtolower($alias);
             if ($lastLeaf !== $aliasLC && $lastLeaf !== '\\' . $aliasLC) {
                 $hasAlias   = true;


### PR DESCRIPTION
As of PHPCSUtils 1.0.12, the values in the return array from the `UseStatements::splitImportUseStatement()` method will now never include a leading backslash.

This commit accounts for that by:
1. Removing work-arounds/tolerance for a potential leading backslash in the return values in various places.
2. Improving the variable name used when walking the return value to make it abundantly clear that the "full name" in the return value from the method, is what PHP calls a "qualified name", i.e. without leading backslash.

Ref: PHPCSStandards/PHPCSUtils#590