### PR TITLE
Composer: raise the minimum supported PHPCS + PHPCSUtils versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,25 +74,25 @@ jobs:
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
         php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.5']
-        phpcs_version: ['lowest', '^3.13', '4.0.0', 'stable']
+        phpcs_version: ['lowest', '^3.13', '4.0.1', 'stable']
         phpcsutils_version: ['stable']
 
         exclude:
           # Note, since the release of PHPCS 4.0, 'stable' == latest 4.x.
           - php: '5.5'
-            phpcs_version: '4.0.0'
+            phpcs_version: '4.0.1'
           - php: '5.5'
             phpcs_version: 'stable'
           - php: '5.6'
-            phpcs_version: '4.0.0'
+            phpcs_version: '4.0.1'
           - php: '5.6'
             phpcs_version: 'stable'
           - php: '7.0'
-            phpcs_version: '4.0.0'
+            phpcs_version: '4.0.1'
           - php: '7.0'
             phpcs_version: 'stable'
           - php: '7.1'
-            phpcs_version: '4.0.0'
+            phpcs_version: '4.0.1'
           - php: '7.1'
             phpcs_version: 'stable'
           # Also exclude the 7.2/stable build as that's already run in code coverage, no need to duplicate.

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ PHPCSExtra is a collection of sniffs and standards for use with [PHP_CodeSniffer
 ## Minimum Requirements
 
 * PHP 5.4 or higher.
-* [PHP_CodeSniffer][phpcs-gh] version **3.13.4** or higher.
-* [PHPCSUtils][phpcsutils-gh] version **1.1.2** or higher.
+* [PHP_CodeSniffer][phpcs-gh] version **3.13.5**/**4.0.1** or higher.
+* [PHPCSUtils][phpcsutils-gh] version **1.2.0** or higher.
 
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     },
     "require" : {
         "php" : ">=5.4",
-        "squizlabs/php_codesniffer" : "^3.13.4 || ^4.0",
-        "phpcsstandards/phpcsutils" : "^1.1.2"
+        "squizlabs/php_codesniffer" : "^3.13.5 || ^4.0.1",
+        "phpcsstandards/phpcsutils" : "^1.2.0"
     },
     "require-dev" : {
         "php-parallel-lint/php-parallel-lint": "^1.4.0",


### PR DESCRIPTION
PHP_CodeSniffer 3.13.5 + 4.0.1 and PHPCSUtils 1.2.0 have been released.
This commit raises the minimum supported PHPCS/Utils versions for improved tokenizer support of attributes.

Ref:
* https://github.com/PHPCSStandards/PHPCSUtils/releases/tag/1.2.0
* https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/tag/3.13.5