### PR TITLE
Composer: raise the minimum supported PHPCSUtils version to 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ PHPCSExtra is a collection of sniffs and standards for use with [PHP_CodeSniffer
 ## Minimum Requirements
 
 * PHP 5.4 or higher.
-* [PHP_CodeSniffer][phpcs-gh] version **3.12.1** or higher.
-* [PHPCSUtils][phpcsutils-gh] version **1.0.12** or higher.
+* [PHP_CodeSniffer][phpcs-gh] version **3.13.0** or higher.
+* [PHPCSUtils][phpcsutils-gh] version **1.1.0** or higher.
 
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     },
     "require" : {
         "php" : ">=5.4",
-        "squizlabs/php_codesniffer" : "^3.12.1",
-        "phpcsstandards/phpcsutils" : "^1.0.12"
+        "squizlabs/php_codesniffer" : "^3.13.0",
+        "phpcsstandards/phpcsutils" : "^1.1.0"
     },
     "require-dev" : {
         "php-parallel-lint/php-parallel-lint": "^1.4.0",


### PR DESCRIPTION
... to benefit from new functionality.

This also automatically raises the minimum PHPCS version to `3.13.0` for syntax support for new PHP syntaxes, such as asymmetric visibility.

Ref: https://github.com/PHPCSStandards/PHPCSUtils/releases/tag/1.1.0