### PR TITLE
:sparkles: New `Universal.Attributes.RequireAttributeParentheses` sniff

### DIFF
--- a/Universal/Docs/Attributes/RequireAttributeParenthesesStandard.xml
+++ b/Universal/Docs/Attributes/RequireAttributeParenthesesStandard.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Require Attribute Parentheses"
+    >
+    <standard>
+    <![CDATA[
+    Require the use of parentheses when instantiating an attribute.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Attribute instantiation with parentheses.">
+        <![CDATA[
+#[MyAttribute<em>()</em>]
+class Foo {}
+        ]]>
+        </code>
+        <code title="Invalid: Attribute instantiation without parentheses.">
+        <![CDATA[
+#[MyAttribute<em></em>]
+class Foo {}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/Attributes/RequireAttributeParenthesesSniff.php
+++ b/Universal/Sniffs/Attributes/RequireAttributeParenthesesSniff.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\Attributes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\AttributeBlock;
+
+/**
+ * Require that an attribute instantiation has parentheses, i.e. `#[MyAttribute()]`.
+ *
+ * @since 1.5.0
+ */
+final class RequireAttributeParenthesesSniff implements Sniff
+{
+
+    /**
+     * Name of the metric.
+     *
+     * @since 1.5.0
+     *
+     * @var string
+     */
+    const METRIC_NAME = 'Attribute instantiation with parentheses';
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.5.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [\T_ATTRIBUTE];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.5.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $instantiations = AttributeBlock::getAttributes($phpcsFile, $stackPtr);
+        if (empty($instantiations)) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        foreach ($instantiations as $attribute) {
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($attribute['name_token'] + 1), null, true);
+
+            // Note: no need to check for `false` as there will always be something after, if only the attribute closer.
+            if ($tokens[$nextNonEmpty]['code'] === \T_OPEN_PARENTHESIS) {
+                // Parentheses found.
+                $phpcsFile->recordMetric($attribute['name_token'], self::METRIC_NAME, 'yes');
+                continue;
+            }
+
+            $phpcsFile->recordMetric($attribute['name_token'], self::METRIC_NAME, 'no');
+
+            $fix = $phpcsFile->addFixableError(
+                'Parentheses required when instantiating an attribute class.',
+                $attribute['name_token'],
+                'Missing'
+            );
+
+            if ($fix === true) {
+                $phpcsFile->fixer->addContent($attribute['name_token'], '()');
+            }
+        }
+    }
+}

--- a/Universal/Tests/Attributes/RequireAttributeParenthesesUnitTest.1.inc
+++ b/Universal/Tests/Attributes/RequireAttributeParenthesesUnitTest.1.inc
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * OK.
+ */
+#[] // Nothing to do.
+#[MyAttribute()]
+#[\MyAttribute(10)]
+#[MyAttribute(10), Partial\AnotherAttribute (), namespace\AndAnotherOne    ('foo')   ]
+#[MyAttribute(
+    new stdClass // No parentheses, but not an attribute class instantiation.
+)]
+#[
+    \Fully\Qualified\MyAttribute // Comment
+    ()
+]
+function foo() {}
+
+
+/*
+ * Bad.
+ */
+#[MyAttribute]
+#[\MyAttribute /*comment*/]
+#[MyAttribute, Partial\AnotherAttribute, namespace\AndAnotherOne]
+#[
+    MyAttribute,
+    \Fully\Qualified\AnotherAttribute,
+    AndAnotherOne,
+]
+#[
+    MyAttribute // Comment
+]
+function foo() {}

--- a/Universal/Tests/Attributes/RequireAttributeParenthesesUnitTest.1.inc.fixed
+++ b/Universal/Tests/Attributes/RequireAttributeParenthesesUnitTest.1.inc.fixed
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * OK.
+ */
+#[] // Nothing to do.
+#[MyAttribute()]
+#[\MyAttribute(10)]
+#[MyAttribute(10), Partial\AnotherAttribute (), namespace\AndAnotherOne    ('foo')   ]
+#[MyAttribute(
+    new stdClass // No parentheses, but not an attribute class instantiation.
+)]
+#[
+    \Fully\Qualified\MyAttribute // Comment
+    ()
+]
+function foo() {}
+
+
+/*
+ * Bad.
+ */
+#[MyAttribute()]
+#[\MyAttribute() /*comment*/]
+#[MyAttribute(), Partial\AnotherAttribute(), namespace\AndAnotherOne()]
+#[
+    MyAttribute(),
+    \Fully\Qualified\AnotherAttribute(),
+    AndAnotherOne(),
+]
+#[
+    MyAttribute() // Comment
+]
+function foo() {}

--- a/Universal/Tests/Attributes/RequireAttributeParenthesesUnitTest.2.inc
+++ b/Universal/Tests/Attributes/RequireAttributeParenthesesUnitTest.2.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Intentional parse error. Specifically testing the handling of this and safeguarding it for the future.
+#[
+function foo() {}

--- a/Universal/Tests/Attributes/RequireAttributeParenthesesUnitTest.3.inc
+++ b/Universal/Tests/Attributes/RequireAttributeParenthesesUnitTest.3.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Intentional parse error. Specifically testing the handling of this and safeguarding it for the future.
+#[MyAttribute
+function foo() {}

--- a/Universal/Tests/Attributes/RequireAttributeParenthesesUnitTest.php
+++ b/Universal/Tests/Attributes/RequireAttributeParenthesesUnitTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\Attributes;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
+
+/**
+ * Unit test class for the RequireAttributeParentheses sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\Attributes\RequireAttributeParenthesesSniff
+ *
+ * @since 1.5.0
+ */
+final class RequireAttributeParenthesesUnitTest extends AbstractSniffTestCase
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @param string $testFile The name of the file being tested.
+     *
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
+     */
+    public function getErrorList($testFile = '')
+    {
+        switch ($testFile) {
+            case 'RequireAttributeParenthesesUnitTest.1.inc':
+                return [
+                    23 => 1,
+                    24 => 1,
+                    25 => 3,
+                    27 => 1,
+                    28 => 1,
+                    29 => 1,
+                    32 => 1,
+                ];
+
+            default:
+                return [];
+        }
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Sister-sniff to the new `Universal.Attributes.DisallowAttributeParentheses` sniff.

This sniff enforces that all attribute instantiations use parentheses, even if no argument is passed.

Includes fixer.
Includes metrics.
Includes unit tests.
Includes documentation.

Related to #387

Closes #387