### PR TITLE
Universal/DisallowUse*: only catch what should be caught

### DIFF
--- a/Universal/Sniffs/UseStatements/DisallowUseClassSniff.php
+++ b/Universal/Sniffs/UseStatements/DisallowUseClassSniff.php
@@ -10,10 +10,10 @@
 
 namespace PHPCSExtra\Universal\Sniffs\UseStatements;
 
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Exceptions\ValueError;
 use PHPCSUtils\Utils\Namespaces;
 use PHPCSUtils\Utils\UseStatements;
 
@@ -115,7 +115,7 @@ final class DisallowUseClassSniff implements Sniff
         // Ok, so this is a T_USE token.
         try {
             $statements = UseStatements::splitImportUseStatement($phpcsFile, $stackPtr);
-        } catch (RuntimeException $e) {
+        } catch (ValueError $e) {
             // Not an import use statement. Bow out.
             return;
         }

--- a/Universal/Sniffs/UseStatements/DisallowUseConstSniff.php
+++ b/Universal/Sniffs/UseStatements/DisallowUseConstSniff.php
@@ -10,10 +10,10 @@
 
 namespace PHPCSExtra\Universal\Sniffs\UseStatements;
 
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Exceptions\ValueError;
 use PHPCSUtils\Utils\Namespaces;
 use PHPCSUtils\Utils\UseStatements;
 
@@ -115,7 +115,7 @@ final class DisallowUseConstSniff implements Sniff
         // Ok, so this is a T_USE token.
         try {
             $statements = UseStatements::splitImportUseStatement($phpcsFile, $stackPtr);
-        } catch (RuntimeException $e) {
+        } catch (ValueError $e) {
             // Not an import use statement. Bow out.
             return;
         }

--- a/Universal/Sniffs/UseStatements/DisallowUseFunctionSniff.php
+++ b/Universal/Sniffs/UseStatements/DisallowUseFunctionSniff.php
@@ -10,10 +10,10 @@
 
 namespace PHPCSExtra\Universal\Sniffs\UseStatements;
 
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Exceptions\ValueError;
 use PHPCSUtils\Utils\Namespaces;
 use PHPCSUtils\Utils\UseStatements;
 
@@ -115,7 +115,7 @@ final class DisallowUseFunctionSniff implements Sniff
         // Ok, so this is a T_USE token.
         try {
             $statements = UseStatements::splitImportUseStatement($phpcsFile, $stackPtr);
-        } catch (RuntimeException $e) {
+        } catch (ValueError $e) {
             // Not an import use statement. Bow out.
             return;
         }


### PR DESCRIPTION
PHPCSUtils 1.1.0 introduces much more modular exceptions for a variety of errors the utility methods can throw.

This commit changes the exceptions being caught in various `catch` statements to more specific ones.

This means that exceptions which shouldn't be able to occur are no longer caught (passing incorrect data type and such) and only the potentially expected (and acceptable) exceptions will now be caught.

Refs:
* PHPCSStandards/PHPCSUtils#598
* PHPCSStandards/PHPCSUtils#599
* PHPCSStandards/PHPCSUtils#600