### PR TITLE
Universal/[Disallow/Require]AnonClassParentheses: add tests with PHP 8.3 readonly anonymous classes

### DIFF
--- a/Universal/Tests/Classes/DisallowAnonClassParenthesesUnitTest.1.inc
+++ b/Universal/Tests/Classes/DisallowAnonClassParenthesesUnitTest.1.inc
@@ -38,6 +38,12 @@ $anon = new
 #[MyAttribute, AnotherAttribute]
 class {}; // OK.
 
+/*
+ * Safeguard handling of PHP 8.3 readonly anon classes.
+ */
+$anon = new readonly class {};
+$anon = new   readonly   class() {};
+
 // Live coding.
 // Intentional parse error. This has to be the last test in the file.
 $anon = new class()

--- a/Universal/Tests/Classes/DisallowAnonClassParenthesesUnitTest.1.inc.fixed
+++ b/Universal/Tests/Classes/DisallowAnonClassParenthesesUnitTest.1.inc.fixed
@@ -38,6 +38,12 @@ $anon = new
 #[MyAttribute, AnotherAttribute]
 class {}; // OK.
 
+/*
+ * Safeguard handling of PHP 8.3 readonly anon classes.
+ */
+$anon = new readonly class {};
+$anon = new   readonly   class {};
+
 // Live coding.
 // Intentional parse error. This has to be the last test in the file.
 $anon = new class()

--- a/Universal/Tests/Classes/DisallowAnonClassParenthesesUnitTest.php
+++ b/Universal/Tests/Classes/DisallowAnonClassParenthesesUnitTest.php
@@ -39,6 +39,7 @@ final class DisallowAnonClassParenthesesUnitTest extends AbstractSniffUnitTest
                     24 => 1,
                     27 => 1,
                     35 => 1,
+                    45 => 1,
                 ];
 
             default:

--- a/Universal/Tests/Classes/RequireAnonClassParenthesesUnitTest.inc
+++ b/Universal/Tests/Classes/RequireAnonClassParenthesesUnitTest.inc
@@ -34,6 +34,12 @@ $anon = new
 #[MyAttribute, AnotherAttribute]
 class {}; // Bad.
 
+/*
+ * Safeguard handling of PHP 8.3 readonly anon classes.
+ */
+$anon = new   readonly   class {};
+$anon = new readonly class() {};
+
 // Live coding.
 // Intentional parse error. This has to be the last test in the file.
 $anon = new class

--- a/Universal/Tests/Classes/RequireAnonClassParenthesesUnitTest.inc.fixed
+++ b/Universal/Tests/Classes/RequireAnonClassParenthesesUnitTest.inc.fixed
@@ -34,6 +34,12 @@ $anon = new
 #[MyAttribute, AnotherAttribute]
 class() {}; // Bad.
 
+/*
+ * Safeguard handling of PHP 8.3 readonly anon classes.
+ */
+$anon = new   readonly   class() {};
+$anon = new readonly class() {};
+
 // Live coding.
 // Intentional parse error. This has to be the last test in the file.
 $anon = new class

--- a/Universal/Tests/Classes/RequireAnonClassParenthesesUnitTest.php
+++ b/Universal/Tests/Classes/RequireAnonClassParenthesesUnitTest.php
@@ -33,6 +33,7 @@ final class RequireAnonClassParenthesesUnitTest extends AbstractSniffUnitTest
             22 => 1,
             23 => 1,
             35 => 1,
+            40 => 1,
         ];
     }
 


### PR DESCRIPTION

Just to safeguard the sniff does not get confused over this, but shouldn't be a problem as the sniff only looks at the tokens after the `class` keyword.