### PR TITLE
Universal/DuplicateArrayKey: add extra tests 

### DIFF
--- a/Universal/Tests/Arrays/DuplicateArrayKeyUnitTest.inc
+++ b/Universal/Tests/Arrays/DuplicateArrayKeyUnitTest.inc
@@ -54,7 +54,7 @@ $everythingZero = [
     0.               => 'r',
     .0               => 's',
     (true) ? 0 : 1   => 't',
-    ! true           => 'u',
+    ! \true          => 'u',
 ];
 
 $everythingOne = [
@@ -80,7 +80,7 @@ $everythingOne = [
     1.               => 'q',
     001.             => 'r',
     (true) ? 1 : 0   => 's',
-    ! false          => 't',
+    ! \false         => 't',
     (string) true    => 'u',
 ];
 

--- a/Universal/Tests/Arrays/DuplicateArrayKeyUnitTest.inc
+++ b/Universal/Tests/Arrays/DuplicateArrayKeyUnitTest.inc
@@ -165,3 +165,13 @@ $testPHPLt8VsPHP8 = array(
     1   => 'j', // Duplicate in PHP < 8, not in PHP 8.
     2   => 'k', // Duplicate in PHP < 8, not in PHP 8.
 );
+
+// Issue PHPCSExtra#316, PHPCSStandards/PHPCSUtils#619 no false positive for numeric string keys starting/ending with an underscore.
+$validStringKeys = array(
+    '_1'  => 'value1',
+    '_2'  => 'value2',
+    '3_'  => 'value3',
+    '4_'  => 'value4',
+    '_5_' => 'value5',
+    '_6_' => 'value6',
+);


### PR DESCRIPTION
### Universal/DuplicateArrayKey: add extra tests 

Numeric strings which do not comply with the rules for PHP 7.4 numeric literals with underscores should not be regarded as numeric array indexes.
This bug was fixed in PHPCSUtils 1.1.0.

This commit adds some tests to safeguard the fix in the sniff for which this problem was originally reported.

See PHPCSStandards/PHPCSUtils#619

### Universal/DuplicateArrayKey: add tests with FQN true/false 

Related to PHPCSStandards/PHPCSUtils#668