### PR TITLE
Universal/CommaSpacing: fix for PHPCSUtils 1.1.0

### DIFF
--- a/Universal/Sniffs/WhiteSpace/CommaSpacingSniff.php
+++ b/Universal/Sniffs/WhiteSpace/CommaSpacingSniff.php
@@ -357,6 +357,9 @@ final class CommaSpacingSniff implements Sniff
                 case \T_FN:
                     return 'InFunctionDeclaration';
 
+                case \T_USE:
+                    return 'InClosureUse';
+
                 case \T_DECLARE:
                     return 'InDeclare';
 
@@ -365,7 +368,7 @@ final class CommaSpacingSniff implements Sniff
                 case \T_UNSET:
                     return 'InFunctionCall';
 
-                // Long array, long list, isset, unset, empty, exit, eval, control structures.
+                // Long array, long list, empty, exit, eval, control structures.
                 default:
                     return '';
             }
@@ -378,9 +381,6 @@ final class CommaSpacingSniff implements Sniff
         }
 
         switch ($tokens[$prevNonEmpty]['code']) {
-            case \T_USE:
-                return 'InClosureUse';
-
             case \T_VARIABLE:
             case \T_SELF:
             case \T_STATIC:


### PR DESCRIPTION
As of PHPCS 4.x - and PHPCS cross-version as of PHPCSUtils 1.1.0, a closure `T_USE` token is now a parenthesis owner.

This also means that when PHPCSUtils 1.1.0 is used, the `T_USE` will be recognized as a parentheses owner, which means the dedicated error code is broken as the logic will go into the switch and end up using the default error code and will never reach the fall-back logic for "unowned" parentheses, in which this was previously handled.

The tests don't fail on this as the tests don't currently safeguard that the correct _error code_ is thrown, they just verify the number of errors and that was unchanged.

Either way, fixed now.

Includes minor inline doc clean-up.