### PR TITLE
Composer: update to PHPCSDevCS 1.2.0

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -45,7 +45,7 @@ jobs:
       - name: 'Composer: adjust dependencies'
         run: >
           composer require --no-update --no-scripts --no-interaction
-          squizlabs/php_codesniffer:"3.x-dev"
+          squizlabs/php_codesniffer:"4.x-dev"
           phpcsstandards/phpcsutils:"dev-develop"
 
       # Install dependencies and handle caching in one go.

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -26,6 +26,10 @@ jobs:
   quicktest:
     runs-on: ubuntu-latest
 
+    env:
+      # - COMPOSER_ROOT_VERSION is needed to get round the recursive dependency when using CI.
+      COMPOSER_ROOT_VERSION: '1.99.99'
+
     strategy:
       matrix:
         # Note, since the release of PHPCS 4.0, 'stable' == latest 4.x.
@@ -57,10 +61,6 @@ jobs:
           # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
           ini-values: error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On
           coverage: none
-
-      # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS 4.x.
-      - name: 'Composer: remove PHPCSDevCS'
-        run: composer remove --dev phpcsstandards/phpcsdevcs --no-update --no-interaction
 
       - name: "Composer: use lock file when necessary"
         if: ${{ matrix.dependencies == 'lowest' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # - COMPOSER_ROOT_VERSION is needed to get round the recursive dependency when using CI.
+  COMPOSER_ROOT_VERSION: '1.99.99'
+
 jobs:
   lint:
     if: ${{ github.ref != 'refs/heads/develop' }}
@@ -157,10 +161,6 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
 
-      # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS 4.x.
-      - name: 'Composer: remove PHPCSDevCS'
-        run: composer remove --dev phpcsstandards/phpcsdevcs --no-update --no-interaction
-
       - name: "Composer: set PHPCS version for tests (dev/specific version)"
         if: ${{ matrix.phpcs_version != 'lowest' && matrix.phpcs_version != 'stable' }}
         run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
@@ -250,10 +250,6 @@ jobs:
           # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
           ini-values: PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On
           coverage: xdebug
-
-      # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS 4.x.
-      - name: 'Composer: remove PHPCSDevCS'
-        run: composer remove --dev phpcsstandards/phpcsdevcs --no-update --no-interaction
 
       - name: "Composer: use lock file when necessary"
         if: ${{ matrix.dependencies == 'lowest' }}

--- a/NormalizedArrays/Sniffs/Arrays/ArrayBraceSpacingSniff.php
+++ b/NormalizedArrays/Sniffs/Arrays/ArrayBraceSpacingSniff.php
@@ -109,7 +109,7 @@ final class ArrayBraceSpacingSniff implements Sniff
         return Collections::arrayOpenTokensBC();
     }
 
-   /**
+    /**
      * Processes this test when one of its tokens is encountered.
      *
      * @since 1.0.0

--- a/Universal/Helpers/DummyTokenizer.php
+++ b/Universal/Helpers/DummyTokenizer.php
@@ -40,11 +40,11 @@ final class DummyTokenizer extends Tokenizer
     /**
      * Creates an array of tokens when given some content.
      *
-     * @param string $string The string to tokenize.
+     * @param string $code The code to tokenize.
      *
      * @return array<int, array<string, mixed>>
      */
-    protected function tokenize($string)
+    protected function tokenize($code)
     {
         return [];
     }

--- a/Universal/Sniffs/CodeAnalysis/ConstructorDestructorReturnSniff.php
+++ b/Universal/Sniffs/CodeAnalysis/ConstructorDestructorReturnSniff.php
@@ -124,7 +124,7 @@ final class ConstructorDestructorReturnSniff implements Sniff
          * OK, so now we know for sure that this is a constructor/destructor method.
          */
 
-         // Check for a return type.
+        // Check for a return type.
         $tokens     = $phpcsFile->getTokens();
         $properties = FunctionDeclarations::getProperties($phpcsFile, $stackPtr);
         if ($properties['return_type'] !== '' && $properties['return_type_token'] !== false) {

--- a/Universal/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
+++ b/Universal/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
@@ -135,9 +135,9 @@ final class DisallowInlineTabsSniff implements Sniff
             $multiLineComment = false;
             if (($tokens[$i]['code'] === \T_COMMENT
                 || isset(Tokens::$phpcsCommentTokens[$tokens[$i]['code']]))
-                 && $tokens[$i]['column'] === 1
-                 && ($tokens[($i - 1)]['code'] === \T_COMMENT
-                 || isset(Tokens::$phpcsCommentTokens[$tokens[($i - 1)]['code']]))
+                && $tokens[$i]['column'] === 1
+                && ($tokens[($i - 1)]['code'] === \T_COMMENT
+                || isset(Tokens::$phpcsCommentTokens[$tokens[($i - 1)]['code']]))
             ) {
                 $multiLineComment = true;
             }

--- a/composer.json
+++ b/composer.json
@@ -28,10 +28,12 @@
     "require-dev" : {
         "php-parallel-lint/php-parallel-lint": "^1.4.0",
         "php-parallel-lint/php-console-highlighter": "^1.0",
-        "phpcsstandards/phpcsdevcs": "^1.1.6",
+        "phpcsstandards/phpcsdevcs": "^1.2.0",
         "phpcsstandards/phpcsdevtools": "^1.2.1",
         "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "extra": {
         "branch-alias": {
             "dev-stable": "1.x-dev",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -33,11 +33,7 @@
     -->
 
     <rule ref="PHPCSDev">
-        <!-- Allow for the file docblock on the line directly following the PHP open tag.
-             As the sniff in PHPCS does not use modular error codes (yet - see PR #2729),
-             the complete error code needs to be disabled, not just the bit involving
-             the file docblocks.
-        -->
+        <!-- Only needed for PHPCS 3.x. This exclusion can be removed when PHPCSDevCS drops support for PHPCS 3.x. -->
         <exclude name="PSR12.Files.FileHeader.SpacingAfterBlock"/>
     </rule>
 


### PR DESCRIPTION
PHPCSDevCS now allows for PHPCS 4.0 and includes PHPCompatibility 10.0.0-alpha1 and a range of sniffs from PHPCSExtra.

Includes preventing issues with recursive dependency.
Includes minor documentation update in the ruleset.
Includes renaming a parameter of a method overloading a PHPCS native method to be in-line with the upstream PHPCS 4.0 parameter name.
Includes various small CS fixes.

Includes running the CS check for this codebase against PHPCS 4.x-dev from now on.

Refs:
* https://github.com/PHPCSStandards/PHPCSDevCS/releases/tag/1.2.0