### PR TITLE
Dependabot: remove `cooldown`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,8 +25,6 @@ updates:
       prefix: "GH Actions:"
     labels:
       - "Type: chores/QA"
-    cooldown:
-      semver-major-days: 10
     groups:
       action-runners:
         applies-to: version-updates


### PR DESCRIPTION
Follow up on PR #380.

Turns out that the `cooldown` configuration option is not supported for the `github-actions` ecosystem.... _sigh_

So I guess I better remove it again as otherwise Dependabot is blocked from running due to this "configuration error".