### PR TITLE
Universal/CommaSpacing: improve handling of comma spacing within PHP attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ For the spacing part, the sniff makes the following exceptions:
 
 * The sniff has a separate error code - `TooMuchSpaceAfterCommaBeforeTrailingComment` - for when a comma is found with more than one space after it, followed by a trailing comment.
     Exclude this error code to allow trailing comment alignment.
-* The other error codes the sniff uses, `SpaceBefore`, `TooMuchSpaceAfter` and `NoSpaceAfter`, may be suffixed with a context indicator - `*InFunctionDeclaration`, `*InFunctionCall`, `*InClosureUse` or `*InDeclare` -.
+* The other error codes the sniff uses, `SpaceBefore`, `TooMuchSpaceAfter` and `NoSpaceAfter`, may be suffixed with a context indicator - `*InFunctionDeclaration`, `*InFunctionCall`, `*InClosureUse`, `*InAttributeBlock` or `*InDeclare` -.
     This allows for disabling the sniff in any of these contexts by excluding the specific suffixed error codes.
 * The sniff will respect a potentially set [`php_version` configuration option][php_version-config] when deciding how to handle the spacing after a heredoc/nowdoc closer.
     In effect, this means that the sniff will enforce a new line between the closer and a comma if the configured PHP version is less than 7.3.

--- a/Universal/Sniffs/WhiteSpace/CommaSpacingSniff.php
+++ b/Universal/Sniffs/WhiteSpace/CommaSpacingSniff.php
@@ -16,6 +16,7 @@ use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Fixers\SpacesFixer;
 use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\Context;
 use PHPCSUtils\Utils\Parentheses;
 
 /**
@@ -26,8 +27,8 @@ use PHPCSUtils\Utils\Parentheses;
  * - Demands that when there is a trailing comment, the comma follows the code, not the comment.
  *
  * The following exclusions are in place:
- * - A comma preceded or followed by a parenthesis, curly or square bracket.
- *   These will not be flagged to prevent conflicts with sniffs handling spacing around braces.
+ * - A comma preceded or followed by a parenthesis, curly or square bracket, including attribute brackets.
+ *   These will not be flagged to prevent conflicts with sniffs handling spacing around braces/brackets.
  * - A comma preceded or followed by another comma, like for skipping items in a list assignment.
  *   These will not be flagged.
  * - A comma preceded by a non-indented heredoc/nowdoc closer.
@@ -170,6 +171,7 @@ final class CommaSpacingSniff implements Sniff
         if (isset(Tokens::$blockOpeners[$tokens[$prevNonWhitespace]['code']]) === true
             || $tokens[$prevNonWhitespace]['code'] === \T_OPEN_SHORT_ARRAY
             || $tokens[$prevNonWhitespace]['code'] === \T_OPEN_USE_GROUP
+            || $tokens[$prevNonWhitespace]['code'] === \T_ATTRIBUTE
         ) {
             // Should only realistically be possible for lists. Leave for a block brace spacing sniff to sort out.
             return;
@@ -246,6 +248,7 @@ final class CommaSpacingSniff implements Sniff
             || $tokens[$nextNonWhitespace]['code'] === \T_CLOSE_PARENTHESIS
             || $tokens[$nextNonWhitespace]['code'] === \T_CLOSE_SHORT_ARRAY
             || $tokens[$nextNonWhitespace]['code'] === \T_CLOSE_USE_GROUP
+            || $tokens[$nextNonWhitespace]['code'] === \T_ATTRIBUTE_END
         ) {
             // Ignore. Leave for a block spacing sniff to sort out.
             return;
@@ -350,6 +353,10 @@ final class CommaSpacingSniff implements Sniff
     {
         $opener = Parentheses::getLastOpener($phpcsFile, $stackPtr);
         if ($opener === false) {
+            if (Context::inAttribute($phpcsFile, $stackPtr) === true) {
+                return 'InAttributeBlock';
+            }
+
             return '';
         }
 

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.1.inc
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.1.inc
@@ -204,3 +204,24 @@ $provider[] = ['jklmnopqrstuvwz', '2.2.0-DEV'];
 
 // Issue #400 - handling of text in error message.
 define( 'SALT',  'c^&7%D%D%D%DIT' );
+
+/*
+ * Improve handling of PHP 8.0 comma's in attribute blocks which instantiate multiple attributes.
+ */
+// All Okay.
+#[,] // Parse error, but not our concern.
+#[SingleAttributeTrailingComma(),]
+#[SingleAttributeTrailingComma(), ]
+#[AttributeOne(), AttributeTwo, AttributeThree()]
+#[AttributeOne,
+    AttributeTwo,
+    AttributeThree,
+]
+// Incorrect.
+#[SingleAttributeTrailingCommaTooMuchSpaceAfterIsIgnoredInFavourOfBlockSpacingSniff() ,    ]
+#[AttributeOne()  ,AttributeTwo,  AttributeThree()]
+#[AttributeOne    ,
+    AttributeTwo  ,
+    AttributeThree,
+]
+function hasAttributes() {}

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.1.inc.fixed
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.1.inc.fixed
@@ -192,3 +192,24 @@ $provider[] = ['jklmnopqrstuvwz', '2.2.0-DEV'];
 
 // Issue #400 - handling of text in error message.
 define( 'SALT', 'c^&7%D%D%D%DIT' );
+
+/*
+ * Improve handling of PHP 8.0 comma's in attribute blocks which instantiate multiple attributes.
+ */
+// All Okay.
+#[,] // Parse error, but not our concern.
+#[SingleAttributeTrailingComma(),]
+#[SingleAttributeTrailingComma(), ]
+#[AttributeOne(), AttributeTwo, AttributeThree()]
+#[AttributeOne,
+    AttributeTwo,
+    AttributeThree,
+]
+// Incorrect.
+#[SingleAttributeTrailingCommaTooMuchSpaceAfterIsIgnoredInFavourOfBlockSpacingSniff(),    ]
+#[AttributeOne(), AttributeTwo, AttributeThree()]
+#[AttributeOne,
+    AttributeTwo,
+    AttributeThree,
+]
+function hasAttributes() {}

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.2.inc
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.2.inc
@@ -62,3 +62,7 @@ $value = match($value) {
 
 // Parse error, but not our concern.
 print ($item1 ,   $item2,$item3);
+
+// *InAttribute suffix.
+#[AttributeOne ,  AttributeTwo,AttributeThree]
+function hasAttribute() {}

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.2.inc.fixed
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.2.inc.fixed
@@ -62,3 +62,7 @@ $value = match($value) {
 
 // Parse error, but not our concern.
 print ($item1, $item2, $item3);
+
+// *InAttribute suffix.
+#[AttributeOne, AttributeTwo, AttributeThree]
+function hasAttribute() {}

--- a/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.php
+++ b/Universal/Tests/WhiteSpace/CommaSpacingUnitTest.php
@@ -136,6 +136,10 @@ final class CommaSpacingUnitTest extends AbstractSniffTestCase
                     201 => 1,
                     202 => 1,
                     206 => 1,
+                    221 => 1,
+                    222 => 3,
+                    223 => 1,
+                    224 => 1,
                 ];
 
             // Modular error code check.
@@ -170,6 +174,7 @@ final class CommaSpacingUnitTest extends AbstractSniffTestCase
                     55 => 3,
                     60 => 3,
                     64 => 3,
+                    67 => 3,
                 ];
 
             // Comma before trailing comment.


### PR DESCRIPTION
While the `Universal.WhiteSpace.CommaSpacing` sniff would previously already flag spacing around commas in PHP attributes, this commit adds some special handling for this.

This commit makes the following changes:
1. Stop flagging "space before comma" when the comma is preceded by an attribute opener.
    This is a parse error, but more importantly, we want to avoid conflicts with "bracket spacing" sniffs, so leave the spacing after an attribute opener to a "bracket spacing" sniff (like the new `Universal.Attributes.BracketSpacing` sniff as introduced via PR #406).
2. Stop flagging "space after comma" when the comma is followed by an attribute closer.
    Trailing commas are allowed in PHP attributes, but more importantly, we want to avoid conflicts with "bracket spacing" sniffs, so bow out.
3. Differentiate the error code for commas found directly in an attribute block.
    This allows for more modularly including/excluding errors specific to comma spacing for commas in attribute blocks.
    Note: only commas between attributes in an attribute block will now use the `InAttributeBlock` suffix.
    Commas used to separate parameters passed to an attribute instantiation will still be flagged with the `InFunctionCall` suffix, same as before.

Includes tests.

Fixes #391