### PR TITLE
Universal/CommaSpacing: fix arbitrary text escaping in error message

### DIFF
--- a/Universal/Sniffs/WhiteSpace/CommaSpacingSniff.php
+++ b/Universal/Sniffs/WhiteSpace/CommaSpacingSniff.php
@@ -320,7 +320,13 @@ final class CommaSpacingSniff implements Sniff
      */
     private function escapePlaceholders($text)
     {
-        return \preg_replace('`(?:^|[^%])(%)(?:[^%]|$)`', '%%', \trim($text));
+        $escapeSinglePercentSign = function ($text) {
+            return \preg_replace('`(^|[^%])%([^%]|$)`', '\1%%\2', \trim($text));
+        };
+
+        // We need to "double" escape to make sure chars involved in the `\2` match will
+        // be taken into account for the decision on whether or not to escape the char _after_ that.
+        return $escapeSinglePercentSign($escapeSinglePercentSign($text));
     }
 
     /**

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.1.inc
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.1.inc
@@ -201,3 +201,6 @@ return [
 $provider[] = ['abc',             '0.10'];
 $provider[] = ['defghi',          '1.0.0BETA3'];
 $provider[] = ['jklmnopqrstuvwz', '2.2.0-DEV'];
+
+// Issue #400 - handling of text in error message.
+define( 'SALT',  'c^&7%D%D%D%DIT' );

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.1.inc.fixed
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.1.inc.fixed
@@ -189,3 +189,6 @@ return [
 $provider[] = ['abc', '0.10'];
 $provider[] = ['defghi', '1.0.0BETA3'];
 $provider[] = ['jklmnopqrstuvwz', '2.2.0-DEV'];
+
+// Issue #400 - handling of text in error message.
+define( 'SALT', 'c^&7%D%D%D%DIT' );

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.php
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.php
@@ -135,6 +135,7 @@ final class CommaSpacingUnitTest extends AbstractSniffTestCase
                     197 => 1,
                     201 => 1,
                     202 => 1,
+                    206 => 1,
                 ];
 
             // Modular error code check.


### PR DESCRIPTION
This commit fixes a bug which could lead to a `Fatal error: Uncaught ValueError: Unknown format specifier "D"`.

Analysis of the bug:
1. The original regex did not "remember" the chars before/after the targeted `%` sign, but the replacement is being done on the complete match, including those chars, not only on the `%` chars.
2. Once that is fixed and the char before and after the `%` sign are now a) remembered and b) included in the replacement, the next problem becomes clear: the regex engine involves characters only in **_one_** match. This means that for a string like this: `C%D%E%F`, the `C%D` would become the first match. As the `D` was included in the first match, the regex engine only continues searching _after_, so the next match will be `E%F`, but the `D%E` would not be matched.
3. To fix that, we execute the regex search & replace twice. This is safe to do as the original regex already contained protection against double escaping.

Includes tests.

Note: while the test now added would have caught this issue due to the fatal error, the _original_ tests for this issue on line 85 - 93 of the same test file suffered from the same problem. The reason this was not caught via the tests, is because the test framework doesn't check the actual error messages, only the fact that an error is thrown (and fixed correctly).

It is the intention to at some point change this via a better base test class in PHPCSUtils, but for now, this will have to do.

Fixes #400