### PR TITLE
Universal/AlphabeticExtendsImplements: fix error message

### DIFF
--- a/Universal/Sniffs/OOStructures/AlphabeticExtendsImplementsSniff.php
+++ b/Universal/Sniffs/OOStructures/AlphabeticExtendsImplementsSniff.php
@@ -182,8 +182,8 @@ final class AlphabeticExtendsImplementsSniff implements Sniff
         $data   = [
             $tokens[$stackPtr]['content'],
             $tokens[$keywordPtr]['content'],
-            \implode(', ', $names),
             \implode(', ', $sorted),
+            \implode(', ', $names),
         ];
 
         if ($fixable === false) {


### PR DESCRIPTION
Oops... the "expected" versus "found" order was displayed incorrectly in the error message. Fixed now.