### PR TITLE
:sparkles: New `Universal.Attributes.DisallowAttributeParentheses` sniff

### DIFF
--- a/Universal/Docs/Attributes/DisallowAttributeParenthesesStandard.xml
+++ b/Universal/Docs/Attributes/DisallowAttributeParenthesesStandard.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Disallow Attribute Parentheses"
+    >
+    <standard>
+    <![CDATA[
+    Disallows the use of parentheses when instantiating an attribute without passing parameters.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Attribute instantiation without parentheses or with parameters.">
+        <![CDATA[
+#[MyAttribute<em></em>]
+#[MyAttribute<em>(self::BAZ)</em>]
+class Foo {}
+        ]]>
+        </code>
+        <code title="Invalid: Attribute instantiation with parentheses, but without parameters.">
+        <![CDATA[
+#[MyAttribute<em>()</em>]
+class Foo {}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/Attributes/DisallowAttributeParenthesesSniff.php
+++ b/Universal/Sniffs/Attributes/DisallowAttributeParenthesesSniff.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\Attributes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\AttributeBlock;
+
+/**
+ * Forbid for an attribute instantiation to have parentheses, except when
+ * parameters are being passed.
+ *
+ * @since 1.5.0
+ */
+final class DisallowAttributeParenthesesSniff implements Sniff
+{
+
+    /**
+     * Name of the metric.
+     *
+     * @since 1.5.0
+     *
+     * @var string
+     */
+    const METRIC_NAME = 'Attribute instantiation with parentheses';
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.5.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [\T_ATTRIBUTE];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.5.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $instantiations = AttributeBlock::getAttributes($phpcsFile, $stackPtr);
+        if (empty($instantiations)) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        foreach ($instantiations as $attribute) {
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($attribute['name_token'] + 1), null, true);
+
+            // Note: no need to check for `false` as there will always be something after, if only the attribute closer.
+            if ($tokens[$nextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS) {
+                // No parentheses found.
+                $phpcsFile->recordMetric($attribute['name_token'], self::METRIC_NAME, 'no');
+                continue;
+            }
+
+            if (isset($tokens[$nextNonEmpty]['parenthesis_closer']) === false) {
+                /*
+                 * Incomplete set of parentheses. Ignore.
+                 * Shouldn't be possible as PHPCS won't have matched the attribute opener with the closer in that case.
+                 */
+                // @codeCoverageIgnoreStart
+                $phpcsFile->recordMetric($attribute['name_token'], self::METRIC_NAME, 'yes');
+                continue;
+                // @codeCoverageIgnoreEnd
+            }
+
+            $opener    = $nextNonEmpty;
+            $closer    = $tokens[$opener]['parenthesis_closer'];
+            $hasParams = $phpcsFile->findNext(Tokens::$emptyTokens, ($opener + 1), $closer, true);
+            if ($hasParams !== false) {
+                // There is something between the parentheses. Ignore.
+                $phpcsFile->recordMetric($attribute['name_token'], self::METRIC_NAME, 'yes, with parameter(s)');
+                continue;
+            }
+
+            $phpcsFile->recordMetric($attribute['name_token'], self::METRIC_NAME, 'yes');
+
+            $fix = $phpcsFile->addFixableError(
+                'Parentheses not allowed when instantiating an attribute class without passing parameters',
+                $opener,
+                'Found'
+            );
+
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+
+                for ($i = $opener; $i <= $closer; $i++) {
+                    if (isset(Tokens::$commentTokens[$tokens[$i]['code']]) === true) {
+                        continue;
+                    }
+
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+
+                $phpcsFile->fixer->endChangeset();
+            }
+        }
+    }
+}

--- a/Universal/Tests/Attributes/DisallowAttributeParenthesesUnitTest.1.inc
+++ b/Universal/Tests/Attributes/DisallowAttributeParenthesesUnitTest.1.inc
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * OK.
+ */
+// No attributes, nothing to do.
+#[]
+
+// No parentheses.
+#[MyAttribute]
+#[\MyAttribute /*comment*/]
+#[MyAttribute, Partial\AnotherAttribute, namespace\AndAnotherOne]
+#[
+    MyAttribute,
+    \Fully\Qualified\AnotherAttribute,
+    AndAnotherOne,
+]
+#[
+    MyAttribute // Comment
+]
+
+// Parentheses, but with arguments.
+#[MyAttribute('foo')]
+#[\MyAttribute /*comment*/ (1)]
+#[MyAttribute(self::BAZ), Partial\AnotherAttribute ([]), namespace\AndAnotherOne  (1, 2, 3)]
+#[
+    MyAttribute(
+        new stdClass // No parentheses, but not an attribute class instantiation.
+    ),
+    \Fully\Qualified\AnotherAttribute(self::BAZ),
+    AndAnotherOne("foo"),
+]
+#[
+    MyAttribute(10) // Comment
+]
+function foo() {}
+
+
+/*
+ * Bad.
+ */
+#[MyAttribute()]
+#[\MyAttribute( )]
+#[MyAttribute(), Partial\AnotherAttribute , namespace\AndAnotherOne    ()   ]
+#[MyAttribute(
+)]
+#[
+    MyAttribute // Comment
+    ( /*comment*/  )
+]
+function foo() {}

--- a/Universal/Tests/Attributes/DisallowAttributeParenthesesUnitTest.1.inc.fixed
+++ b/Universal/Tests/Attributes/DisallowAttributeParenthesesUnitTest.1.inc.fixed
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * OK.
+ */
+// No attributes, nothing to do.
+#[]
+
+// No parentheses.
+#[MyAttribute]
+#[\MyAttribute /*comment*/]
+#[MyAttribute, Partial\AnotherAttribute, namespace\AndAnotherOne]
+#[
+    MyAttribute,
+    \Fully\Qualified\AnotherAttribute,
+    AndAnotherOne,
+]
+#[
+    MyAttribute // Comment
+]
+
+// Parentheses, but with arguments.
+#[MyAttribute('foo')]
+#[\MyAttribute /*comment*/ (1)]
+#[MyAttribute(self::BAZ), Partial\AnotherAttribute ([]), namespace\AndAnotherOne  (1, 2, 3)]
+#[
+    MyAttribute(
+        new stdClass // No parentheses, but not an attribute class instantiation.
+    ),
+    \Fully\Qualified\AnotherAttribute(self::BAZ),
+    AndAnotherOne("foo"),
+]
+#[
+    MyAttribute(10) // Comment
+]
+function foo() {}
+
+
+/*
+ * Bad.
+ */
+#[MyAttribute]
+#[\MyAttribute]
+#[MyAttribute, Partial\AnotherAttribute , namespace\AndAnotherOne       ]
+#[MyAttribute]
+#[
+    MyAttribute // Comment
+    /*comment*/
+]
+function foo() {}

--- a/Universal/Tests/Attributes/DisallowAttributeParenthesesUnitTest.2.inc
+++ b/Universal/Tests/Attributes/DisallowAttributeParenthesesUnitTest.2.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Intentional parse error. Specifically testing the handling of this and safeguarding it for the future.
+#[
+function foo() {}

--- a/Universal/Tests/Attributes/DisallowAttributeParenthesesUnitTest.3.inc
+++ b/Universal/Tests/Attributes/DisallowAttributeParenthesesUnitTest.3.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Intentional parse error. Specifically testing the handling of this and safeguarding it for the future.
+#[MyAttribute
+function foo() {}

--- a/Universal/Tests/Attributes/DisallowAttributeParenthesesUnitTest.4.inc
+++ b/Universal/Tests/Attributes/DisallowAttributeParenthesesUnitTest.4.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Intentional parse error. Specifically testing the handling of this and safeguarding it for the future.
+#[MyAttribute($param ]
+function foo() {}

--- a/Universal/Tests/Attributes/DisallowAttributeParenthesesUnitTest.5.inc
+++ b/Universal/Tests/Attributes/DisallowAttributeParenthesesUnitTest.5.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Intentional parse error. Specifically documenting the handling of this and safeguarding it for the future.
+#[MyAttribute($param, AnotherAttribute() ]
+function foo() {}

--- a/Universal/Tests/Attributes/DisallowAttributeParenthesesUnitTest.php
+++ b/Universal/Tests/Attributes/DisallowAttributeParenthesesUnitTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\Attributes;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
+
+/**
+ * Unit test class for the DisallowAttributeParentheses sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\Attributes\DisallowAttributeParenthesesSniff
+ *
+ * @since 1.5.0
+ */
+final class DisallowAttributeParenthesesUnitTest extends AbstractSniffTestCase
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @param string $testFile The name of the file being tested.
+     *
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
+     */
+    public function getErrorList($testFile = '')
+    {
+        switch ($testFile) {
+            case 'DisallowAttributeParenthesesUnitTest.1.inc':
+                return [
+                    42 => 1,
+                    43 => 1,
+                    44 => 2,
+                    45 => 1,
+                    49 => 1,
+                ];
+
+            default:
+                return [];
+        }
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
This sniff enforces that attribute instantiations only use parentheses when parameters are passed to the attribute constructor.

This sniff can be used to address the following rule from PER-CS:

> 12.1 Basics
> ...
> If an attribute has no arguments, the `()` MUST be omitted.

Ref: https://www.php-fig.org/per/coding-style/#121-basics

Includes fixer.
Includes metrics.
Includes unit tests.
Includes documentation.

Related to #387