### PR TITLE
Update for compatibility with PHPCS 4.0

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -29,7 +29,16 @@ jobs:
     strategy:
       matrix:
         php: ['5.4', 'latest']
-        dependencies: ['lowest', 'stable']
+        dependencies: ['lowest', 'stable', 'dev']
+
+        exclude:
+          - php: '5.4'
+            dependencies: 'dev'
+
+        include:
+          # Replace the "low PHP" dev build for PHPCS 4.x.
+          - php: '7.2'
+            dependencies: 'dev'
 
     name: "QTest${{ matrix.dependencies == 'stable' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.dependencies }}"
 
@@ -37,14 +46,36 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # On stable PHPCS versions, allow for PHP deprecation notices.
+      # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
+      - name: Setup ini config
+        id: set_ini
+        # yamllint disable rule:line-length
+        run: |
+          if [ "${{ matrix.dependencies == 'dev' }}" == "false" ]; then
+            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> "$GITHUB_OUTPUT"
+          else
+            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> "$GITHUB_OUTPUT"
+          fi
+          # yamllint enable rule:line-length
+
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          # With stable PHPCS dependencies, allow for PHP deprecation notices.
-          # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
-          ini-values: error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On
+          ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
+
+      # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS 4.x.
+      - name: 'Composer: remove PHPCSDevCS'
+        run: composer remove --dev phpcsstandards/phpcsdevcs --no-update --no-interaction
+
+      - name: "Composer: set PHPCS version for tests (dev)"
+        if: ${{ matrix.dependencies == 'dev' }}
+        run: >
+          composer require --no-scripts --no-interaction
+          squizlabs/php_codesniffer:"4.x-dev"
+          phpcsstandards/phpcsutils:"dev-develop"
 
       - name: "Composer: use lock file when necessary"
         if: ${{ matrix.dependencies == 'lowest' }}
@@ -69,5 +100,15 @@ jobs:
         if: matrix.dependencies == 'stable'
         run: composer lint
 
-      - name: Run the unit tests
-        run: composer test
+      - name: Grab PHPCS version
+        id: phpcs_version
+        # yamllint disable-line rule:line-length
+        run: echo "VERSION=$(vendor/bin/phpcs --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
+
+      - name: Run the unit tests (PHPCS 3.x)
+        if: ${{ startsWith( steps.phpcs_version.outputs.VERSION, '3.' ) }}
+        run: composer test-phpcs3
+
+      - name: Run the unit tests (PHPCS 4.x)
+        if: ${{ startsWith( steps.phpcs_version.outputs.VERSION, '4.' ) }}
+        run: composer test-phpcs4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,8 +68,18 @@ jobs:
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
         php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.5']
-        phpcs_version: ['lowest', 'stable']
+        phpcs_version: ['lowest', 'stable', '4.x-dev']
         phpcsutils_version: ['stable']
+
+        exclude:
+          - php: '5.5'
+            phpcs_version: '4.x-dev'
+          - php: '5.6'
+            phpcs_version: '4.x-dev'
+          - php: '7.0'
+            phpcs_version: '4.x-dev'
+          - php: '7.1'
+            phpcs_version: '4.x-dev'
 
         include:
           # Add some builds with variations of the dependency versions.
@@ -87,14 +97,14 @@ jobs:
           - php: '5.4'
             phpcs_version: 'dev-master'
             phpcsutils_version: 'dev-develop'
-          - php: '7.0'
+          - php: '7.2'
             phpcs_version: 'dev-master'
             phpcsutils_version: 'dev-develop'
           - php: '7.4'
-            phpcs_version: 'dev-master'
+            phpcs_version: '4.x-dev'
             phpcsutils_version: 'dev-develop'
-          - php: '8.4'
-            phpcs_version: 'dev-master'
+          - php: '8.2'
+            phpcs_version: '4.x-dev'
             phpcsutils_version: 'dev-develop'
 
     name: "Test: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }} - Utils ${{ matrix.phpcsutils_version }}"
@@ -124,6 +134,10 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
+
+      # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS 4.x.
+      - name: 'Composer: remove PHPCSDevCS'
+        run: composer remove --dev phpcsstandards/phpcsdevcs --no-update --no-interaction
 
       - name: "Composer: set PHPCS version for tests (dev/specific version)"
         if: ${{ matrix.phpcs_version != 'lowest' && matrix.phpcs_version != 'stable' }}
@@ -157,8 +171,19 @@ jobs:
       - name: Composer info
         run: composer info
 
-      - name: Run the unit tests
-        run: composer test
+      - name: Grab PHPCS version
+        id: phpcs_version
+        # yamllint disable-line rule:line-length
+        run: echo "VERSION=$(vendor/bin/phpcs --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
+
+      - name: Run the unit tests (PHPCS 3.x)
+        if: ${{ startsWith( steps.phpcs_version.outputs.VERSION, '3.' ) }}
+        run: composer test-phpcs3
+
+      - name: Run the unit tests (PHPCS 4.x)
+        if: ${{ startsWith( steps.phpcs_version.outputs.VERSION, '4.' ) }}
+        run: composer test-phpcs4
+
 
   #### CODE COVERAGE STAGE ####
   # N.B.: Coverage is only checked on the lowest and highest stable PHP versions
@@ -175,7 +200,16 @@ jobs:
     strategy:
       matrix:
         php: ['5.4', '8.4']
-        dependencies: ['lowest', 'stable']
+        dependencies: ['lowest', 'stable', 'dev']
+
+        exclude:
+          - php: '5.4'
+            dependencies: 'dev'
+
+        include:
+          # Replace the "low PHP" dev build for PHPCS 4.x.
+          - php: '7.2'
+            dependencies: 'dev'
 
     name: "Coverage: PHP ${{ matrix.php }} - PHPCS ${{ matrix.dependencies }}"
 
@@ -183,14 +217,36 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # On stable PHPCS versions, allow for PHP deprecation notices.
+      # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
+      - name: Setup ini config
+        id: set_ini
+        # yamllint disable rule:line-length
+        run: |
+          if [ "${{ matrix.dependencies == 'dev' }}" == "false" ]; then
+            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> "$GITHUB_OUTPUT"
+          else
+            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> "$GITHUB_OUTPUT"
+          fi
+          # yamllint enable rule:line-length
+
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          # On stable PHPCS versions, allow for PHP deprecation notices.
-          # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
-          ini-values: PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On
+          ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: xdebug
+
+      # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS 4.x.
+      - name: 'Composer: remove PHPCSDevCS'
+        run: composer remove --dev phpcsstandards/phpcsdevcs --no-update --no-interaction
+
+      - name: "Composer: set PHPCS version for tests (dev)"
+        if: ${{ matrix.dependencies == 'dev' }}
+        run: >
+          composer require --no-scripts --no-interaction
+          squizlabs/php_codesniffer:"4.x-dev"
+          phpcsstandards/phpcsutils:"dev-develop"
 
       - name: "Composer: use lock file when necessary"
         if: ${{ matrix.dependencies == 'lowest' }}
@@ -211,8 +267,18 @@ jobs:
           squizlabs/php_codesniffer
           phpcsstandards/phpcsutils
 
-      - name: Run the unit tests with code coverage
-        run: composer coverage
+      - name: Grab PHPCS version
+        id: phpcs_version
+        # yamllint disable-line rule:line-length
+        run: echo "VERSION=$(vendor/bin/phpcs --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
+
+      - name: Run the unit tests with code coverage (PHPCS 3.x)
+        if: ${{ startsWith( steps.phpcs_version.outputs.VERSION, '3.' ) }}
+        run: composer coverage-phpcs3
+
+      - name: Run the unit tests with code coverage (PHPCS 4.x)
+        if: ${{ startsWith( steps.phpcs_version.outputs.VERSION, '4.' ) }}
+        run: composer coverage-phpcs4
 
       - name: Upload coverage results to Coveralls
         if: ${{ success() }}

--- a/Modernize/Tests/FunctionCalls/DirnameUnitTest.php
+++ b/Modernize/Tests/FunctionCalls/DirnameUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Modernize\Tests\FunctionCalls;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 use PHPCSUtils\BackCompat\Helper;
 
 /**
@@ -20,7 +20,7 @@ use PHPCSUtils\BackCompat\Helper;
  *
  * @since 1.0.0
  */
-final class DirnameUnitTest extends AbstractSniffUnitTest
+final class DirnameUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/NormalizedArrays/Tests/Arrays/ArrayBraceSpacingUnitTest.php
+++ b/NormalizedArrays/Tests/Arrays/ArrayBraceSpacingUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\NormalizedArrays\Tests\Arrays;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ArrayBraceSpacing sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class ArrayBraceSpacingUnitTest extends AbstractSniffUnitTest
+final class ArrayBraceSpacingUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/NormalizedArrays/Tests/Arrays/CommaAfterLastUnitTest.php
+++ b/NormalizedArrays/Tests/Arrays/CommaAfterLastUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\NormalizedArrays\Tests\Arrays;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the CommaAfterLast sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class CommaAfterLastUnitTest extends AbstractSniffUnitTest
+final class CommaAfterLastUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Sniffs/UseStatements/DisallowUseClassSniff.php
+++ b/Universal/Sniffs/UseStatements/DisallowUseClassSniff.php
@@ -128,12 +128,19 @@ final class DisallowUseClassSniff implements Sniff
         $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($stackPtr + 1));
 
         foreach ($statements['name'] as $alias => $qualifiedName) {
+            /*
+             * Determine which token to flag.
+             *
+             * - If there is an alias, the alias should be flagged.
+             * - If there isn't an alias, the class name at the end of the qualified name should be flagged
+             *   on PHPCS 3.x and the complete qualified class name on PHPCS 4.x.
+             */
             $reportPtr = $stackPtr;
             do {
                 $reportPtr = $phpcsFile->findNext(\T_STRING, ($reportPtr + 1), $endOfStatement, false, $alias);
                 if ($reportPtr === false) {
-                    // Shouldn't be possible.
-                    continue 2; // @codeCoverageIgnore
+                    // Shouldn't be possible on 3.x, but perfectly possible on 4.x when the class is not aliased.
+                    break;
                 }
 
                 $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($reportPtr + 1), $endOfStatement, true);
@@ -144,6 +151,54 @@ final class DisallowUseClassSniff implements Sniff
 
                 break;
             } while (true);
+
+            if ($reportPtr === false) {
+                // Find the non-aliased name on PHPCS 4.x.
+                $reportPtr = $phpcsFile->findNext(
+                    [\T_NAME_QUALIFIED],
+                    ($stackPtr + 1),
+                    $endOfStatement,
+                    false,
+                    $qualifiedName
+                );
+
+                if ($reportPtr === false) {
+                    // This may be an imported class (incorrectly) passed as an FQN.
+                    $reportPtr = $phpcsFile->findNext(
+                        [\T_NAME_FULLY_QUALIFIED],
+                        ($stackPtr + 1),
+                        $endOfStatement,
+                        false,
+                        '\\' . $qualifiedName
+                    );
+
+                    if ($reportPtr === false) {
+                        // This may be a partial name in a group use statement.
+                        $groupStart = $phpcsFile->findNext(\T_OPEN_USE_GROUP, ($stackPtr + 1), $endOfStatement);
+                        if ($groupStart === false) {
+                            // Shouldn't be possible.
+                            continue; // @codeCoverageIgnore
+                        }
+
+                        for ($i = ($groupStart + 1); $i < $endOfStatement; $i++) {
+                            if ($tokens[$i]['code'] === \T_NAME_QUALIFIED
+                                || $tokens[$i]['code'] === \T_NAME_FULLY_QUALIFIED
+                            ) {
+                                $contentLength = \strlen($tokens[$i]['content']);
+                                if (\substr($qualifiedName, -$contentLength) === $tokens[$i]['content']) {
+                                    $reportPtr = $i;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if ($reportPtr === false) {
+                            // Shouldn't be possible.
+                            continue; // @codeCoverageIgnore
+                        }
+                    }
+                }
+            }
 
             /*
              * Build the error message and code.

--- a/Universal/Sniffs/UseStatements/DisallowUseConstSniff.php
+++ b/Universal/Sniffs/UseStatements/DisallowUseConstSniff.php
@@ -128,12 +128,19 @@ final class DisallowUseConstSniff implements Sniff
         $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($stackPtr + 1));
 
         foreach ($statements['const'] as $alias => $qualifiedName) {
+            /*
+             * Determine which token to flag.
+             *
+             * - If there is an alias, the alias should be flagged.
+             * - If there isn't an alias, the constant name at the end of the qualified name should be flagged
+             *   on PHPCS 3.x and the complete qualified constant name on PHPCS 4.x.
+             */
             $reportPtr = $stackPtr;
             do {
                 $reportPtr = $phpcsFile->findNext(\T_STRING, ($reportPtr + 1), $endOfStatement, false, $alias);
                 if ($reportPtr === false) {
-                    // Shouldn't be possible.
-                    continue 2; // @codeCoverageIgnore
+                    // Shouldn't be possible on 3.x, but perfectly possible on 4.x when the class is not aliased.
+                    break;
                 }
 
                 $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($reportPtr + 1), $endOfStatement, true);
@@ -144,6 +151,54 @@ final class DisallowUseConstSniff implements Sniff
 
                 break;
             } while (true);
+
+            if ($reportPtr === false) {
+                // Find the non-aliased name on PHPCS 4.x.
+                $reportPtr = $phpcsFile->findNext(
+                    [\T_NAME_QUALIFIED],
+                    ($stackPtr + 1),
+                    $endOfStatement,
+                    false,
+                    $qualifiedName
+                );
+
+                if ($reportPtr === false) {
+                    // This may be an imported constant (incorrectly) passed as an FQN.
+                    $reportPtr = $phpcsFile->findNext(
+                        [\T_NAME_FULLY_QUALIFIED],
+                        ($stackPtr + 1),
+                        $endOfStatement,
+                        false,
+                        '\\' . $qualifiedName
+                    );
+
+                    if ($reportPtr === false) {
+                        // This may be a partial name in a group use statement.
+                        $groupStart = $phpcsFile->findNext(\T_OPEN_USE_GROUP, ($stackPtr + 1), $endOfStatement);
+                        if ($groupStart === false) {
+                            // Shouldn't be possible.
+                            continue; // @codeCoverageIgnore
+                        }
+
+                        for ($i = ($groupStart + 1); $i < $endOfStatement; $i++) {
+                            if ($tokens[$i]['code'] === \T_NAME_QUALIFIED
+                                || $tokens[$i]['code'] === \T_NAME_FULLY_QUALIFIED
+                            ) {
+                                $contentLength = \strlen($tokens[$i]['content']);
+                                if (\substr($qualifiedName, -$contentLength) === $tokens[$i]['content']) {
+                                    $reportPtr = $i;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if ($reportPtr === false) {
+                            // Shouldn't be possible.
+                            continue; // @codeCoverageIgnore
+                        }
+                    }
+                }
+            }
 
             /*
              * Build the error message and code.

--- a/Universal/Sniffs/UseStatements/DisallowUseFunctionSniff.php
+++ b/Universal/Sniffs/UseStatements/DisallowUseFunctionSniff.php
@@ -128,12 +128,19 @@ final class DisallowUseFunctionSniff implements Sniff
         $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($stackPtr + 1));
 
         foreach ($statements['function'] as $alias => $qualifiedName) {
+            /*
+             * Determine which token to flag.
+             *
+             * - If there is an alias, the alias should be flagged.
+             * - If there isn't an alias, the function name at the end of the qualified name should be flagged
+             *   on PHPCS 3.x and the complete qualified function name on PHPCS 4.x.
+             */
             $reportPtr = $stackPtr;
             do {
                 $reportPtr = $phpcsFile->findNext(\T_STRING, ($reportPtr + 1), $endOfStatement, false, $alias);
                 if ($reportPtr === false) {
-                    // Shouldn't be possible.
-                    continue 2; // @codeCoverageIgnore
+                    // Shouldn't be possible on 3.x, but perfectly possible on 4.x when the class is not aliased.
+                    break;
                 }
 
                 $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($reportPtr + 1), $endOfStatement, true);
@@ -144,6 +151,54 @@ final class DisallowUseFunctionSniff implements Sniff
 
                 break;
             } while (true);
+
+            if ($reportPtr === false) {
+                // Find the non-aliased name on PHPCS 4.x.
+                $reportPtr = $phpcsFile->findNext(
+                    [\T_NAME_QUALIFIED],
+                    ($stackPtr + 1),
+                    $endOfStatement,
+                    false,
+                    $qualifiedName
+                );
+
+                if ($reportPtr === false) {
+                    // This may be an imported function (incorrectly) passed as an FQN.
+                    $reportPtr = $phpcsFile->findNext(
+                        [\T_NAME_FULLY_QUALIFIED],
+                        ($stackPtr + 1),
+                        $endOfStatement,
+                        false,
+                        '\\' . $qualifiedName
+                    );
+
+                    if ($reportPtr === false) {
+                        // This may be a partial name in a group use statement.
+                        $groupStart = $phpcsFile->findNext(\T_OPEN_USE_GROUP, ($stackPtr + 1), $endOfStatement);
+                        if ($groupStart === false) {
+                            // Shouldn't be possible.
+                            continue; // @codeCoverageIgnore
+                        }
+
+                        for ($i = ($groupStart + 1); $i < $endOfStatement; $i++) {
+                            if ($tokens[$i]['code'] === \T_NAME_QUALIFIED
+                                || $tokens[$i]['code'] === \T_NAME_FULLY_QUALIFIED
+                            ) {
+                                $contentLength = \strlen($tokens[$i]['content']);
+                                if (\substr($qualifiedName, -$contentLength) === $tokens[$i]['content']) {
+                                    $reportPtr = $i;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if ($reportPtr === false) {
+                            // Shouldn't be possible.
+                            continue; // @codeCoverageIgnore
+                        }
+                    }
+                }
+            }
 
             /*
              * Build the error message and code.

--- a/Universal/Sniffs/UseStatements/NoLeadingBackslashSniff.php
+++ b/Universal/Sniffs/UseStatements/NoLeadingBackslashSniff.php
@@ -141,7 +141,9 @@ final class NoLeadingBackslashSniff implements Sniff
             }
         }
 
-        if ($tokens[$nextNonEmpty]['code'] === \T_NS_SEPARATOR) {
+        if ($tokens[$nextNonEmpty]['code'] === \T_NS_SEPARATOR
+            || $tokens[$nextNonEmpty]['code'] === \T_NAME_FULLY_QUALIFIED
+        ) {
             $phpcsFile->recordMetric($nextNonEmpty, self::METRIC_NAME, 'yes');
 
             $error = 'An import use statement should never start with a leading backslash';
@@ -155,10 +157,16 @@ final class NoLeadingBackslashSniff implements Sniff
             $fix = $phpcsFile->addFixableError($error, $nextNonEmpty, $code);
 
             if ($fix === true) {
-                if ($tokens[$nextNonEmpty - 1]['code'] !== \T_WHITESPACE) {
-                    $phpcsFile->fixer->replaceToken($nextNonEmpty, ' ');
+                if ($tokens[$nextNonEmpty]['code'] === \T_NS_SEPARATOR) {
+                    // PHPCS 3.x.
+                    if ($tokens[$nextNonEmpty - 1]['code'] !== \T_WHITESPACE) {
+                        $phpcsFile->fixer->replaceToken($nextNonEmpty, ' ');
+                    } else {
+                        $phpcsFile->fixer->replaceToken($nextNonEmpty, '');
+                    }
                 } else {
-                    $phpcsFile->fixer->replaceToken($nextNonEmpty, '');
+                    // PHPCS 4.x / T_NAME_FULLY_QUALIFIED.
+                    $phpcsFile->fixer->replaceToken($nextNonEmpty, \ltrim($tokens[$nextNonEmpty]['content'], '\\'));
                 }
             }
         } else {

--- a/Universal/Sniffs/UseStatements/NoUselessAliasesSniff.php
+++ b/Universal/Sniffs/UseStatements/NoUselessAliasesSniff.php
@@ -13,6 +13,7 @@ namespace PHPCSExtra\Universal\Sniffs\UseStatements;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\NamingConventions;
 use PHPCSUtils\Utils\UseStatements;
 
@@ -117,8 +118,21 @@ final class NoUselessAliasesSniff implements Sniff
 
                     // Make sure this is really the right one.
                     $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($asPtr - 1), null, true);
-                    if ($tokens[$prev]['code'] !== \T_STRING
-                        || $tokens[$prev]['content'] !== $unqualifiedName
+                    if (isset(Collections::nameTokens()[$tokens[$prev]['code']]) === false) {
+                        // Shouldn't be possible.
+                        continue; // @codeCoverageIgnore
+                    } elseif ($tokens[$prev]['code'] === \T_STRING
+                        && $tokens[$prev]['content'] !== $unqualifiedName
+                    ) {
+                        continue;
+                    } elseif ($tokens[$prev]['code'] === \T_NAME_QUALIFIED
+                        && $tokens[$prev]['content'] !== $qualifiedName
+                        && \substr($qualifiedName, -(\strlen($tokens[$prev]['content']))) !== $tokens[$prev]['content']
+                    ) {
+                        continue;
+                    } elseif ($tokens[$prev]['code'] === \T_NAME_FULLY_QUALIFIED
+                        && $tokens[$prev]['content'] !== '\\' . $qualifiedName
+                        && \substr($qualifiedName, -(\strlen($tokens[$prev]['content']))) !== $tokens[$prev]['content']
                     ) {
                         continue;
                     }

--- a/Universal/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
+++ b/Universal/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
@@ -33,6 +33,7 @@ use PHPCSUtils\Tokens\Collections;
  *   `Generic.WhiteSpace.DisallowSpaceIndent` sniff to clean up the results if so desired.
  *
  * @since 1.0.0
+ * @since 1.4.0 Support for scanning JS and CSS files is deprecated and will be removed in the next major.
  */
 final class PrecisionAlignmentSniff implements Sniff
 {

--- a/Universal/Tests/Arrays/DisallowShortArraySyntaxUnitTest.php
+++ b/Universal/Tests/Arrays/DisallowShortArraySyntaxUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\Arrays;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowShortArraySyntax sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class DisallowShortArraySyntaxUnitTest extends AbstractSniffUnitTest
+final class DisallowShortArraySyntaxUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/Arrays/DuplicateArrayKeyUnitTest.php
+++ b/Universal/Tests/Arrays/DuplicateArrayKeyUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\Arrays;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DuplicateArrayKey sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class DuplicateArrayKeyUnitTest extends AbstractSniffUnitTest
+final class DuplicateArrayKeyUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/Arrays/MixedArrayKeyTypesUnitTest.php
+++ b/Universal/Tests/Arrays/MixedArrayKeyTypesUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\Arrays;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the MixedArrayKeyTypes sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class MixedArrayKeyTypesUnitTest extends AbstractSniffUnitTest
+final class MixedArrayKeyTypesUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/Arrays/MixedKeyedUnkeyedArrayUnitTest.php
+++ b/Universal/Tests/Arrays/MixedKeyedUnkeyedArrayUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\Arrays;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the MixedKeyedUnkeyedArray sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class MixedKeyedUnkeyedArrayUnitTest extends AbstractSniffUnitTest
+final class MixedKeyedUnkeyedArrayUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/Classes/DisallowAnonClassParenthesesUnitTest.php
+++ b/Universal/Tests/Classes/DisallowAnonClassParenthesesUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\Classes;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowAnonClassParentheses sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class DisallowAnonClassParenthesesUnitTest extends AbstractSniffUnitTest
+final class DisallowAnonClassParenthesesUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/Classes/DisallowFinalClassUnitTest.php
+++ b/Universal/Tests/Classes/DisallowFinalClassUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\Classes;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowFinalClass sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class DisallowFinalClassUnitTest extends AbstractSniffUnitTest
+final class DisallowFinalClassUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/Classes/ModifierKeywordOrderUnitTest.php
+++ b/Universal/Tests/Classes/ModifierKeywordOrderUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\Classes;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the Classes\ModifierKeywordOrder sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class ModifierKeywordOrderUnitTest extends AbstractSniffUnitTest
+final class ModifierKeywordOrderUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/Classes/RequireAnonClassParenthesesUnitTest.php
+++ b/Universal/Tests/Classes/RequireAnonClassParenthesesUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\Classes;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the RequireAnonClassParentheses sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class RequireAnonClassParenthesesUnitTest extends AbstractSniffUnitTest
+final class RequireAnonClassParenthesesUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/Classes/RequireFinalClassUnitTest.php
+++ b/Universal/Tests/Classes/RequireFinalClassUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\Classes;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the RequireFinalClass sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class RequireFinalClassUnitTest extends AbstractSniffUnitTest
+final class RequireFinalClassUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/CodeAnalysis/ConstructorDestructorReturnUnitTest.php
+++ b/Universal/Tests/CodeAnalysis/ConstructorDestructorReturnUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\CodeAnalysis;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 use PHPCSUtils\BackCompat\Helper;
 
 /**
@@ -20,7 +20,7 @@ use PHPCSUtils\BackCompat\Helper;
  *
  * @since 1.0.0
  */
-final class ConstructorDestructorReturnUnitTest extends AbstractSniffUnitTest
+final class ConstructorDestructorReturnUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/CodeAnalysis/ForeachUniqueAssignmentUnitTest.php
+++ b/Universal/Tests/CodeAnalysis/ForeachUniqueAssignmentUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\CodeAnalysis;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ForeachUniqueAssignment sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class ForeachUniqueAssignmentUnitTest extends AbstractSniffUnitTest
+final class ForeachUniqueAssignmentUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/CodeAnalysis/NoDoubleNegativeUnitTest.php
+++ b/Universal/Tests/CodeAnalysis/NoDoubleNegativeUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\CodeAnalysis;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the NoDoubleNegative sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.2.0
  */
-final class NoDoubleNegativeUnitTest extends AbstractSniffUnitTest
+final class NoDoubleNegativeUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/CodeAnalysis/NoEchoSprintfUnitTest.php
+++ b/Universal/Tests/CodeAnalysis/NoEchoSprintfUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\CodeAnalysis;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the NoEchoSprintf sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.1.0
  */
-final class NoEchoSprintfUnitTest extends AbstractSniffUnitTest
+final class NoEchoSprintfUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/CodeAnalysis/StaticInFinalClassUnitTest.php
+++ b/Universal/Tests/CodeAnalysis/StaticInFinalClassUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\CodeAnalysis;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the UnnecessaryStaticInFinalClass sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class StaticInFinalClassUnitTest extends AbstractSniffUnitTest
+final class StaticInFinalClassUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/Constants/LowercaseClassResolutionKeywordUnitTest.php
+++ b/Universal/Tests/Constants/LowercaseClassResolutionKeywordUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\Constants;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the LowercaseClassResolutionKeyword sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class LowercaseClassResolutionKeywordUnitTest extends AbstractSniffUnitTest
+final class LowercaseClassResolutionKeywordUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/Constants/ModifierKeywordOrderUnitTest.php
+++ b/Universal/Tests/Constants/ModifierKeywordOrderUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\Constants;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the Constants\ModifierKeywordOrder sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class ModifierKeywordOrderUnitTest extends AbstractSniffUnitTest
+final class ModifierKeywordOrderUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/Constants/UppercaseMagicConstantsUnitTest.php
+++ b/Universal/Tests/Constants/UppercaseMagicConstantsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\Constants;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the UppercaseMagicConstants sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class UppercaseMagicConstantsUnitTest extends AbstractSniffUnitTest
+final class UppercaseMagicConstantsUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.php
+++ b/Universal/Tests/ControlStructures/DisallowAlternativeSyntaxUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\ControlStructures;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowAlternativeSyntax sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class DisallowAlternativeSyntaxUnitTest extends AbstractSniffUnitTest
+final class DisallowAlternativeSyntaxUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/ControlStructures/DisallowLonelyIfUnitTest.php
+++ b/Universal/Tests/ControlStructures/DisallowLonelyIfUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\ControlStructures;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowLonelyIf sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class DisallowLonelyIfUnitTest extends AbstractSniffUnitTest
+final class DisallowLonelyIfUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/ControlStructures/IfElseDeclarationUnitTest.php
+++ b/Universal/Tests/ControlStructures/IfElseDeclarationUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\ControlStructures;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the IfElseDeclaration sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class IfElseDeclarationUnitTest extends AbstractSniffUnitTest
+final class IfElseDeclarationUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.php
+++ b/Universal/Tests/Files/SeparateFunctionsFromOOUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\Files;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the SeparateFunctionsFromOO sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class SeparateFunctionsFromOOUnitTest extends AbstractSniffUnitTest
+final class SeparateFunctionsFromOOUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.php
+++ b/Universal/Tests/FunctionDeclarations/NoLongClosuresUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\FunctionDeclarations;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the NoLongClosures sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.1.0
  */
-final class NoLongClosuresUnitTest extends AbstractSniffUnitTest
+final class NoLongClosuresUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/FunctionDeclarations/RequireFinalMethodsInTraitsUnitTest.php
+++ b/Universal/Tests/FunctionDeclarations/RequireFinalMethodsInTraitsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\FunctionDeclarations;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the RequireFinalMethodsInTraits sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.1.0
  */
-final class RequireFinalMethodsInTraitsUnitTest extends AbstractSniffUnitTest
+final class RequireFinalMethodsInTraitsUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/Lists/DisallowLongListSyntaxUnitTest.php
+++ b/Universal/Tests/Lists/DisallowLongListSyntaxUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\Lists;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowLongListSyntax sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class DisallowLongListSyntaxUnitTest extends AbstractSniffUnitTest
+final class DisallowLongListSyntaxUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.php
+++ b/Universal/Tests/Lists/DisallowShortListSyntaxUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\Lists;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowShortListSyntax sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class DisallowShortListSyntaxUnitTest extends AbstractSniffUnitTest
+final class DisallowShortListSyntaxUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/Namespaces/DisallowCurlyBraceSyntaxUnitTest.php
+++ b/Universal/Tests/Namespaces/DisallowCurlyBraceSyntaxUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\Namespaces;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowCurlyBraceSyntax sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class DisallowCurlyBraceSyntaxUnitTest extends AbstractSniffUnitTest
+final class DisallowCurlyBraceSyntaxUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/Namespaces/DisallowDeclarationWithoutNameUnitTest.php
+++ b/Universal/Tests/Namespaces/DisallowDeclarationWithoutNameUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\Namespaces;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowDeclarationWithoutName sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class DisallowDeclarationWithoutNameUnitTest extends AbstractSniffUnitTest
+final class DisallowDeclarationWithoutNameUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/Namespaces/EnforceCurlyBraceSyntaxUnitTest.php
+++ b/Universal/Tests/Namespaces/EnforceCurlyBraceSyntaxUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\Namespaces;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the EnforceCurlyBraceSyntax sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class EnforceCurlyBraceSyntaxUnitTest extends AbstractSniffUnitTest
+final class EnforceCurlyBraceSyntaxUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/Namespaces/OneDeclarationPerFileUnitTest.php
+++ b/Universal/Tests/Namespaces/OneDeclarationPerFileUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\Namespaces;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the OneDeclarationPerFile sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class OneDeclarationPerFileUnitTest extends AbstractSniffUnitTest
+final class OneDeclarationPerFileUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.php
+++ b/Universal/Tests/NamingConventions/NoReservedKeywordParameterNamesUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\NamingConventions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the NoReservedKeywordParameterNames sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class NoReservedKeywordParameterNamesUnitTest extends AbstractSniffUnitTest
+final class NoReservedKeywordParameterNamesUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/OOStructures/AlphabeticExtendsImplementsUnitTest.php
+++ b/Universal/Tests/OOStructures/AlphabeticExtendsImplementsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\OOStructures;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the AlphabeticExtendsImplements sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class AlphabeticExtendsImplementsUnitTest extends AbstractSniffUnitTest
+final class AlphabeticExtendsImplementsUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/Operators/ConcatPositionUnitTest.php
+++ b/Universal/Tests/Operators/ConcatPositionUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\Operators;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ConcatPosition sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.2.0
  */
-final class ConcatPositionUnitTest extends AbstractSniffUnitTest
+final class ConcatPositionUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/Operators/DisallowLogicalAndOrUnitTest.php
+++ b/Universal/Tests/Operators/DisallowLogicalAndOrUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\Operators;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowLogicalAndOr sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class DisallowLogicalAndOrUnitTest extends AbstractSniffUnitTest
+final class DisallowLogicalAndOrUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/Operators/DisallowShortTernaryUnitTest.php
+++ b/Universal/Tests/Operators/DisallowShortTernaryUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\Operators;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowShortTernary sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class DisallowShortTernaryUnitTest extends AbstractSniffUnitTest
+final class DisallowShortTernaryUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/Operators/DisallowStandalonePostIncrementDecrementUnitTest.php
+++ b/Universal/Tests/Operators/DisallowStandalonePostIncrementDecrementUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\Operators;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowStandalonePostIncrementDecrement sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class DisallowStandalonePostIncrementDecrementUnitTest extends AbstractSniffUnitTest
+final class DisallowStandalonePostIncrementDecrementUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/Operators/StrictComparisonsUnitTest.php
+++ b/Universal/Tests/Operators/StrictComparisonsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\Operators;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the StrictComparisons sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class StrictComparisonsUnitTest extends AbstractSniffUnitTest
+final class StrictComparisonsUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/Operators/TypeSeparatorSpacingUnitTest.php
+++ b/Universal/Tests/Operators/TypeSeparatorSpacingUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\Operators;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the TypeSeparatorSpacing sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class TypeSeparatorSpacingUnitTest extends AbstractSniffUnitTest
+final class TypeSeparatorSpacingUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/PHP/LowercasePHPTagUnitTest.php
+++ b/Universal/Tests/PHP/LowercasePHPTagUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the LowercasePHPTag sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.2.0
  */
-final class LowercasePHPTagUnitTest extends AbstractSniffUnitTest
+final class LowercasePHPTagUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/PHP/NoFQNTrueFalseNullUnitTest.php
+++ b/Universal/Tests/PHP/NoFQNTrueFalseNullUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the NoFQNTrueFalseNull sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.3.0
  */
-final class NoFQNTrueFalseNullUnitTest extends AbstractSniffUnitTest
+final class NoFQNTrueFalseNullUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/PHP/OneStatementInShortEchoTagUnitTest.php
+++ b/Universal/Tests/PHP/OneStatementInShortEchoTagUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the OneStatementInShortEchoTag sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class OneStatementInShortEchoTagUnitTest extends AbstractSniffUnitTest
+final class OneStatementInShortEchoTagUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/UseStatements/DisallowMixedGroupUseUnitTest.php
+++ b/Universal/Tests/UseStatements/DisallowMixedGroupUseUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\UseStatements;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowMixedGroupUse sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.1.0
  */
-final class DisallowMixedGroupUseUnitTest extends AbstractSniffUnitTest
+final class DisallowMixedGroupUseUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/UseStatements/DisallowUseClassUnitTest.php
+++ b/Universal/Tests/UseStatements/DisallowUseClassUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\UseStatements;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowUseClass sniff.
@@ -22,7 +22,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class DisallowUseClassUnitTest extends AbstractSniffUnitTest
+final class DisallowUseClassUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/UseStatements/DisallowUseConstUnitTest.1.inc
+++ b/Universal/Tests/UseStatements/DisallowUseConstUnitTest.1.inc
@@ -33,9 +33,17 @@ use const PHP_VERSION_ID as version_id; // Alias for global import.
 use const PHP_VERSION as php_version; // Alias for global import to same name.
 
 // Test reporting on the correct line. Contrived example, but is valid PHP.
-use const My
-    \php_version
-    \PHP_VERSION as php_version;
+use const
+    My\php_version\PHP_VERSION
+    as php_version;
+
+// Test reporting on the correct token with group use.
+use const prefix\{
+    UNQUALIFIED_INNER_NAME,
+    partially\qualified\INNER_NAME,
+    // Intentional parse error.
+    \fully\qualified\Inner\NAME,
+};
 
 // Ignore as not import use.
 $closure = function() use($bar) {

--- a/Universal/Tests/UseStatements/DisallowUseConstUnitTest.php
+++ b/Universal/Tests/UseStatements/DisallowUseConstUnitTest.php
@@ -49,6 +49,9 @@ final class DisallowUseConstUnitTest extends AbstractSniffTestCase
                     32 => 1, // GlobalNamespaceWithAlias.
                     33 => 1, // GlobalNamespace. Note: alias same as name, so not counted as aliased.
                     38 => 1,
+                    42 => 1,
+                    43 => 1,
+                    45 => 1,
                 ];
 
             case 'DisallowUseConstUnitTest.2.inc':

--- a/Universal/Tests/UseStatements/DisallowUseConstUnitTest.php
+++ b/Universal/Tests/UseStatements/DisallowUseConstUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\UseStatements;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowUseConst sniff.
@@ -22,7 +22,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class DisallowUseConstUnitTest extends AbstractSniffUnitTest
+final class DisallowUseConstUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/UseStatements/DisallowUseFunctionUnitTest.1.inc
+++ b/Universal/Tests/UseStatements/DisallowUseFunctionUnitTest.1.inc
@@ -35,11 +35,9 @@ use function My\preg_replace as Preg_Replace;
 use function str_pos as Pos; // Alias for global import.
 use function \str_pad as STR_PAD; // Alias for global import to same name.
 
-// Test reporting on the correct line. Contrived example, but is valid PHP.
-use function My
-    \function_name
-    \sub
-    \function_name;
+// Test reporting on the correct line.
+use function
+    My\function_name\sub\function_name;
 
 // Ignore as not import use.
 $closure = function() use($bar) {

--- a/Universal/Tests/UseStatements/DisallowUseFunctionUnitTest.php
+++ b/Universal/Tests/UseStatements/DisallowUseFunctionUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\UseStatements;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowUseFunction sniff.
@@ -22,7 +22,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class DisallowUseFunctionUnitTest extends AbstractSniffUnitTest
+final class DisallowUseFunctionUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/UseStatements/DisallowUseFunctionUnitTest.php
+++ b/Universal/Tests/UseStatements/DisallowUseFunctionUnitTest.php
@@ -51,7 +51,7 @@ final class DisallowUseFunctionUnitTest extends AbstractSniffTestCase
                     34 => 1, // Note: alias same as name, so not counted as aliased.
                     35 => 1, // GlobalNamespaceWithAlias.
                     36 => 1, // GlobalNamespace. Note: alias same as name, so not counted as aliased.
-                    42 => 1,
+                    40 => 1,
                 ];
 
             case 'DisallowUseFunctionUnitTest.2.inc':

--- a/Universal/Tests/UseStatements/KeywordSpacingUnitTest.1.inc
+++ b/Universal/Tests/UseStatements/KeywordSpacingUnitTest.1.inc
@@ -55,9 +55,9 @@ use
    as
 
    otherFunction;
-use FuncTion\Util\functionB;
+use FuncTion  \Util\functionB;
 use  CONST  Vendor\Package\CONSTANT_NAME   as  /*comment*/ OTHER_CONSTANT;
-use Const\Util\MyClass\CONSTANT_Y;
+use Const  \Util\MyClass\CONSTANT_Y;
 
 use Vendor\Package\MultiStatement as   Multi,
     DateTime   AS   dateT;

--- a/Universal/Tests/UseStatements/KeywordSpacingUnitTest.2.inc
+++ b/Universal/Tests/UseStatements/KeywordSpacingUnitTest.2.inc
@@ -2,8 +2,8 @@
 
 /*
  * The behaviour of the sniff for this code sample will be different depending on the PHP version.
- * For PHP < 8.0, it will correctly flag this as "no space" after the `use` keyword.
- * For PHP 8.0+, this will no longer be flagged as keywords are allowed in namespaced names,
+ * For PHP < 8.0 on PHPCS 3.x, it will correctly flag this as "no space" after the `use` keyword.
+ * For PHP 8.0+ and PHPCS 4.x, this will no longer be flagged as keywords are allowed in namespaced names,
  * so the `use` is tokenized as `T_STRING` instead of `T_USE` and won't be flagged.
  */
 use\Util\MyOtherClass;

--- a/Universal/Tests/UseStatements/KeywordSpacingUnitTest.2.inc.fixed
+++ b/Universal/Tests/UseStatements/KeywordSpacingUnitTest.2.inc.fixed
@@ -2,8 +2,8 @@
 
 /*
  * The behaviour of the sniff for this code sample will be different depending on the PHP version.
- * For PHP < 8.0, it will correctly flag this as "no space" after the `use` keyword.
- * For PHP 8.0+, this will no longer be flagged as keywords are allowed in namespaced names,
+ * For PHP < 8.0 on PHPCS 3.x, it will correctly flag this as "no space" after the `use` keyword.
+ * For PHP 8.0+ and PHPCS 4.x, this will no longer be flagged as keywords are allowed in namespaced names,
  * so the `use` is tokenized as `T_STRING` instead of `T_USE` and won't be flagged.
  */
 use \Util\MyOtherClass;

--- a/Universal/Tests/UseStatements/KeywordSpacingUnitTest.5.inc
+++ b/Universal/Tests/UseStatements/KeywordSpacingUnitTest.5.inc
@@ -1,0 +1,10 @@
+<?php
+
+/*
+ * The behaviour of the sniff for this code sample will be different depending on the PHPCS version.
+ * On PHPCS < 4.0, these will correctly be flagged for "no space" after the `function`/`const` keyword.
+ * On PHPCS 4.0, this will no longer be flagged as keywords are allowed in namespaced names,
+ * so the `function`/`const` is tokenized as part of the namespaced name and won't be flagged.
+ */
+use FuncTion\Util\functionB;
+use Const\Util\MyClass\CONSTANT_Y;

--- a/Universal/Tests/UseStatements/KeywordSpacingUnitTest.5.inc.fixed
+++ b/Universal/Tests/UseStatements/KeywordSpacingUnitTest.5.inc.fixed
@@ -1,0 +1,10 @@
+<?php
+
+/*
+ * The behaviour of the sniff for this code sample will be different depending on the PHPCS version.
+ * On PHPCS < 4.0, these will correctly be flagged for "no space" after the `function`/`const` keyword.
+ * On PHPCS 4.0, this will no longer be flagged as keywords are allowed in namespaced names,
+ * so the `function`/`const` is tokenized as part of the namespaced name and won't be flagged.
+ */
+use FuncTion \Util\functionB;
+use Const \Util\MyClass\CONSTANT_Y;

--- a/Universal/Tests/UseStatements/KeywordSpacingUnitTest.php
+++ b/Universal/Tests/UseStatements/KeywordSpacingUnitTest.php
@@ -11,6 +11,7 @@
 namespace PHPCSExtra\Universal\Tests\UseStatements;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
+use PHPCSUtils\BackCompat\Helper;
 
 /**
  * Unit test class for the KeywordSpacing sniff.
@@ -33,17 +34,28 @@ final class KeywordSpacingUnitTest extends AbstractSniffTestCase
     {
         $testFiles = parent::getTestFiles($testFileBase);
 
-        if (\PHP_VERSION_ID < 80000) {
-            return $testFiles;
+        if (\PHP_VERSION_ID >= 80000) {
+            // The issue being tested in the "2" test case file cannot be flagged/fixed on PHP 8.0+.
+            $target = 'KeywordSpacingUnitTest.2.inc';
+            $length = \strlen($target);
+            foreach ($testFiles as $i => $fileName) {
+                if (\substr($fileName, -$length) === $target) {
+                    unset($testFiles[$i]);
+                    break;
+                }
+            }
         }
 
-        // The issue being tested in the "2" test case file cannot be flagged/fixed on PHP 8.0+.
-        $target = 'KeywordSpacingUnitTest.2.inc';
-        $length = \strlen($target);
-        foreach ($testFiles as $i => $fileName) {
-            if (\substr($fileName, -$length) === $target) {
-                unset($testFiles[$i]);
-                break;
+        if (\version_compare(Helper::getVersion(), '3.99.99', '>') === true) {
+            // The issues being tested in the "2" and "5" test case files cannot be flagged/fixed on PHPCS 4.0+.
+            $length = \strlen('KeywordSpacingUnitTest.#.inc');
+            foreach ($testFiles as $i => $fileName) {
+                $substring = \substr($fileName, -$length);
+                if ($substring === 'KeywordSpacingUnitTest.2.inc'
+                    || $substring === 'KeywordSpacingUnitTest.5.inc'
+                ) {
+                    unset($testFiles[$i]);
+                }
             }
         }
 
@@ -85,6 +97,12 @@ final class KeywordSpacingUnitTest extends AbstractSniffTestCase
             case 'KeywordSpacingUnitTest.2.inc':
                 return [
                     9 => 1,
+                ];
+
+            case 'KeywordSpacingUnitTest.5.inc':
+                return [
+                    9  => 1,
+                    10 => 1,
                 ];
 
             default:

--- a/Universal/Tests/UseStatements/KeywordSpacingUnitTest.php
+++ b/Universal/Tests/UseStatements/KeywordSpacingUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\UseStatements;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the KeywordSpacing sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.1.0
  */
-final class KeywordSpacingUnitTest extends AbstractSniffUnitTest
+final class KeywordSpacingUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/UseStatements/LowercaseFunctionConstUnitTest.1.inc
+++ b/Universal/Tests/UseStatements/LowercaseFunctionConstUnitTest.1.inc
@@ -6,11 +6,11 @@ use \Util\MyOtherClass;
 
 // Function/const import use statements.
 use function Util\functionA;
-use FuncTion\Util\functionB;
+use FuncTion \Util\functionB;
 use FUNCTION \Util\functionC;
 
 use const Util\MyClass\CONSTANT_X;
-use Const\Util\MyClass\CONSTANT_Y;
+use Const \Util\MyClass\CONSTANT_Y;
 use CONST Util\MyClass\CONSTANT_Z;
 
 use \some\namespacing\{

--- a/Universal/Tests/UseStatements/LowercaseFunctionConstUnitTest.1.inc.fixed
+++ b/Universal/Tests/UseStatements/LowercaseFunctionConstUnitTest.1.inc.fixed
@@ -6,11 +6,11 @@ use \Util\MyOtherClass;
 
 // Function/const import use statements.
 use function Util\functionA;
-use function\Util\functionB;
+use function \Util\functionB;
 use function \Util\functionC;
 
 use const Util\MyClass\CONSTANT_X;
-use const\Util\MyClass\CONSTANT_Y;
+use const \Util\MyClass\CONSTANT_Y;
 use const Util\MyClass\CONSTANT_Z;
 
 use \some\namespacing\{

--- a/Universal/Tests/UseStatements/LowercaseFunctionConstUnitTest.2.inc
+++ b/Universal/Tests/UseStatements/LowercaseFunctionConstUnitTest.2.inc
@@ -1,0 +1,10 @@
+<?php
+
+/*
+ * The behaviour of the sniff for this code sample will be different depending on the PHPCS version.
+ * On PHPCS < 4.0, these will correctly be flagged for "no lowercase" for the `function`/`const` keyword.
+ * On PHPCS 4.0, this will no longer be flagged as keywords are allowed in namespaced names,
+ * so the `function`/`const` is tokenized as part of the namespaced name and won't be flagged.
+ */
+use FuncTion\Util\functionB;
+use Const\Util\MyClass\CONSTANT_Y;

--- a/Universal/Tests/UseStatements/LowercaseFunctionConstUnitTest.2.inc.fixed
+++ b/Universal/Tests/UseStatements/LowercaseFunctionConstUnitTest.2.inc.fixed
@@ -1,0 +1,10 @@
+<?php
+
+/*
+ * The behaviour of the sniff for this code sample will be different depending on the PHPCS version.
+ * On PHPCS < 4.0, these will correctly be flagged for "no lowercase" for the `function`/`const` keyword.
+ * On PHPCS 4.0, this will no longer be flagged as keywords are allowed in namespaced names,
+ * so the `function`/`const` is tokenized as part of the namespaced name and won't be flagged.
+ */
+use function\Util\functionB;
+use const\Util\MyClass\CONSTANT_Y;

--- a/Universal/Tests/UseStatements/LowercaseFunctionConstUnitTest.php
+++ b/Universal/Tests/UseStatements/LowercaseFunctionConstUnitTest.php
@@ -11,6 +11,7 @@
 namespace PHPCSExtra\Universal\Tests\UseStatements;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
+use PHPCSUtils\BackCompat\Helper;
 
 /**
  * Unit test class for the LowercaseFunctionConst sniff.
@@ -23,20 +24,60 @@ final class LowercaseFunctionConstUnitTest extends AbstractSniffTestCase
 {
 
     /**
+     * Get a list of all test files to check.
+     *
+     * @param string $testFileBase The base path that the unit tests files will have.
+     *
+     * @return array<string>
+     */
+    protected function getTestFiles($testFileBase)
+    {
+        $testFiles = parent::getTestFiles($testFileBase);
+
+        if (\version_compare(Helper::getVersion(), '3.99.99', '>') === true) {
+            // The issue being tested in the "2" test case file cannot be flagged/fixed on PHPCS 4.0+.
+            $target = 'LowercaseFunctionConstUnitTest.2.inc';
+            $length = \strlen($target);
+            foreach ($testFiles as $i => $fileName) {
+                if (\substr($fileName, -$length) === $target) {
+                    unset($testFiles[$i]);
+                    break;
+                }
+            }
+        }
+
+        return $testFiles;
+    }
+
+    /**
      * Returns the lines where errors should occur.
+     *
+     * @param string $testFile The name of the file being tested.
      *
      * @return array<int, int> Key is the line number, value is the number of expected errors.
      */
-    public function getErrorList()
+    public function getErrorList($testFile = '')
     {
-        return [
-            9  => 1,
-            10 => 1,
-            13 => 1,
-            14 => 1,
-            17 => 1,
-            19 => 1,
-        ];
+        switch ($testFile) {
+            case 'LowercaseFunctionConstUnitTest.1.inc':
+                return [
+                    9  => 1,
+                    10 => 1,
+                    13 => 1,
+                    14 => 1,
+                    17 => 1,
+                    19 => 1,
+                ];
+
+            case 'LowercaseFunctionConstUnitTest.2.inc':
+                return [
+                    9  => 1,
+                    10 => 1,
+                ];
+
+            default:
+                return [];
+        }
     }
 
     /**

--- a/Universal/Tests/UseStatements/LowercaseFunctionConstUnitTest.php
+++ b/Universal/Tests/UseStatements/LowercaseFunctionConstUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\UseStatements;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the LowercaseFunctionConst sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class LowercaseFunctionConstUnitTest extends AbstractSniffUnitTest
+final class LowercaseFunctionConstUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.1.inc
+++ b/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.1.inc
@@ -8,7 +8,7 @@ use function Util\functionA;
 use FUNCTION \Util\functionB as functionC;
 
 use const Util\MyClass\CONSTANT_X;
-use Const\Util\MyClass\CONSTANT_Y;
+use Const \Util\MyClass\CONSTANT_Y;
 
 use Vendor\Foo\ClassA as ClassABC,
     /*comment*/ \Vendor\Bar\InterfaceB,

--- a/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.6.inc
+++ b/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.6.inc
@@ -1,0 +1,10 @@
+<?php
+
+/*
+ * The behaviour of the sniff for this code sample will be different depending on the PHPCS version.
+ * On PHPCS < 4.0, these will correctly be flagged for "no space" after the `function`/`const` keyword.
+ * On PHPCS 4.0, this will no longer be flagged as keywords are allowed in namespaced names,
+ * so the `function`/`const` is tokenized as part of the namespaced name and won't be flagged.
+ */
+use FuncTion\Util\functionB;
+use Const\Util\MyClass\CONSTANT_Y;

--- a/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.6.inc.fixed
+++ b/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.6.inc.fixed
@@ -1,0 +1,10 @@
+<?php
+
+/*
+ * The behaviour of the sniff for this code sample will be different depending on the PHPCS version.
+ * On PHPCS < 4.0, these will correctly be flagged for "no space" after the `function`/`const` keyword.
+ * On PHPCS 4.0, this will no longer be flagged as keywords are allowed in namespaced names,
+ * so the `function`/`const` is tokenized as part of the namespaced name and won't be flagged.
+ */
+use FuncTion Util\functionB;
+use Const Util\MyClass\CONSTANT_Y;

--- a/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.php
+++ b/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\UseStatements;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the NoLeadingBackslash sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class NoLeadingBackslashUnitTest extends AbstractSniffUnitTest
+final class NoLeadingBackslashUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.php
+++ b/Universal/Tests/UseStatements/NoLeadingBackslashUnitTest.php
@@ -11,6 +11,7 @@
 namespace PHPCSExtra\Universal\Tests\UseStatements;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
+use PHPCSUtils\BackCompat\Helper;
 
 /**
  * Unit test class for the NoLeadingBackslash sniff.
@@ -21,6 +22,32 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
  */
 final class NoLeadingBackslashUnitTest extends AbstractSniffTestCase
 {
+
+    /**
+     * Get a list of all test files to check.
+     *
+     * @param string $testFileBase The base path that the unit tests files will have.
+     *
+     * @return array<string>
+     */
+    protected function getTestFiles($testFileBase)
+    {
+        $testFiles = parent::getTestFiles($testFileBase);
+
+        if (\version_compare(Helper::getVersion(), '3.99.99', '>') === true) {
+            // The issue being tested in the "6" test case file cannot be flagged/fixed on PHPCS 4.0+.
+            $target = 'NoLeadingBackslashUnitTest.6.inc';
+            $length = \strlen($target);
+            foreach ($testFiles as $i => $fileName) {
+                if (\substr($fileName, -$length) === $target) {
+                    unset($testFiles[$i]);
+                    break;
+                }
+            }
+        }
+
+        return $testFiles;
+    }
 
     /**
      * Returns the lines where errors should occur.
@@ -43,6 +70,12 @@ final class NoLeadingBackslashUnitTest extends AbstractSniffTestCase
                     27 => 1,
                     28 => 1,
                     29 => 1,
+                ];
+
+            case 'NoLeadingBackslashUnitTest.6.inc':
+                return [
+                    9  => 1,
+                    10 => 1,
                 ];
 
             default:

--- a/Universal/Tests/UseStatements/NoUselessAliasesUnitTest.inc
+++ b/Universal/Tests/UseStatements/NoUselessAliasesUnitTest.inc
@@ -64,7 +64,7 @@ use Some\NS\ {
 
 // Verify handling of non-ascii names.
 use Vendor\Package\Déjàvü as Dejavu; // OK.
-use Vendor\Package\Déjàvü as DÉJÀVÜ; // Ok.
+use Vendor\Package\Déjàvü as DÉJÀVÜ; // OK.
 use Vendor\Package\Déjàvü as Déjàvü; // Error.
 use Vendor\Package\Déjàvü as déJàVü; // Error.
 
@@ -74,6 +74,23 @@ use function 💩💩 as 💩💩; // Error.
 // Verify handing with (illegal) duplicate aliases.
 use function foo\math\sin as Cos, // OK.
     foo\math\cos as Cos; // Error.
+
+// Duplicate aliases, but that's not our concern - this test is about flagging the correct alias pointer.
+use function foo,
+    bar as baz,
+    baz as baz; // Error.
+
+use function partial\foo,
+    partial\bar as baz,
+    partial\baz as baz; // Error.
+
+use function \foo,
+    \bar as baz,
+    \baz as baz; // Error.
+
+use function \full\foo,
+    \full\bar as baz,
+    \full\baz as baz; // Error.
 
 // Intentional parse error.
 use function as ;

--- a/Universal/Tests/UseStatements/NoUselessAliasesUnitTest.inc.fixed
+++ b/Universal/Tests/UseStatements/NoUselessAliasesUnitTest.inc.fixed
@@ -62,7 +62,7 @@ use Some\NS\ {
 
 // Verify handling of non-ascii names.
 use Vendor\Package\Déjàvü as Dejavu; // OK.
-use Vendor\Package\Déjàvü as DÉJÀVÜ; // Ok.
+use Vendor\Package\Déjàvü as DÉJÀVÜ; // OK.
 use Vendor\Package\Déjàvü; // Error.
 use Vendor\Package\Déjàvü; // Error.
 
@@ -72,6 +72,23 @@ use function 💩💩; // Error.
 // Verify handing with (illegal) duplicate aliases.
 use function foo\math\sin as Cos, // OK.
     foo\math\cos; // Error.
+
+// Duplicate aliases, but that's not our concern - this test is about flagging the correct alias pointer.
+use function foo,
+    bar as baz,
+    baz; // Error.
+
+use function partial\foo,
+    partial\bar as baz,
+    partial\baz; // Error.
+
+use function \foo,
+    \bar as baz,
+    \baz; // Error.
+
+use function \full\foo,
+    \full\bar as baz,
+    \full\baz; // Error.
 
 // Intentional parse error.
 use function as ;

--- a/Universal/Tests/UseStatements/NoUselessAliasesUnitTest.php
+++ b/Universal/Tests/UseStatements/NoUselessAliasesUnitTest.php
@@ -48,6 +48,10 @@ final class NoUselessAliasesUnitTest extends AbstractSniffTestCase
             69 => 1,
             72 => 1,
             76 => 1,
+            81 => 1,
+            85 => 1,
+            89 => 1,
+            93 => 1,
         ];
     }
 

--- a/Universal/Tests/UseStatements/NoUselessAliasesUnitTest.php
+++ b/Universal/Tests/UseStatements/NoUselessAliasesUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\UseStatements;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the NoUselessAliases sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.1.0
  */
-final class NoUselessAliasesUnitTest extends AbstractSniffUnitTest
+final class NoUselessAliasesUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/WhiteSpace/AnonClassKeywordSpacingUnitTest.php
+++ b/Universal/Tests/WhiteSpace/AnonClassKeywordSpacingUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the AnonClassKeywordSpacing sniff.
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class AnonClassKeywordSpacingUnitTest extends AbstractSniffUnitTest
+final class AnonClassKeywordSpacingUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.php
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 use PHPCSUtils\BackCompat\Helper;
 
 /**
@@ -20,7 +20,7 @@ use PHPCSUtils\BackCompat\Helper;
  *
  * @since 1.1.0
  */
-final class CommaSpacingUnitTest extends AbstractSniffUnitTest
+final class CommaSpacingUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
+++ b/Universal/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
@@ -11,7 +11,7 @@
 namespace PHPCSExtra\Universal\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Config;
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowInlineTabs sniff.
@@ -20,7 +20,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.0.0
  */
-final class DisallowInlineTabsUnitTest extends AbstractSniffUnitTest
+final class DisallowInlineTabsUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.php
+++ b/Universal/Tests/WhiteSpace/PrecisionAlignmentUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSExtra\Universal\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 use PHPCSUtils\BackCompat\Helper;
 
 /**
@@ -20,7 +20,7 @@ use PHPCSUtils\BackCompat\Helper;
  *
  * @since 1.0.0
  */
-final class PrecisionAlignmentUnitTest extends AbstractSniffUnitTest
+final class PrecisionAlignmentUnitTest extends AbstractSniffTestCase
 {
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require" : {
         "php" : ">=5.4",
-        "squizlabs/php_codesniffer" : "^3.13.0",
+        "squizlabs/php_codesniffer" : "^3.13.0 || ^4.0",
         "phpcsstandards/phpcsutils" : "^1.1.0"
     },
     "require-dev" : {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "php-parallel-lint/php-console-highlighter": "^1.0",
         "phpcsstandards/phpcsdevcs": "^1.1.6",
         "phpcsstandards/phpcsdevtools": "^1.2.1",
-        "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+        "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
     },
     "extra": {
         "branch-alias": {
@@ -51,14 +51,23 @@
         "check-complete": [
             "@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./Modernize ./NormalizedArrays ./Universal"
         ],
-        "test": [
+        "test-phpcs3": [
             "@php ./vendor/phpunit/phpunit/phpunit --filter PHPCSExtra --no-coverage ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
         ],
-        "coverage": [
+        "test-phpcs4": [
+            "@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
+        ],
+        "coverage-phpcs3": [
             "@php ./vendor/phpunit/phpunit/phpunit --filter PHPCSExtra ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
         ],
-        "coverage-local": [
+        "coverage-phpcs4": [
+            "@php ./vendor/phpunit/phpunit/phpunit"
+        ],
+        "coverage-phpcs3-local": [
             "@php ./vendor/phpunit/phpunit/phpunit --filter PHPCSExtra ./vendor/squizlabs/php_codesniffer/tests/AllTests.php --coverage-html ./build/coverage-html"
+        ],
+        "coverage-phpcs4-local": [
+            "@php ./vendor/phpunit/phpunit/phpunit --coverage-html ./build/coverage-html"
         ]
     },
     "config": {

--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -4,7 +4,7 @@
  *
  * Bootstrap file for running the tests.
  *
- * - Load the PHPCS PHPUnit bootstrap file providing cross-version PHPUnit support.
+ * - Load the PHPCS PHPUnit bootstrap file to set up the PHPCS native autoloading and some constants.
  *   {@link https://github.com/squizlabs/PHP_CodeSniffer/pull/1384}
  * - Allows for a `PHPCS_DIR` environment variable to be set to point to a different
  *   PHPCS install than the one in the `vendor` directory to allow for testing with
@@ -58,6 +58,16 @@ for that PHPCS install.
 ';
 
     exit(1);
+}
+
+// Alias the PHPCS 3.x test case to the PHPCS 4.x name.
+if (class_exists('PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest') === true
+    && class_exists('PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase') === false
+) {
+    class_alias(
+        'PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest',
+        'PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase'
+    );
 }
 
 /*


### PR DESCRIPTION
### Tests: update to allow for running the tests on PHPCS 4.x 

As of PHPCS 4.0, the base sniff test class has been renamed from `AbstractSniffUnitTest` to `AbstractSniffTestCase`.
Additionally the PHPCS test setup no longer uses the outdated custom test suite creation.

This means that to allow for the tests to run on both PHPCS 3.x as well as 4.x, some changes are needed.

This commit handles this by:
* Changing all test files to `extend` the new test case class and adding a class alias to the test bootstrap for compatibility with PHPCS 3.x.
* Adding separate scripts to the `composer.json` file for invoking the tests on PHPCS 3.x vs 4.x.
* Add jobs to test against PHPCS 4.x to all `test` matrices.
* Updating the `quicktest`, `test` and `coverage` jobs to use the correct Composer script based on the installed PHPCS version.

This commit also adds a step to all three jobs to remove the `PHPCSDevCS` dependency. This dependency is not needed in the tests and is currently not (yet) compatible with PHPCS 4.x, so it would block the `composer install`.

_Note: even though PHPCS 4.x supports PHPUnit 10 and 11, we cannot widen the version restrictions for PHPUnit (yet) while PHPCS 3.x is also supported as it would lead to PHPUnit 10/11 being installed for PHPCS 3.x on PHP >= 8.1, which would break the test runs._

### Universal/PrecisionAlignment: deprecate JS/CSS support 

As of PHPCS 4.0, PHPCS will no longer support scanning of JS/CSS files.

This is the only sniff in PHPCSExtra which supports JS/CSS and that support is hereby deprecated and will be removed in PHPCSExtra 2.0.

### Modernize/Dirname: update for PHPCS 4.0 

The tokenization of (namespaced) "names" has changed in PHP 8.0 and this new tokenization will come into effect for PHP_CodeSniffer as of version 4.0.0.

This commit adds handling for the new tokenization of fully qualified function calls to `dirname()` to this sniff.

### Universal/NoEchoSprintf: update for PHPCS 4.0 

The tokenization of (namespaced) "names" has changed in PHP 8.0 and this new tokenization will come into effect for PHP_CodeSniffer as of version 4.0.0.

This commit adds handling for the new tokenization of fully qualified function calls to `*sprintf()` to this sniff.

### Universal/NoFQNTrueFalseNull: update for PHPCS 4.0 

The tokenization of (namespaced) "names" has changed in PHP 8.0 and this new tokenization will come into effect for PHP_CodeSniffer as of version 4.0.0.

This commit adds handling for the new tokenization of fully qualified `true`/`false`/`null` to this sniff.

### Universal/KeywordSpacing: update tests for PHPCS 4.0 

Two tests from the `KeywordSpacingUnitTest.1.inc` file involve code which is interpreted differently in PHP < 8.0 vs 8.0 due to the PHP change to tokenize namespaced names as a single token.
Along the same lines, the code samples in the `KeywordSpacingUnitTest.2.inc` file will also no longer trigger the sniff.

As this change has been polyfilled in PHPCS 4.0, this invalidates those tests when running the sniff on PHPCS 4.0.

This commit moves the original tests from the `KeywordSpacingUnitTest.1.inc` file to a new `KeywordSpacingUnitTest.5.inc` file, which will be skipped on PHPCS 4.0. The `KeywordSpacingUnitTest.2.inc` file will also be skipped.
It also updates the tests in the `KeywordSpacingUnitTest.1.inc` file to be tests which are PHPCS cross-version compatible.

### Universal/LowercaseFunctionConst: update tests for PHPCS 4.0 

Two tests from the `LowercaseFunctionConst.inc` file involve code which is interpreted differently in PHP < 8.0 vs 8.0 due to the PHP change to tokenize namespaced names as a single token.

As this change has been polyfilled in PHPCS 4.0, this invalidates those tests when running the sniff on PHPCS 4.0.

This commit:
* Renames the `LowercaseFunctionConst.inc` test case file to `LowercaseFunctionConst.1.inc`.
* Moves the original tests to a new `LowercaseFunctionConst.2.inc` file, which will be skipped on PHPCS 4.0.
* And updates the tests in the `LowercaseFunctionConst.1.inc` file to be tests which are PHPCS cross-version compatible.

### Universal/NoLeadingBackslash: update for PHPCS 4.0 

One test from the `NoLeadingBackslashUnitTest.1.inc` file involves code which is interpreted differently in PHP < 8.0 vs 8.0 due to the PHP change to tokenize namespaced names as a single token.

As this change has been polyfilled in PHPCS 4.0, this invalidates those tests when running the sniff on PHPCS 4.0.

This commit:
* Updates the sniff to be PHPCS cross-version compatible.
* Moves the original tests to a new `NoLeadingBackslashUnitTest.6.inc` file, which will be skipped on PHPCS 4.0.
* And updates the tests in the `NoLeadingBackslashUnitTest.1.inc` file to be tests which are PHPCS cross-version compatible.

### Universal/DisallowUseClass: update for PHPCS 4.0 

The token walking this sniff did to find the exact token to report the error on needed to be updated to allow for the PHP 8.0 namespaced name as single token change as applied in PHPCS 4.0.

Fixed now.

### Universal/DisallowUseConst: update for PHPCS 4.0 

The token walking this sniff did to find the exact token to report the error on needed to be updated to allow for the PHP 8.0 namespaced name as single token change as applied in PHPCS 4.0.

Fixed now.

Includes some additional tests.
Includes updating one test to make it cross-version compatible as the original code was not valid since PHP 8.0.

### Universal/DisallowUseFunction: update for PHPCS 4.0 

The token walking this sniff did to find the exact token to report the error on needed to be updated to allow for the PHP 8.0 namespaced name as single token change as applied in PHPCS 4.0.

Fixed now.

Includes updating one test to make it cross-version compatible as the original code was not valid since PHP 8.0.

### Universal/NoUselessAliases: update for PHPCS 4.0 

The tokenization of (namespaced) "names" has changed in PHP 8.0 and this new tokenization will come into effect for PHP_CodeSniffer as of version 4.0.0.

This commit adds handling for this new tokenization to this sniff.

Includes some additional tests.

### Make PHPCS 4 support official