### PR TITLE
Release PHPCSExtra 1.4.1

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -109,7 +109,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Updating the lists can fail intermittently, typically after Microsoft has released a new package.
       # This should not be blocking for this job, so ignore any errors from this step.

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -53,9 +53,9 @@ jobs:
         # yamllint disable rule:line-length
         run: |
           if [ "${{ matrix.dependencies == 'dev' }}" == "false" ]; then
-            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> "$GITHUB_OUTPUT"
+            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, display_startup_errors=On' >> "$GITHUB_OUTPUT"
           else
-            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> "$GITHUB_OUTPUT"
+            echo 'PHP_INI=error_reporting=-1, display_errors=On, display_startup_errors=On' >> "$GITHUB_OUTPUT"
           fi
           # yamllint enable rule:line-length
 

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # On stable PHPCS versions, allow for PHP deprecation notices.
       # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -113,7 +113,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # On stable PHPCS versions, allow for PHP deprecation notices.
       # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
@@ -215,7 +215,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # On stable PHPCS versions, allow for PHP deprecation notices.
       # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,9 +122,9 @@ jobs:
         # yamllint disable rule:line-length
         run: |
           if [[ "${{ contains( matrix.phpcs_version, 'dev') }}" == "false" && "${{ contains( matrix.phpcsutils_version, 'dev') }}" == "false" ]]; then
-            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> "$GITHUB_OUTPUT"
+            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, display_startup_errors=On' >> "$GITHUB_OUTPUT"
           else
-            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> "$GITHUB_OUTPUT"
+            echo 'PHP_INI=error_reporting=-1, display_errors=On, display_startup_errors=On' >> "$GITHUB_OUTPUT"
           fi
           # yamllint enable rule:line-length
 
@@ -224,9 +224,9 @@ jobs:
         # yamllint disable rule:line-length
         run: |
           if [ "${{ matrix.dependencies == 'dev' }}" == "false" ]; then
-            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> "$GITHUB_OUTPUT"
+            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, display_startup_errors=On' >> "$GITHUB_OUTPUT"
           else
-            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> "$GITHUB_OUTPUT"
+            echo 'PHP_INI=error_reporting=-1, display_errors=On, display_startup_errors=On' >> "$GITHUB_OUTPUT"
           fi
           # yamllint enable rule:line-length
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,23 @@ This projects adheres to [Keep a CHANGELOG](https://keepachangelog.com/) and use
 
 _Nothing yet._
 
+## [1.4.1] - 2025-09-05
+
+### Changed
+
+#### Other
+
+* Various housekeeping.
+
+
+### Fixed
+
+#### Universal
+
+* `Universal.PHP.NoFQNTrueFalseNull`: fix breakage due to upstream change in tokenization. [#375]
+
+[#375]: https://github.com/PHPCSStandards/PHPCSExtra/pull/375
+
 
 ## [1.4.0] - 2025-06-14
 
@@ -662,6 +679,7 @@ This initial alpha release contains the following sniffs:
 [php_version-config]:    https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-php-version
 
 [Unreleased]: https://github.com/PHPCSStandards/PHPCSExtra/compare/stable...HEAD
+[1.4.1]: https://github.com/PHPCSStandards/PHPCSExtra/compare/1.4.0...1.4.1
 [1.4.0]: https://github.com/PHPCSStandards/PHPCSExtra/compare/1.3.1...1.4.0
 [1.3.1]: https://github.com/PHPCSStandards/PHPCSExtra/compare/1.3.0...1.3.1
 [1.3.0]: https://github.com/PHPCSStandards/PHPCSExtra/compare/1.2.1...1.3.0

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ PHPCSExtra is a collection of sniffs and standards for use with [PHP_CodeSniffer
 ## Minimum Requirements
 
 * PHP 5.4 or higher.
-* [PHP_CodeSniffer][phpcs-gh] version **3.13.0** or higher.
-* [PHPCSUtils][phpcsutils-gh] version **1.1.0** or higher.
+* [PHP_CodeSniffer][phpcs-gh] version **3.13.4** or higher.
+* [PHPCSUtils][phpcsutils-gh] version **1.1.2** or higher.
 
 
 ## Installation
@@ -58,7 +58,7 @@ Installing via Composer is highly recommended.
 Run the following from the root of your project:
 ```bash
 composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
-composer require --dev phpcsstandards/phpcsextra:"^1.2.0"
+composer require --dev phpcsstandards/phpcsextra:"^1.3.0"
 ```
 
 ### Composer Global Installation
@@ -66,7 +66,7 @@ composer require --dev phpcsstandards/phpcsextra:"^1.2.0"
 Alternatively, you may want to install this standard globally:
 ```bash
 composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
-composer global require --dev phpcsstandards/phpcsextra:"^1.2.0"
+composer global require --dev phpcsstandards/phpcsextra:"^1.3.0"
 ```
 
 ### Updating to a newer version

--- a/Universal/Sniffs/PHP/NoFQNTrueFalseNullSniff.php
+++ b/Universal/Sniffs/PHP/NoFQNTrueFalseNullSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSExtra\Universal\Sniffs\PHP;
 
+use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
@@ -31,18 +32,17 @@ final class NoFQNTrueFalseNullSniff implements Sniff
      */
     public function register()
     {
-        return [
-            // PHPCS 3.x on PHP < 8.0.
+        $targets =  [
             \T_TRUE,
             \T_FALSE,
             \T_NULL,
-
-            // PHPCS 3.x on PHP >= 8.0.
-            \T_STRING,
-
-            // PHPCS 4.x.
-            \T_NAME_FULLY_QUALIFIED,
         ];
+
+        if (\version_compare(Config::VERSION, '4.0.0', '>=') === true) {
+            $targets[] = \T_NS_SEPARATOR;
+        }
+
+        return $targets;
     }
 
     /**
@@ -62,17 +62,21 @@ final class NoFQNTrueFalseNullSniff implements Sniff
         $content   = $tokens[$stackPtr]['content'];
         $contentLC = \strtolower($content);
 
-        if ($tokens[$stackPtr]['code'] === \T_NAME_FULLY_QUALIFIED) {
+        if ($contentLC === '\true' || $contentLC === '\false' || $contentLC === '\null') {
             // PHPCS 4.x.
-            if ($contentLC !== '\true' && $contentLC !== '\false' && $contentLC !== '\null') {
+        } elseif ($tokens[$stackPtr]['code'] === \T_NS_SEPARATOR) {
+            // PHPCS 4.x for code which is a parse error on PHP 8.0+.
+            $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            if ($tokens[$next]['code'] !== \T_STRING) {
+                return;
+            }
+
+            $nextContentLC = \strtolower($tokens[$next]['content']);
+            if ($nextContentLC !== 'true' && $nextContentLC !== 'false' && $nextContentLC !== 'null') {
                 return;
             }
         } else {
             // PHPCS 3.x.
-            if ($contentLC !== 'true' && $contentLC !== 'false' && $contentLC !== 'null') {
-                return;
-            }
-
             $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
             if ($tokens[$prev]['code'] !== \T_NS_SEPARATOR) {
                 return;
@@ -97,9 +101,12 @@ final class NoFQNTrueFalseNullSniff implements Sniff
         );
 
         if ($fix === true) {
-            if ($tokens[$stackPtr]['code'] === \T_NAME_FULLY_QUALIFIED) {
+            if ($contentLC === '\true' || $contentLC === '\false' || $contentLC === '\null') {
                 // PHPCS 4.x.
                 $phpcsFile->fixer->replaceToken($stackPtr, \ltrim($tokens[$stackPtr]['content'], '\\'));
+            } elseif ($tokens[$stackPtr]['code'] === \T_NS_SEPARATOR) {
+                // PHPCS 4.x for code which is a parse error on PHP 8.0+.
+                $phpcsFile->fixer->replaceToken($stackPtr, '');
             } else {
                 // PHPCS 3.x.
                 $phpcsFile->fixer->replaceToken($prev, '');

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     },
     "require" : {
         "php" : ">=5.4",
-        "squizlabs/php_codesniffer" : "^3.13.0 || ^4.0",
-        "phpcsstandards/phpcsutils" : "^1.1.0"
+        "squizlabs/php_codesniffer" : "^3.13.4 || ^4.0",
+        "phpcsstandards/phpcsutils" : "^1.1.2"
     },
     "require-dev" : {
         "php-parallel-lint/php-parallel-lint": "^1.4.0",


### PR DESCRIPTION
## Release checklist

### General

- [x] Verify, and if necessary, update the allowed version ranges for various dependencies in the `composer.json` - PR #375
- [x] Go through changelog PHPCS looking for updates to the Tokenizer.
    Review if there are sniffs which need updating in relation to the Tokenizer changes (support for new PHP syntaxes, bugs fixed etc).
- [x] Add changelog for the release - PR #376
    :pencil2: Remember to add a release link at the bottom!
- [ ] ~~Update sniff list in `README` (if applicable) - PR #xxx.~~

### Release

- [x] Merge this PR
- [x] Make sure all CI builds are green.
- [x] Tag and create a release (careful, GH defaults to `develop`!) & copy & paste the changelog to it.
    :pencil2: Check if anything from the link collection at the bottom of the changelog needs to be copied in!
- [x] Make sure all CI builds are green.
- [x] Close the milestone
- [x] Open a new milestone for the next release
- [x] If any open PRs/issues which were milestoned for this release did not make it into the release, update their milestone.
- [x] Fast-forward `develop` to be equal to `stable`

### Publicize

- [x] Toot about the release.
- [x] Tweet about the release.