### PR TITLE
:sparkles: New `Universal.Attributes.BracketSpacing` sniff

### DIFF
--- a/Universal/Docs/Attributes/BracketSpacingStandard.xml
+++ b/Universal/Docs/Attributes/BracketSpacingStandard.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Attribute Bracket Spacing"
+    >
+    <standard>
+    <![CDATA[
+    Enforce a fixed number of spaces on the inside of attribute block brackets. By default, 0 (no) spaces are allowed.
+
+    Optionally allows for new lines.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: No whitespace on the inside of attribute block brackets.">
+        <![CDATA[
+<em>#[</em>MyAttribute()<em>]<em>
+class Foo {}
+        ]]>
+        </code>
+        <code title="Invalid: Whitespace on the inside of attribute block brackets.">
+        <![CDATA[
+<em>#[ </em>MyAttribute()<em>  ]<em>
+class Foo {}
+        ]]>
+        </code>
+    </code_comparison>
+
+    <standard>
+    <![CDATA[
+    When the option to allow a new line is turned on, the sniff will verify that there are no blank lines at the start/end of the attribute block.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: No blank lines at the start/end of an attribute block.">
+        <![CDATA[
+#[<em>
+    </em>MyAttribute()<em>
+<em>]
+class Foo {}
+        ]]>
+        </code>
+        <code title="Invalid: Blank lines at the start/end of an attribute block.">
+        <![CDATA[
+#[<em>
+
+
+    </em>MyAttribute()<em>
+
+<em>]
+class Foo {}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/Attributes/BracketSpacingSniff.php
+++ b/Universal/Sniffs/Attributes/BracketSpacingSniff.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\Attributes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHPCSUtils\Fixers\SpacesFixer;
+
+/**
+ * Requires a configurable number of spaces on the inside of attribute block brackets.
+ *
+ * When newlines are allowed, will also safeguard against blank lines at the start/end of the attribute block.
+ *
+ * @since 1.5.0
+ */
+final class BracketSpacingSniff implements Sniff
+{
+
+    /**
+     * Name of the metric.
+     *
+     * @since 1.5.0
+     *
+     * @var string
+     */
+    const METRIC_NAME = 'Spaces on the inside of attribute brackets';
+
+    /**
+     * The amount of spacing to demand on the inside of attribute brackets.
+     *
+     * @since 1.5.0
+     *
+     * @var int
+     */
+    public $spacing = 0;
+
+    /**
+     * Allow newlines instead of spaces.
+     *
+     * @since 1.5.0
+     *
+     * @var bool
+     */
+    public $ignoreNewlines = false;
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.5.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [\T_ATTRIBUTE];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.5.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['attribute_closer']) === false) {
+            // Live coding/parse error. Ignore.
+            return;
+        }
+
+        if ($tokens[$stackPtr]['attribute_closer'] === ($stackPtr + 1)) {
+            // Empty attribute block. Ignore.
+            return;
+        }
+
+        $this->spacing = (int) $this->spacing;
+
+        $this->processOpener($phpcsFile, $stackPtr);
+        $this->processCloser($phpcsFile, $tokens[$stackPtr]['attribute_closer']);
+    }
+
+    /**
+     * Processes the attribute block opener bracket.
+     *
+     * @since 1.5.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the attribute block opener
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function processOpener(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $nextNonWhitespace = $phpcsFile->findNext(\T_WHITESPACE, ($stackPtr + 1), null, true);
+        if ($this->ignoreNewlines === true
+            && $tokens[$stackPtr]['line'] !== $tokens[$nextNonWhitespace]['line']
+        ) {
+            if (($tokens[$stackPtr]['line'] + 1) === $tokens[$nextNonWhitespace]['line']) {
+                // Single new line.
+                $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'a new line');
+                return;
+            }
+
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'multiple new lines');
+
+            $error = 'Blank line(s) found at the start of an attribute block';
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'BlankLineAtStart');
+
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                $phpcsFile->fixer->addNewline($stackPtr);
+
+                // Remove all blank lines, but don't remove the indentation of the line containing the next bit of code.
+                for ($i = ($stackPtr + 1); $i < $nextNonWhitespace; $i++) {
+                    if ($tokens[$i]['line'] === $tokens[$nextNonWhitespace]['line']) {
+                        break;
+                    }
+
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+                $phpcsFile->fixer->endChangeset();
+            }
+            return;
+        }
+
+        SpacesFixer::checkAndFix(
+            $phpcsFile,
+            $stackPtr,
+            $nextNonWhitespace,
+            $this->spacing,
+            'Expected %s after the attribute block opener. Found: %s.',
+            'SpaceAfterOpener',
+            'error',
+            0,
+            self::METRIC_NAME
+        );
+    }
+
+    /**
+     * Processes the attribute block closer bracket.
+     *
+     * @since 1.5.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the attribute block closer
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function processCloser(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $previousNonWhitespace = $phpcsFile->findPrevious(\T_WHITESPACE, ($stackPtr - 1), null, true);
+        if ($this->ignoreNewlines === true
+            && $tokens[$stackPtr]['line'] !== $tokens[$previousNonWhitespace]['line']
+        ) {
+            if (($tokens[$stackPtr]['line'] - 1) === $tokens[$previousNonWhitespace]['line']) {
+                // Single new line.
+                $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'a new line');
+                return;
+            }
+
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME, 'multiple new lines');
+
+            $error = 'Blank line(s) found at the end of an attribute block';
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'BlankLineAtEnd');
+
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                $phpcsFile->fixer->addNewline($previousNonWhitespace);
+
+                // Remove all blank lines, but don't remove the indentation of the line containing the next bit of code.
+                for ($i = ($previousNonWhitespace + 1); $i < $stackPtr; $i++) {
+                    if ($tokens[$i]['line'] === $tokens[$stackPtr]['line']) {
+                        break;
+                    }
+
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+                $phpcsFile->fixer->endChangeset();
+            }
+            return;
+        }
+
+        SpacesFixer::checkAndFix(
+            $phpcsFile,
+            $previousNonWhitespace,
+            $stackPtr,
+            $this->spacing,
+            'Expected %s before the attribute block closer. Found: %s.',
+            'SpaceBeforeCloser',
+            'error',
+            0,
+            self::METRIC_NAME
+        );
+    }
+}

--- a/Universal/Tests/Attributes/BracketSpacingUnitTest.1.inc
+++ b/Universal/Tests/Attributes/BracketSpacingUnitTest.1.inc
@@ -1,0 +1,164 @@
+<?php
+
+#[] // Nothing to do.
+
+/*
+ * OK with default settings.
+ */
+#[NoSpacesInsideBrackets]
+#[NoSpacesInsideBrackets()]
+#[NoSpacesInsideBrackets(),]
+#[/*comment*/ NoSpacesInsideBrackets() /*comment*/]
+#[NoSpacesInsideBracketsMultilineParamList(
+)]
+#[NoSpacesInsideBracketsMultilineParamList(
+    10,
+    [],
+)]
+
+/*
+ * Bad with default settings.
+ */
+#[ SpacesInsideBrackets ]
+#[  SpacesAfterOpener()]
+#[SpacesBeforeCloser()   ]
+#[ /*comment*/ SpacesInsideBrackets() /*comment*/ ]
+#[
+    SpacesInsideBrackets(),
+]
+#[ SpacesInsideBracketsMultilineParamList(
+) ]
+#[
+    SpacesInsideBracketsMultilineParamList(
+        10,
+        [],
+    )
+]
+
+/*
+ * OK with spacing 1.
+ */
+// phpcs:set Universal.Attributes.BracketSpacing spacing 1
+
+#[ OneSpaceInsideBrackets ]
+#[ OneSpaceInsideBrackets() ]
+#[ OneSpaceInsideBrackets(), ]
+#[ /*comment*/ OneSpaceInsideBrackets /*comment*/ ]
+#[ OneSpaceInsideBracketsMultilineParamList(
+) ]
+#[ OneSpaceInsideBracketsMultilineParamList(
+    10,
+    [],
+) ]
+
+/*
+ * Bad with spacing 1.
+ */
+#[NoSpacesInsideBrackets]
+#[ /*comment*/ NoSpacesInsideBrackets() /*comment*/]
+#[NoSpacesInsideBracketsMultilineParamList(
+) ]
+
+#[  TooManySpacesInsideBrackets  ]
+#[		/*comment*/ TooManySpacesAndTabsInsideBrackets() /*comment*/	 ]
+#[
+    TooManySpacesInsideBrackets()
+]
+
+/*
+ * OK with spacing 2.
+ */
+// phpcs:set Universal.Attributes.BracketSpacing spacing 2
+
+#[  TwoSpacesInsideBrackets  ]
+#[  TwoSpacesInsideBrackets()  ]
+#[  TwoSpacesInsideBrackets(),  ]
+#[  /*comment*/ TwoSpacesInsideBrackets /*comment*/  ]
+#[  TwoSpacesInsideBracketsMultilineParamList(
+)  ]
+#[  TwoSpacesInsideBracketsMultilineParamList(
+    10,
+    [],
+)  ]
+
+/*
+ * Bad with spacing 2.
+ */
+#[NoSpacesInsideBrackets]
+#[/*comment*/ NoSpacesInsideBrackets() /*comment*/]
+#[NoSpacesInsideBracketsMultilineParamList(
+)]
+
+#[ TooLittleSpacesInsideBrackets ]
+#[ /*comment*/ TooLittleSpacesInsideBrackets() /*comment*/ ]
+
+#[    TooManySpacesInsideBrackets    ]
+#[   	/*comment*/ TooManySpacesInsideBrackets() /*comment*/	  ]
+#[
+    TooManySpacesInsideBrackets()
+]
+
+
+/*
+ * Test ignoring new lines.
+ */
+// phpcs:set Universal.Attributes.BracketSpacing spacing 0
+// phpcs:set Universal.Attributes.BracketSpacing ignoreNewlines true
+#[ SpacesInsideBrackets ]
+#[   SpacesInsideBrackets()   ]
+#[ SpacesInsideBracketsMultilineParamList(
+) ]
+#[ // comment.
+    SpacingWithCommentsOnOpenerCloserLineShouldBeHandled(
+        10
+    )
+/*comment */ ]
+
+/*
+ * OK while ignoring new lines.
+ */
+#[
+    TheSpacingHereShouldBeIgnored(),
+]
+#[
+    // comment.
+    CommentsOnOtherLinesShouldHaveNoInfluence(
+        10,
+        [],
+    )
+    /*comment */
+]
+
+/*
+ * Bad while ignoring new lines - blank lines at start/end.
+ */
+#[
+
+    FlagBlankLinesAtStartEndOfAttributeBlock(),
+
+]
+#[
+
+
+
+    MakeSureFixerHandlesMultipleLinesCorrectly(
+        10,
+        [],
+    )
+
+    /*comment */
+
+
+
+
+]
+
+        #[
+
+            MakeSureFixerDoesntRemoveIndentation(),
+
+        ]
+
+// phpcs:set Universal.Attributes.BracketSpacing ignoreNewlines false
+
+function foo() {}

--- a/Universal/Tests/Attributes/BracketSpacingUnitTest.1.inc.fixed
+++ b/Universal/Tests/Attributes/BracketSpacingUnitTest.1.inc.fixed
@@ -1,0 +1,145 @@
+<?php
+
+#[] // Nothing to do.
+
+/*
+ * OK with default settings.
+ */
+#[NoSpacesInsideBrackets]
+#[NoSpacesInsideBrackets()]
+#[NoSpacesInsideBrackets(),]
+#[/*comment*/ NoSpacesInsideBrackets() /*comment*/]
+#[NoSpacesInsideBracketsMultilineParamList(
+)]
+#[NoSpacesInsideBracketsMultilineParamList(
+    10,
+    [],
+)]
+
+/*
+ * Bad with default settings.
+ */
+#[SpacesInsideBrackets]
+#[SpacesAfterOpener()]
+#[SpacesBeforeCloser()]
+#[/*comment*/ SpacesInsideBrackets() /*comment*/]
+#[SpacesInsideBrackets(),]
+#[SpacesInsideBracketsMultilineParamList(
+)]
+#[SpacesInsideBracketsMultilineParamList(
+        10,
+        [],
+    )]
+
+/*
+ * OK with spacing 1.
+ */
+// phpcs:set Universal.Attributes.BracketSpacing spacing 1
+
+#[ OneSpaceInsideBrackets ]
+#[ OneSpaceInsideBrackets() ]
+#[ OneSpaceInsideBrackets(), ]
+#[ /*comment*/ OneSpaceInsideBrackets /*comment*/ ]
+#[ OneSpaceInsideBracketsMultilineParamList(
+) ]
+#[ OneSpaceInsideBracketsMultilineParamList(
+    10,
+    [],
+) ]
+
+/*
+ * Bad with spacing 1.
+ */
+#[ NoSpacesInsideBrackets ]
+#[ /*comment*/ NoSpacesInsideBrackets() /*comment*/ ]
+#[ NoSpacesInsideBracketsMultilineParamList(
+) ]
+
+#[ TooManySpacesInsideBrackets ]
+#[ /*comment*/ TooManySpacesAndTabsInsideBrackets() /*comment*/ ]
+#[ TooManySpacesInsideBrackets() ]
+
+/*
+ * OK with spacing 2.
+ */
+// phpcs:set Universal.Attributes.BracketSpacing spacing 2
+
+#[  TwoSpacesInsideBrackets  ]
+#[  TwoSpacesInsideBrackets()  ]
+#[  TwoSpacesInsideBrackets(),  ]
+#[  /*comment*/ TwoSpacesInsideBrackets /*comment*/  ]
+#[  TwoSpacesInsideBracketsMultilineParamList(
+)  ]
+#[  TwoSpacesInsideBracketsMultilineParamList(
+    10,
+    [],
+)  ]
+
+/*
+ * Bad with spacing 2.
+ */
+#[  NoSpacesInsideBrackets  ]
+#[  /*comment*/ NoSpacesInsideBrackets() /*comment*/  ]
+#[  NoSpacesInsideBracketsMultilineParamList(
+)  ]
+
+#[  TooLittleSpacesInsideBrackets  ]
+#[  /*comment*/ TooLittleSpacesInsideBrackets() /*comment*/  ]
+
+#[  TooManySpacesInsideBrackets  ]
+#[  /*comment*/ TooManySpacesInsideBrackets() /*comment*/  ]
+#[  TooManySpacesInsideBrackets()  ]
+
+
+/*
+ * Test ignoring new lines.
+ */
+// phpcs:set Universal.Attributes.BracketSpacing spacing 0
+// phpcs:set Universal.Attributes.BracketSpacing ignoreNewlines true
+#[SpacesInsideBrackets]
+#[SpacesInsideBrackets()]
+#[SpacesInsideBracketsMultilineParamList(
+)]
+#[// comment.
+    SpacingWithCommentsOnOpenerCloserLineShouldBeHandled(
+        10
+    )
+/*comment */]
+
+/*
+ * OK while ignoring new lines.
+ */
+#[
+    TheSpacingHereShouldBeIgnored(),
+]
+#[
+    // comment.
+    CommentsOnOtherLinesShouldHaveNoInfluence(
+        10,
+        [],
+    )
+    /*comment */
+]
+
+/*
+ * Bad while ignoring new lines - blank lines at start/end.
+ */
+#[
+    FlagBlankLinesAtStartEndOfAttributeBlock(),
+]
+#[
+    MakeSureFixerHandlesMultipleLinesCorrectly(
+        10,
+        [],
+    )
+
+    /*comment */
+]
+
+        #[
+            MakeSureFixerDoesntRemoveIndentation(),
+        ]
+
+// phpcs:set Universal.Attributes.BracketSpacing ignoreNewlines false
+
+function foo() {}

--- a/Universal/Tests/Attributes/BracketSpacingUnitTest.2.inc
+++ b/Universal/Tests/Attributes/BracketSpacingUnitTest.2.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Intentional parse error. Specifically testing the handling of this and safeguarding it for the future.
+#[
+function foo() {}

--- a/Universal/Tests/Attributes/BracketSpacingUnitTest.php
+++ b/Universal/Tests/Attributes/BracketSpacingUnitTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\Attributes;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
+
+/**
+ * Unit test class for the Attributes\BracketSpacing sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\Attributes\BracketSpacingSniff
+ *
+ * @since 1.5.0
+ */
+final class BracketSpacingUnitTest extends AbstractSniffTestCase
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @param string $testFile The name of the file being tested.
+     *
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
+     */
+    public function getErrorList($testFile = '')
+    {
+        switch ($testFile) {
+            case 'BracketSpacingUnitTest.1.inc':
+                return [
+                    // No spaces.
+                    22  => 2,
+                    23  => 1,
+                    24  => 1,
+                    25  => 2,
+                    26  => 1,
+                    27  => 1,
+                    29  => 1,
+                    30  => 1,
+                    31  => 1,
+                    35  => 1,
+
+                    // One space.
+                    57  => 2,
+                    58  => 1,
+                    59  => 1,
+                    62  => 2,
+                    63  => 2,
+                    64  => 1,
+                    65  => 1,
+
+                    // Two spaces.
+                    87  => 2,
+                    88  => 2,
+                    89  => 1,
+                    90  => 1,
+                    92  => 2,
+                    93  => 2,
+                    95  => 2,
+                    96  => 2,
+                    97  => 1,
+                    98  => 1,
+
+                    // Ignoring new lines.
+                    107 => 2,
+                    108 => 2,
+                    109 => 1,
+                    110 => 1,
+                    111 => 1,
+                    115 => 1,
+
+                    // Handling of blank lines at start/end.
+                    135 => 1,
+                    139 => 1,
+                    140 => 1,
+                    154 => 1,
+                    156 => 1,
+                    160 => 1,
+                ];
+
+            default:
+                return [];
+        }
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
New sniff to enforce a fixed number of spaces on the inside of attribute block brackets. By default, the sniff expects `0` spaces, but this is configurable via a custom ruleset using the `spaces` property.
Also by default, new lines will not be allowed. This setting can also be toggled by changing the `ignoreNewlines` property in a custom ruleset.

Additionally, when `ignoreNewlines` is set to `true`, the sniff will also check there are no blank lines at the start or end of the attribute block.

Note: the `$spacing` and `$ignoreNewlines` property names are chosen to be in line with commonly used property names as used in PHPCS itself.

This sniff can be used with the default settings to address the following rule from PER-CS:

> 12.1 Basics
> ...
> Attribute names MUST immediately follow the opening attribute block indicator `#[` with no space.
>
> The closing attribute block indicator `]` MUST follow the last character of the attribute name or the closing `)` of its argument list, with no preceding space.

Ref: https://www.php-fig.org/per/coding-style/#121-basics

Includes fixers.
Includes metrics.
Includes unit tests.
Includes documentation.

Fixes #386