### PR TITLE
:sparkles: New `Universal.PHP.RequireExitDieParentheses` sniff

### DIFF
--- a/Universal/Docs/PHP/RequireExitDieParenthesesStandard.xml
+++ b/Universal/Docs/PHP/RequireExitDieParenthesesStandard.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Require Exit/Die Parentheses"
+    >
+    <standard>
+    <![CDATA[
+    Require the use of parentheses when calling `exit` or `die`, even if no argument is given.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Calling exit/die with parentheses.">
+        <![CDATA[
+die<em>()</em>;
+exit<em>($status)</em>;
+        ]]>
+        </code>
+        <code title="Invalid: Calling exit/die without parentheses.">
+        <![CDATA[
+die<em></em>;
+exit<em></em>;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/PHP/RequireExitDieParenthesesSniff.php
+++ b/Universal/Sniffs/PHP/RequireExitDieParenthesesSniff.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\PHP;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Require that `exit`/`die` always be called with parentheses, even if no argument is given.
+ *
+ * @since 1.5.0
+ */
+final class RequireExitDieParenthesesSniff implements Sniff
+{
+
+    /**
+     * Name of the metric.
+     *
+     * @since 1.5.0
+     *
+     * @var string
+     */
+    const METRIC_NAME = 'Exit/die with parentheses';
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.5.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [\T_EXIT];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.5.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens       = $phpcsFile->getTokens();
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($nextNonEmpty === false) {
+            // Live coding. Do not flag (yet).
+            return;
+        }
+
+        if ($tokens[$nextNonEmpty]['code'] === \T_OPEN_PARENTHESIS) {
+            // Parentheses found.
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'yes');
+            return;
+        }
+
+        $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'no');
+
+        $fix = $phpcsFile->addFixableError(
+            'Parentheses required when calling %s, even if no argument is given.',
+            $stackPtr,
+            'Missing',
+            [\strtolower(\ltrim($tokens[$stackPtr]['content'], '\\'))]
+        );
+
+        if ($fix === true) {
+            $phpcsFile->fixer->addContent($stackPtr, '()');
+        }
+    }
+}

--- a/Universal/Tests/PHP/RequireExitDieParenthesesUnitTest.1.inc
+++ b/Universal/Tests/PHP/RequireExitDieParenthesesUnitTest.1.inc
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * Not our targets.
+ * These tests are mostly safeguards against tokenizer issues in PHPCS, at this moment (3.13.4/4.0.0), these wouldn't be tokenized as T_EXIT anyway.
+ */
+class Mirror {
+    const exit = 0;
+    const die = 1;
+
+    public $exit = 0;
+    protected $die = 1;
+
+    function exit() {}
+    function die() {}
+
+    function useMe() {
+        echo self::exit;
+        echo static::die;
+        echo parent::exit;
+        echo AnotherObject::die;
+        echo $this->exit;
+        echo $this->die;
+        echo $this->exit();
+        echo $this->die();
+    }
+}
+
+// Invalid PHP, but not our concern. Not our target.
+namespace\Sub\exit;
+Partially\Qualified\die;
+\Fully\Qualified\exit;
+
+/*
+ * OK.
+ */
+exit();
+die();
+Exit();
+DIE();
+\exit();
+\die();
+exit   ($status);
+\die /*comment*/ (10);
+
+/*
+ * Bad.
+ */
+exit;
+die;
+EXIT;
+Die;
+\exit;
+\die;

--- a/Universal/Tests/PHP/RequireExitDieParenthesesUnitTest.1.inc.fixed
+++ b/Universal/Tests/PHP/RequireExitDieParenthesesUnitTest.1.inc.fixed
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * Not our targets.
+ * These tests are mostly safeguards against tokenizer issues in PHPCS, at this moment (3.13.4/4.0.0), these wouldn't be tokenized as T_EXIT anyway.
+ */
+class Mirror {
+    const exit = 0;
+    const die = 1;
+
+    public $exit = 0;
+    protected $die = 1;
+
+    function exit() {}
+    function die() {}
+
+    function useMe() {
+        echo self::exit;
+        echo static::die;
+        echo parent::exit;
+        echo AnotherObject::die;
+        echo $this->exit;
+        echo $this->die;
+        echo $this->exit();
+        echo $this->die();
+    }
+}
+
+// Invalid PHP, but not our concern. Not our target.
+namespace\Sub\exit;
+Partially\Qualified\die;
+\Fully\Qualified\exit;
+
+/*
+ * OK.
+ */
+exit();
+die();
+Exit();
+DIE();
+\exit();
+\die();
+exit   ($status);
+\die /*comment*/ (10);
+
+/*
+ * Bad.
+ */
+exit();
+die();
+EXIT();
+Die();
+\exit();
+\die();

--- a/Universal/Tests/PHP/RequireExitDieParenthesesUnitTest.2.inc
+++ b/Universal/Tests/PHP/RequireExitDieParenthesesUnitTest.2.inc
@@ -1,0 +1,6 @@
+<?php
+
+// Intentional parse error/live coding.
+// This must be the only test in the file.
+// This code sniff should **not** be flagged (yet).
+exit

--- a/Universal/Tests/PHP/RequireExitDieParenthesesUnitTest.php
+++ b/Universal/Tests/PHP/RequireExitDieParenthesesUnitTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\PHP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
+
+/**
+ * Unit test class for the RequireExitDieParentheses sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\PHP\RequireExitDieParenthesesSniff
+ *
+ * @since 1.5.0
+ */
+final class RequireExitDieParenthesesUnitTest extends AbstractSniffTestCase
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @param string $testFile The name of the file being tested.
+     *
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
+     */
+    public function getErrorList($testFile = '')
+    {
+        switch ($testFile) {
+            case 'RequireExitDieParenthesesUnitTest.1.inc':
+                return [
+                    49 => 1,
+                    50 => 1,
+                    51 => 1,
+                    52 => 1,
+                    53 => 1,
+                    54 => 1,
+                ];
+
+            default:
+                return [];
+        }
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
This sniff checks that calls to `exit`/`die` use parentheses, even if no argument is given and can be used to address the following rule from PER-CS:

> 4.7 Method and Function Calls
> ...
> The `exit()` and `die()` functions SHOULD always be called with parentheses even if no argument is given to clearly distinguish them from an access to a constant named `exit` or `die`.

Ref: https://www.php-fig.org/per/coding-style/#47-method-and-function-calls

Includes fixer.
Includes unit tests.
Includes documentation.