### PR TITLE
:sparkles: New `Universal.Attributes.TrailingComma` sniff

### DIFF
--- a/Universal/Docs/Attributes/TrailingCommaStandard.xml
+++ b/Universal/Docs/Attributes/TrailingCommaStandard.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Trailing Commas in Attribute Blocks"
+    >
+    <standard>
+    <![CDATA[
+    Require a trailing comma for multi-line attribute blocks in which multiple attributes are being instantiated.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Multiple attributes in a multi-line attribute block with trailing comma.">
+        <![CDATA[
+#[
+    AttributeOne(10),
+    AttributeTwo,
+    AttributeThree(MY_CONST)<em>,</em>
+]
+class Foo {}
+        ]]>
+        </code>
+        <code title="Invalid: Multiple attributes in a multi-line attribute block without trailing comma.">
+        <![CDATA[
+#[
+    AttributeOne(10),
+    AttributeTwo,
+    AttributeThree(MY_CONST)<em>
+</em>]
+class Foo {}
+        ]]>
+        </code>
+    </code_comparison>
+
+    <standard>
+    <![CDATA[
+    Forbid trailing commas in attribute blocks in all other cases.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Single line attribute block without trailing comma.">
+        <![CDATA[
+#[AttributeOne, AttributeTwo]
+class Foo {}
+        ]]>
+        </code>
+        <code title="Invalid: Single line attribute block with trailing comma.">
+        <![CDATA[
+#[AttributeOne, AttributeTwo<em>,<em>]
+class Foo {}
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: Single attribute in a multi-line attribute block without trailing comma.">
+        <![CDATA[
+#[
+    MyAttribute(
+        paramA: 10,
+        paramB: 20,
+    )
+]
+class Foo {}
+        ]]>
+        </code>
+        <code title="Invalid: Single attribute in a multi-line attribute block with trailing comma.">
+        <![CDATA[
+#[
+    MyAttribute(
+        paramA: 10,
+        paramB: 20,
+    )<em>,</em>
+]
+class Foo {}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Universal/Sniffs/Attributes/TrailingCommaSniff.php
+++ b/Universal/Sniffs/Attributes/TrailingCommaSniff.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Sniffs\Attributes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\AttributeBlock;
+
+/**
+ * Require a trailing comma for multi-line, multi-attribute attribute blocks and forbid trailing commas
+ * in single-line attribute blocks and multi-line attributes containing only a single attribute.
+ *
+ * @since 1.5.0
+ */
+final class TrailingCommaSniff implements Sniff
+{
+
+    /**
+     * Name of the metric for single-line attribute blocks.
+     *
+     * @since 1.5.0
+     *
+     * @var string
+     */
+    const METRIC_NAME_SINGLE_LINE = 'Trailing comma in single-line attribute block';
+
+    /**
+     * Name of the metric for multi-line attribute blocks.
+     *
+     * @since 1.5.0
+     *
+     * @var string
+     */
+    const METRIC_NAME_MULTI_LINE = 'Trailing comma in multi-line attribute block';
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.5.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [\T_ATTRIBUTE];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.5.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['attribute_closer']) === false) {
+            // Live coding/parse error. Ignore.
+            return;
+        }
+
+        $opener = $stackPtr;
+        $closer = $tokens[$stackPtr]['attribute_closer'];
+
+        $beforeCloser = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($closer - 1), null, true);
+        if ($opener === $beforeCloser) {
+            // Empty attribute block. Ignore.
+            return;
+        }
+
+        if ($tokens[$opener]['line'] === $tokens[$closer]['line']) {
+            // Single-line attribute block.
+            if ($tokens[$beforeCloser]['code'] === \T_COMMA) {
+                $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME_SINGLE_LINE, 'yes');
+
+                $fix = $phpcsFile->addFixableError(
+                    'Trailing comma is not allowed in a single-line attribute block',
+                    $beforeCloser,
+                    'ForbiddenSingleLine'
+                );
+                if ($fix === true) {
+                    $phpcsFile->fixer->replaceToken($beforeCloser, '');
+                }
+            } else {
+                $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME_SINGLE_LINE, 'no');
+            }
+
+            return;
+        }
+
+        // Multi-line attribute block, check whether it contains a single attribute or multiple.
+        $attributeCount = AttributeBlock::countAttributes($phpcsFile, $stackPtr);
+        if ($attributeCount > 1) {
+            // Multiple attributes in a multi-line attribute block, require trailing comma.
+            if ($tokens[$beforeCloser]['code'] !== \T_COMMA) {
+                $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME_MULTI_LINE, 'No, multi-attribute');
+
+                $fix = $phpcsFile->addFixableError(
+                    'Trailing comma required after last attribute in a multi-line, multi-attribute attribute block',
+                    $beforeCloser,
+                    'RequiredMultiAttributeMultiLine'
+                );
+                if ($fix === true) {
+                    $phpcsFile->fixer->addContent($beforeCloser, ',');
+                }
+            } else {
+                $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME_MULTI_LINE, 'Yes, multi-attribute');
+            }
+
+            return;
+        }
+
+        // Single attribute in a multi-line attribute block, forbid trailing comma.
+        if ($tokens[$beforeCloser]['code'] === \T_COMMA) {
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME_MULTI_LINE, 'Yes, single attribute');
+
+            $fix = $phpcsFile->addFixableError(
+                'Trailing comma is not allowed when a multi-line attribute block only contains a single attribute',
+                $beforeCloser,
+                'ForbiddenSingleAttributeMultiLine'
+            );
+            if ($fix === true) {
+                $phpcsFile->fixer->replaceToken($beforeCloser, '');
+            }
+        } else {
+            $phpcsFile->recordMetric($stackPtr, self::METRIC_NAME_MULTI_LINE, 'No, single attribute');
+        }
+    }
+}

--- a/Universal/Tests/Attributes/TrailingCommaUnitTest.1.inc
+++ b/Universal/Tests/Attributes/TrailingCommaUnitTest.1.inc
@@ -1,0 +1,98 @@
+<?php
+
+#[] // Nothing to do.
+
+/*
+ * OK, no trailing comma for single line blocks or multi-line blocks with single attribute.
+ */
+#[SingleAttribute]
+#[SingleAttributeWithParens]
+#[AttributeOne, AttributeTwo]
+
+#[SingleAttributeInMultiLineAttributeBlock(
+    paramA: 10,
+    paramB: 20,
+)]
+
+#[
+    SingleAttributeInMultiLineAttributeBlock()
+]
+
+/*
+ * OK, trailing comma for multi-line blocks with multiple attributes.
+ *
+ * Note: the sniff should not care about the rest of the formatting of the attribute, we are only looking at the trailing comma.
+ */
+#[AttributeOne,
+AttributeTwo,]
+
+#[AttributeOne,
+AttributeTwo,
+]
+
+#[
+    AttributeOne,
+    AttributeTwo,
+]
+#[
+    AttributeOne(10),
+    AttributeTwo(
+        paramB: 20,
+    ),
+]
+#[
+    AttributeOne,
+    AttributeTwo /*comment*/,
+]
+#[
+    AttributeOne,
+    AttributeTwo // comment
+    ,
+]
+
+/*
+ * Bad, trailing comma for single line blocks or multi-line blocks with single attribute.
+ */
+#[SingleAttribute,]
+#[SingleAttributeWithParens   ,   ]
+#[AttributeOne, AttributeTwo, ]
+
+#[SingleAttributeInMultiLineAttributeBlock(
+    paramA: 10,
+    paramB: 20,
+),]
+
+#[
+    SingleAttributeInMultiLineAttributeBlock(),
+]
+
+/*
+ * Bad, no trailing comma for multi-line blocks with multiple attributes.
+ */
+#[AttributeOne,
+AttributeTwo]
+
+#[AttributeOne,
+AttributeTwo
+]
+
+#[
+    AttributeOne,
+    AttributeTwo
+]
+#[
+    AttributeOne(10),
+    AttributeTwo(
+        paramB: 20,
+    )
+]
+#[
+    AttributeOne,
+    AttributeTwo /*comment*/
+]
+#[
+    AttributeOne,
+    AttributeTwo // comment
+]
+
+function foo() {}

--- a/Universal/Tests/Attributes/TrailingCommaUnitTest.1.inc.fixed
+++ b/Universal/Tests/Attributes/TrailingCommaUnitTest.1.inc.fixed
@@ -1,0 +1,98 @@
+<?php
+
+#[] // Nothing to do.
+
+/*
+ * OK, no trailing comma for single line blocks or multi-line blocks with single attribute.
+ */
+#[SingleAttribute]
+#[SingleAttributeWithParens]
+#[AttributeOne, AttributeTwo]
+
+#[SingleAttributeInMultiLineAttributeBlock(
+    paramA: 10,
+    paramB: 20,
+)]
+
+#[
+    SingleAttributeInMultiLineAttributeBlock()
+]
+
+/*
+ * OK, trailing comma for multi-line blocks with multiple attributes.
+ *
+ * Note: the sniff should not care about the rest of the formatting of the attribute, we are only looking at the trailing comma.
+ */
+#[AttributeOne,
+AttributeTwo,]
+
+#[AttributeOne,
+AttributeTwo,
+]
+
+#[
+    AttributeOne,
+    AttributeTwo,
+]
+#[
+    AttributeOne(10),
+    AttributeTwo(
+        paramB: 20,
+    ),
+]
+#[
+    AttributeOne,
+    AttributeTwo /*comment*/,
+]
+#[
+    AttributeOne,
+    AttributeTwo // comment
+    ,
+]
+
+/*
+ * Bad, trailing comma for single line blocks or multi-line blocks with single attribute.
+ */
+#[SingleAttribute]
+#[SingleAttributeWithParens      ]
+#[AttributeOne, AttributeTwo ]
+
+#[SingleAttributeInMultiLineAttributeBlock(
+    paramA: 10,
+    paramB: 20,
+)]
+
+#[
+    SingleAttributeInMultiLineAttributeBlock()
+]
+
+/*
+ * Bad, no trailing comma for multi-line blocks with multiple attributes.
+ */
+#[AttributeOne,
+AttributeTwo,]
+
+#[AttributeOne,
+AttributeTwo,
+]
+
+#[
+    AttributeOne,
+    AttributeTwo,
+]
+#[
+    AttributeOne(10),
+    AttributeTwo(
+        paramB: 20,
+    ),
+]
+#[
+    AttributeOne,
+    AttributeTwo, /*comment*/
+]
+#[
+    AttributeOne,
+    AttributeTwo, // comment
+]
+
+function foo() {}

--- a/Universal/Tests/Attributes/TrailingCommaUnitTest.2.inc
+++ b/Universal/Tests/Attributes/TrailingCommaUnitTest.2.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Intentional parse error/live coding.
+// Specifically testing the handling of this and safeguarding it for the future.
+#[

--- a/Universal/Tests/Attributes/TrailingCommaUnitTest.php
+++ b/Universal/Tests/Attributes/TrailingCommaUnitTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace PHPCSExtra\Universal\Tests\Attributes;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
+
+/**
+ * Unit test class for the Attributes\TrailingComma sniff.
+ *
+ * @covers PHPCSExtra\Universal\Sniffs\Attributes\TrailingCommaSniff
+ *
+ * @since 1.5.0
+ */
+final class TrailingCommaUnitTest extends AbstractSniffTestCase
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * @param string $testFile The name of the file being tested.
+     *
+     * @return array<int, int> Key is the line number, value is the number of expected errors.
+     */
+    public function getErrorList($testFile = '')
+    {
+        switch ($testFile) {
+            case 'TrailingCommaUnitTest.1.inc':
+                return [
+                    // ForbiddenSingleLine.
+                    56 => 1,
+                    57 => 1,
+                    58 => 1,
+
+                    // ForbiddenSingleAttributeMultiLine.
+                    63 => 1,
+                    66 => 1,
+
+                    // RequiredMultiAttributeMultiLine.
+                    73 => 1,
+                    76 => 1,
+                    81 => 1,
+                    87 => 1,
+                    91 => 1,
+                    95 => 1,
+                ];
+
+            default:
+                return [];
+        }
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * @return array<int, int> Key is the line number, value is the number of expected warnings.
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
New sniff to require a trailing comma for multi-line, multi-attribute attribute blocks and forbid trailing commas in single-line attribute blocks and multi-line attributes containing only a single attribute.

While trailing commas is not covered by PERCS, this sniff as proposed does not conflict with the expectations of PERCS.

Includes fixer.
Includes metrics.
Includes unit tests.
Includes documentation.

Fixes #397