### PR TITLE
Universal/DisallowMixedGroupUse: bug fix for group names with leading backslash

### DIFF
--- a/Universal/Tests/UseStatements/DisallowMixedGroupUseUnitTest.inc
+++ b/Universal/Tests/UseStatements/DisallowMixedGroupUseUnitTest.inc
@@ -116,6 +116,19 @@ use One\OfEach\{
     const Constants\CONSTANT_NAME as SOME_CONSTANT,
 };
 
+use \LeadingBackslash\OnPrefix\{
+    function SubLevel\functionName,
+    const Constants\CONSTANT_NAME as SOME_CONSTANT,
+    const ANOTHER_NAME,
+};
+
+// Intentional parse error: leading backslash on partial statements within the group is a parse error in all PHP versions.
+// The sniff does not correct for this (not its job), so the fixed version will also contain this parse error.
+use LeadingBackslash\WithinGroup\{
+    function \SubLevel\functionName,
+    function \SubLevel\anotherFunction,
+    const \Constants\CONSTANT_NAME as SOME_CONSTANT,
+};
 
 // Intentional parse error.
 // This has to be the last test in the file.

--- a/Universal/Tests/UseStatements/DisallowMixedGroupUseUnitTest.inc.fixed
+++ b/Universal/Tests/UseStatements/DisallowMixedGroupUseUnitTest.inc.fixed
@@ -128,6 +128,19 @@ use One\OfEach\ClassName;
 use function One\OfEach\SubLevel\functionName;
 use const One\OfEach\Constants\CONSTANT_NAME as SOME_CONSTANT;
 
+use function LeadingBackslash\OnPrefix\SubLevel\functionName;
+use const LeadingBackslash\OnPrefix\{
+    Constants\CONSTANT_NAME as SOME_CONSTANT,
+    ANOTHER_NAME
+};
+
+// Intentional parse error: leading backslash on partial statements within the group is a parse error in all PHP versions.
+// The sniff does not correct for this (not its job), so the fixed version will also contain this parse error.
+use function LeadingBackslash\WithinGroup\{
+    \SubLevel\functionName,
+    \SubLevel\anotherFunction
+};
+use const LeadingBackslash\WithinGroup\\Constants\CONSTANT_NAME as SOME_CONSTANT;
 
 // Intentional parse error.
 // This has to be the last test in the file.

--- a/Universal/Tests/UseStatements/DisallowMixedGroupUseUnitTest.php
+++ b/Universal/Tests/UseStatements/DisallowMixedGroupUseUnitTest.php
@@ -52,6 +52,8 @@ final class DisallowMixedGroupUseUnitTest extends AbstractSniffUnitTest
             100 => 1,
             107 => 1,
             113 => 1,
+            119 => 1,
+            127 => 1,
         ];
     }
 


### PR DESCRIPTION
As of PHPCSUtils 1.0.12, the return value from `UseStatements::splitImportUseStatement()` will never include leading backslashes for use statements.

A knock-on effect of this, is that if the original group name ("prefix") contained a leading backslash, the fixer in the `DisallowMixedGroupUse` sniff would no longer correctly strip the "prefix" if a new group statement was created when the fixer was run.

I.e. the first of the new tests would previously incorrectly be fixed to:
```php
use function LeadingBackslash\OnPrefix\SubLevel\functionName;
use const LeadingBackslash\OnPrefix\{
    \LeadingBackslash\OnPrefix\Constants\CONSTANT_NAME as SOME_CONSTANT,
    \LeadingBackslash\OnPrefix\ANOTHER_NAME
};
```

This bug has now been fixed and the fixer will handle this correctly again.

Note:
* Group "prefixes" which had a leading backslash in the original code will now never have a leading backslash in the "fixed" code.
* Leading backslashes in the "partial" statements _within_ a group are not handled. This is a parse error in any PHP version and the "fixed" code will still contain a parse error, as fixing parse errors is not the responsibility of this sniff.

This behaviour has now been documented, both in the inline documentation in the sniff, as well as via a test.

Includes improving the variable name used when walking the return value of the `UseStatements::splitImportUseStatement()` method to make it abundantly clear that the "full name" in the return value from the method, is what PHP calls a "qualified name", i.e. without leading backslash.

Ref: PHPCSStandards/PHPCSUtils#590