### PR TITLE
GH Actions: tweak the way the CS dependency versions are set

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -39,10 +39,12 @@ jobs:
       - name: Validate Composer installation
         run: composer validate --no-check-all --strict
 
+      # Use the WIP/develop branches of the Extra CS dependencies as an early detection system for bugs upstream.
       - name: 'Composer: adjust dependencies'
-        run: |
-          # Using PHPCS `master` as an early detection system for bugs upstream.
-          composer require --no-update squizlabs/php_codesniffer:"dev-master" --no-interaction
+        run: >
+          composer require --no-update --no-scripts --no-interaction
+          squizlabs/php_codesniffer:"dev-master"
+          phpcsstandards/phpcsutils:"dev-develop"
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   #### QUICK TEST STAGE ####
   # This is a much quicker test which only runs the unit tests and linting against the low/high
-  # supported PHP/PHPCS combinations.
+  # supported PHP/PHPCS/PHPCSUtils combinations.
   # These are basically the same builds as in the Test->Coverage workflow, but then without doing
   # the code-coverage.
   quicktest:
@@ -29,38 +29,25 @@ jobs:
     strategy:
       matrix:
         php: ['5.4', 'latest']
-        phpcs_version: ['lowest', 'dev-master']
+        dependencies: ['lowest', 'stable']
 
-    name: "QTest${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
+    name: "QTest${{ matrix.dependencies == 'stable' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.dependencies }}"
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # On stable PHPCS versions, allow for PHP deprecation notices.
-      # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
-      - name: Setup ini config
-        id: set_ini
-        run: |
-          if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> "$GITHUB_OUTPUT"
-          else
-            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
+          # With stable PHPCS dependencies, allow for PHP deprecation notices.
+          # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
+          ini-values: error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On
           coverage: none
 
-      - name: "Composer: set PHPCS version for tests (master)"
-        if: ${{ matrix.phpcs_version != 'lowest' }}
-        run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
-
       - name: "Composer: use lock file when necessary"
-        if: ${{ matrix.phpcs_version == 'lowest' }}
+        if: ${{ matrix.dependencies == 'lowest' }}
         run: composer config --unset lock
 
       # Install dependencies and handle caching in one go.
@@ -72,14 +59,14 @@ jobs:
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: "Composer: set PHPCS/PHPCSUtils version for tests (lowest)"
-        if: ${{ matrix.phpcs_version == 'lowest' }}
+        if: ${{ matrix.dependencies == 'lowest' }}
         run: >
           composer update --prefer-lowest --no-scripts --no-interaction
           squizlabs/php_codesniffer
           phpcsstandards/phpcsutils
 
       - name: Lint against parse errors
-        if: matrix.phpcs_version == 'dev-master'
+        if: matrix.dependencies == 'stable'
         run: composer lint
 
       - name: Run the unit tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,9 +68,36 @@ jobs:
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
         php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.5']
-        phpcs_version: ['lowest', 'dev-master']
+        phpcs_version: ['lowest', 'stable']
+        phpcsutils_version: ['stable']
 
-    name: "Test: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
+        include:
+          # Add some builds with variations of the dependency versions.
+          # Note: the PHPCS low/stable + Utils stable combi is already run via the above matrix.
+          # And the PHPCS low + Utils low combi is run in the code coverage builds.
+          # So these are the only combis missing.
+          - php: '5.4'
+            phpcs_version: 'stable'
+            phpcsutils_version: 'lowest'
+          - php: '8.4'
+            phpcs_version: 'stable'
+            phpcsutils_version: 'lowest'
+
+          # Test against dev versions of all dependencies with select PHP versions for early detection of issues.
+          - php: '5.4'
+            phpcs_version: 'dev-master'
+            phpcsutils_version: 'dev-develop'
+          - php: '7.0'
+            phpcs_version: 'dev-master'
+            phpcsutils_version: 'dev-develop'
+          - php: '7.4'
+            phpcs_version: 'dev-master'
+            phpcsutils_version: 'dev-develop'
+          - php: '8.4'
+            phpcs_version: 'dev-master'
+            phpcsutils_version: 'dev-develop'
+
+    name: "Test: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }} - Utils ${{ matrix.phpcsutils_version }}"
 
     continue-on-error: ${{ matrix.php == '8.5' }}
 
@@ -82,12 +109,14 @@ jobs:
       # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
       - name: Setup ini config
         id: set_ini
+        # yamllint disable rule:line-length
         run: |
-          if [[ "${{ matrix.phpcs_version }}" != "dev-master" ]]; then
+          if [[ "${{ contains( matrix.phpcs_version, 'dev') }}" == "false" && "${{ contains( matrix.phpcsutils_version, 'dev') }}" == "false" ]]; then
             echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> "$GITHUB_OUTPUT"
           else
             echo 'PHP_INI=error_reporting=-1, display_errors=On' >> "$GITHUB_OUTPUT"
           fi
+          # yamllint enable rule:line-length
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -96,12 +125,15 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
 
-      - name: "Composer: set PHPCS version for tests (master)"
-        if: ${{ matrix.phpcs_version != 'lowest' }}
+      - name: "Composer: set PHPCS version for tests (dev/specific version)"
+        if: ${{ matrix.phpcs_version != 'lowest' && matrix.phpcs_version != 'stable' }}
         run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
-      - name: "Composer: use lock file when necessary"
-        if: ${{ matrix.phpcs_version == 'lowest' }}
+      - name: "Composer: set PHPCSUtils version for tests (dev/specific version)"
+        if: ${{ matrix.phpcsutils_version != 'lowest' && matrix.phpcsutils_version != 'stable' }}
+        run: composer require phpcsstandards/phpcsutils:"${{ matrix.phpcsutils_version }}" --no-update --no-scripts --no-interaction
+
+      - name: "Composer: use lock file"
         run: composer config --unset lock
 
       # Install dependencies and handle caching in one go.
@@ -114,19 +146,23 @@ jobs:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
-      - name: "Composer: set PHPCS/PHPCSUtils version for tests (lowest)"
+      - name: "Composer: set PHPCS version for tests (lowest)"
         if: ${{ matrix.phpcs_version == 'lowest' }}
-        run: >
-          composer update --prefer-lowest --no-scripts --no-interaction
-          squizlabs/php_codesniffer
-          phpcsstandards/phpcsutils
+        run: composer update squizlabs/php_codesniffer --prefer-lowest --no-scripts --no-interaction
+
+      - name: "Composer: set PHPCSUtils version for tests (lowest)"
+        if: ${{ matrix.phpcsutils_version == 'lowest' }}
+        run: composer update phpcsstandards/phpcsutils --prefer-lowest --no-scripts --no-interaction
+
+      - name: Composer info
+        run: composer info
 
       - name: Run the unit tests
         run: composer test
 
   #### CODE COVERAGE STAGE ####
   # N.B.: Coverage is only checked on the lowest and highest stable PHP versions
-  # and a low/high of each major for PHPCS.
+  # and a low/high for PHPCS and PHPCSUtils.
   # These builds are left out off the "test" stage so as not to duplicate test runs.
   coverage:
     # No use running the coverage builds if there are failing test builds.
@@ -139,38 +175,25 @@ jobs:
     strategy:
       matrix:
         php: ['5.4', '8.4']
-        phpcs_version: ['lowest', 'dev-master']
+        dependencies: ['lowest', 'stable']
 
-    name: "Coverage: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
+    name: "Coverage: PHP ${{ matrix.php }} - PHPCS ${{ matrix.dependencies }}"
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # On stable PHPCS versions, allow for PHP deprecation notices.
-      # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
-      - name: Setup ini config
-        id: set_ini
-        run: |
-          if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> "$GITHUB_OUTPUT"
-          else
-            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
+          # On stable PHPCS versions, allow for PHP deprecation notices.
+          # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
+          ini-values: PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On
           coverage: xdebug
 
-      - name: "Composer: set PHPCS version for tests (master)"
-        if: ${{ matrix.phpcs_version != 'lowest' }}
-        run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
-
       - name: "Composer: use lock file when necessary"
-        if: ${{ matrix.phpcs_version == 'lowest' }}
+        if: ${{ matrix.dependencies == 'lowest' }}
         run: composer config --unset lock
 
       # Install dependencies and handle caching in one go.
@@ -182,7 +205,7 @@ jobs:
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: "Composer: set PHPCS/PHPCSUtils version for tests (lowest)"
-        if: ${{ matrix.phpcs_version == 'lowest' }}
+        if: ${{ matrix.dependencies == 'lowest' }}
         run: >
           composer update --prefer-lowest --no-scripts --no-interaction
           squizlabs/php_codesniffer
@@ -197,7 +220,7 @@ jobs:
         with:
           format: clover
           file: build/logs/clover.xml
-          flag-name: php-${{ matrix.php }}-phpcs-${{ matrix.phpcs_version }}
+          flag-name: php-${{ matrix.php }}-phpcs-${{ matrix.dependencies }}
           parallel: true
 
   coveralls-finish:


### PR DESCRIPTION
PR #214 previously already changed the logic of the workflow to take advantage of the Composer `--prefer-lowest` setting. This commit takes this yet another step further.

### Stable vs Dev

As things were, the sniff tests were being run against the _lowest_ supported CS dependencies (PHPCS + PHPCSUtils) and the _development_ version of PHPCS (but not PHPCSUtils).

While testing against the _dev_ versions of CS dependencies is relevant, it is more important that the tests safeguard that the sniffs work correctly on typical user-installable combinations of the CS dependencies.

Now, it could be argued that every single combination of the different versions of each of these dependencies should be tested, but that would make the matrix _huge_ for little added benefit.

So, I'm changing the `quicktest` and the `coverage` matrices to test by default against the `lowest` and `stable` supported versions of all dependencies, i.e low PHPCS + PHPCSUtils and high PHPCS + PHPCSUtils. This allows to simplify those workflows a little too.

Note: `stable` is also the name used for the Composer sister-argument to `--prefer-lowest`: `--prefer-stable`, so should be clear-cut for anyone reading the workflow.

## Dev and version specific testing

Now we do want to keep testing against dev versions as well and, what with PHPCS 4.0 around the corner, may want to get more specific about the versions being tested sometime soon.

By decoupling the setting of the PHPCS version versus the setting of the PHPCSUtils version, we gain that flexibility.

So, for the `test` job, I'm adding a new key `phpcsutils_version`, which defaults to 'stable'. All PHP versions will be tested against the low + stable PHPCS version with stable PHPCSUtils.

A few extra builds are added to test against the missing combi of PHPCS stable + low PHPCSUtils. And then yet some more builds are explicitly added to test against dev versions of both tools.

This should make sure all relevant dependency combis are sufficiently tested and sets us up with more flexibility for the future.

Includes adding new (debug) step to display the output of the `composer info` command to make it more straight-forward to see exactly which versions of dependencies ended up being installed.

Notes:
* It could be considered to mark the "dev" dependency builds as "allowed to fail" (`continue-on-error`), but I've decided against that as the sniffs should always be ready for the next minor/patch release of the CS dependencies.