### PR TITLE
Universal/ModifierKeywordOrder: add tests with PHP 8.3 typed constants

### DIFF
--- a/Universal/Tests/Constants/ModifierKeywordOrderUnitTest.inc
+++ b/Universal/Tests/Constants/ModifierKeywordOrderUnitTest.inc
@@ -108,6 +108,16 @@ class IncorrectOrderUsingDefaultOrderPref {
 // Reset to default.
 // phpcs:set Universal.Constants.ModifierKeywordOrder order final visibility
 
+/*
+ * Safeguard to ensure there are no side-effects when PHP 8.3 typed properties are used.
+ */
+class PHP83TypedProperties {
+    final public const ?string FINAL_PUBLIC = 'foo';
+
+    #[SomeAttribute]
+    Protected Final const SomeClass|string PROTECTED_FINAL = 'foo', PROTECTED_FINAL_TOO = 'bar';
+}
+
 // Live coding. Ignore as class boundaries cannot be determined yet. This must be the last test in the file.
 class LiveCoding {
     protected final const

--- a/Universal/Tests/Constants/ModifierKeywordOrderUnitTest.inc.fixed
+++ b/Universal/Tests/Constants/ModifierKeywordOrderUnitTest.inc.fixed
@@ -106,6 +106,16 @@ class IncorrectOrderUsingDefaultOrderPref {
 // Reset to default.
 // phpcs:set Universal.Constants.ModifierKeywordOrder order final visibility
 
+/*
+ * Safeguard to ensure there are no side-effects when PHP 8.3 typed properties are used.
+ */
+class PHP83TypedProperties {
+    final public const ?string FINAL_PUBLIC = 'foo';
+
+    #[SomeAttribute]
+    Final Protected const SomeClass|string PROTECTED_FINAL = 'foo', PROTECTED_FINAL_TOO = 'bar';
+}
+
 // Live coding. Ignore as class boundaries cannot be determined yet. This must be the last test in the file.
 class LiveCoding {
     protected final const

--- a/Universal/Tests/Constants/ModifierKeywordOrderUnitTest.php
+++ b/Universal/Tests/Constants/ModifierKeywordOrderUnitTest.php
@@ -37,6 +37,7 @@ final class ModifierKeywordOrderUnitTest extends AbstractSniffUnitTest
             81  => 1,
             83  => 1,
             105 => 1,
+            118 => 1,
         ];
     }
 


### PR DESCRIPTION
Just to safeguard the sniff does not get confused over this, but shouldn't be a problem as the sniff only looks at the tokens before the `const` keyword.