### PR TITLE
GH Actions: update for the release of PHP 8.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.4', '7.0', '7.4', '8.0', '8.4', 'nightly']
+        php: ['5.4', '7.0', '7.4', '8.0', '8.5', 'nightly']
 
     name: "Lint: PHP ${{ matrix.php }}"
 
@@ -73,7 +73,7 @@ jobs:
         # @link https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
-        php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.5']
+        php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.6']
         phpcs_version: ['lowest', '^3.13', '4.0.1', 'stable']
         phpcsutils_version: ['stable']
 
@@ -110,10 +110,10 @@ jobs:
           - php: '7.2'
             phpcs_version: 'stable'
             phpcsutils_version: 'lowest'
-          - php: '8.4'
+          - php: '8.5'
             phpcs_version: '^3.13'
             phpcsutils_version: 'lowest'
-          - php: '8.4'
+          - php: '8.5'
             phpcs_version: 'stable'
             phpcsutils_version: 'lowest'
 
@@ -124,16 +124,16 @@ jobs:
           - php: '7.2'
             phpcs_version: '4.x-dev'
             phpcsutils_version: 'dev-develop'
-          - php: '8.4'
+          - php: '8.5'
             phpcs_version: '3.x-dev'
             phpcsutils_version: 'dev-develop'
-          - php: '8.4'
+          - php: '8.5'
             phpcs_version: '4.x-dev'
             phpcsutils_version: 'dev-develop'
 
     name: "Test: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }} - Utils ${{ matrix.phpcsutils_version }}"
 
-    continue-on-error: ${{ matrix.php == '8.5' }}
+    continue-on-error: ${{ matrix.php == '8.6' }}
 
     steps:
       - name: Checkout code
@@ -178,7 +178,7 @@ jobs:
         uses: "ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520" # 3.1.1
         with:
           # For the PHP "nightly", we need to install with ignore platform reqs as not all dependencies may allow it yet.
-          composer-options: ${{ matrix.php == '8.5' && '--ignore-platform-req=php+' || '' }}
+          composer-options: ${{ matrix.php == '8.6' && '--ignore-platform-req=php+' || '' }}
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
@@ -222,7 +222,7 @@ jobs:
     strategy:
       matrix:
         # Note, since the release of PHPCS 4.0, 'stable' == latest 4.x.
-        php: ['5.4', '8.4']
+        php: ['5.4', '8.5']
         dependencies: ['lowest', 'stable']
 
         exclude:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/PHPCSStandards/PHPCSExtra/badge.svg)](https://coveralls.io/github/PHPCSStandards/PHPCSExtra)
 
 [![Minimum PHP Version](https://img.shields.io/packagist/dependency-v/phpcsstandards/phpcsextra/php.svg)][phpcsextra-packagist]
-[![Tested on PHP 5.4 to 8.4](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4%20|%208.0%20|%208.1%20|%208.2%20|%208.3%20|%208.4-brightgreen.svg?maxAge=2419200)][gha-test-results]
+[![Tested on PHP 5.4 to 8.5](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4%20|%208.0%20|%208.1%20|%208.2%20|%208.3%20|%208.4%20|%208.5-brightgreen.svg?maxAge=2419200)][gha-test-results]
 
 [![License: LGPLv3](https://img.shields.io/github/license/PHPCSStandards/PHPCSExtra)](https://github.com/PHPCSStandards/PHPCSExtra/blob/stable/LICENSE)
 ![Awesome](https://img.shields.io/badge/awesome%3F-yes!-brightgreen.svg)


### PR DESCRIPTION
... which is expected to be released this Thursday.

* Builds against PHP 8.5 are no longer allowed to fail.
* Update PHP version on which code coverage is run (high should now be 8.5).
* Add _allowed to fail_ build against PHP 8.6.
* Update "tested against" badge in the README.